### PR TITLE
출고 예약 기능 추가 (예약 이력 → 출고 확정)

### DIFF
--- a/src/app/(auth)/_components/ConfirmModal.tsx
+++ b/src/app/(auth)/_components/ConfirmModal.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import Button from '@/app/_components/Button';
+
+interface ConfirmModalProps {
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  confirmingLabel?: string;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
+
+const ConfirmModal = ({
+  title,
+  description,
+  confirmLabel = '확인',
+  confirmingLabel = '처리 중...',
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleConfirm = async () => {
+    setIsSubmitting(true);
+    try {
+      await onConfirm();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <h2 className="text-lg font-semibold mb-3">{title}</h2>
+
+      <p className="text-sm text-gray-700 whitespace-pre-line">{description}</p>
+
+      <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 mt-6">
+        <Button size="sm" variant="gray" onClick={onCancel} disabled={isSubmitting}>
+          취소
+        </Button>
+        <Button size="sm" onClick={handleConfirm} disabled={isSubmitting}>
+          {isSubmitting ? confirmingLabel : confirmLabel}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;

--- a/src/app/(auth)/_components/StampLogEditModal.tsx
+++ b/src/app/(auth)/_components/StampLogEditModal.tsx
@@ -26,11 +26,14 @@ interface StampLogEditModalProps {
   initialPaymentType?: PaymentTypeEnumType['value'];
   initialStoreName?: StoreTypeEnumType['value'];
   initialLogMeta?: StampLogMeta | null;
+  isStampAmountEditable?: boolean;
+  title?: string;
   onSubmit: (values: {
     note: string;
     paymentType?: PaymentTypeEnumType['value'];
     storeName: StoreTypeEnumType['value'];
     logMeta: StampLogMeta;
+    amount: number;
   }) => Promise<void>;
   onCancel: () => void;
 }
@@ -40,6 +43,8 @@ const StampLogEditModal = ({
   initialPaymentType,
   initialStoreName,
   initialLogMeta,
+  isStampAmountEditable = false,
+  title = '출고 이력 수정',
   onSubmit,
   onCancel,
 }: StampLogEditModalProps) => {
@@ -66,6 +71,7 @@ const StampLogEditModal = ({
         paymentType: stampLog.paymentType,
         storeName: stampLog.storeName,
         logMeta: stampLog.logMeta,
+        amount: stampLog.amount,
       });
     } finally {
       setIsSubmitting(false);
@@ -75,13 +81,13 @@ const StampLogEditModal = ({
   return (
     <div className="w-full flex max-h-[calc(90vh-2rem)] min-h-0 flex-col">
       <h2 className="shrink-0 text-xl font-semibold text-gray-900 mb-4">
-        출고 이력 수정
+        {title}
       </h2>
 
       <div className="min-h-0 flex-1 overflow-y-auto pr-1">
         <StampLogForm
           initialValue={initialValue}
-          isStampAmountEditable={false}
+          isStampAmountEditable={isStampAmountEditable}
           onChange={setStampLog}
         />
       </div>

--- a/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
@@ -19,6 +19,7 @@ import { groupLogsByDate, formatDateKey } from '@/app/_utils/utils';
 import { toast } from 'react-hot-toast';
 import { useModal } from '@/app/_contexts/ModalContext';
 import DeleteConfirmModal from '@/app/(auth)/_components/DeleteConfirmModal';
+import ConfirmModal from '@/app/(auth)/_components/ConfirmModal';
 import StampLogEditModal from '@/app/(auth)/_components/StampLogEditModal';
 import RemarkLogCreateModal from '../RemarkLogCreateModal';
 import type { StampLogMeta } from '@/app/_domains/_stamp/_services/stampService';
@@ -31,6 +32,8 @@ const CustomersDetailStampsHistories = ({
   isAdmin,
   onDeleteLog,
   onUpdateLog,
+  isReservation = false,
+  onConfirmReservation,
 }: {
   targetUser: { phone: string; name: string; gender?: 'male' | 'female' | null };
   isLoading: boolean;
@@ -44,9 +47,45 @@ const CustomersDetailStampsHistories = ({
       item: CustomersLogsResType[number],
     ) => CustomersLogsResType[number],
   ) => void;
+  isReservation?: boolean;
+  onConfirmReservation?: (logId: string) => Promise<void>;
 }) => {
   const { open, close } = useModal();
   const { copyLogToClipboard } = useCopy();
+
+  const handleConfirm = useCallback(
+    (log: CustomersLogsResType[number]) => {
+      if (!onConfirmReservation) return;
+      const handleConfirmAction = async () => {
+        try {
+          await onConfirmReservation(log.id);
+          onDeleteLog(log.id);
+          close();
+          toast.success('출고 이력으로 확정되었습니다.');
+        } catch (e) {
+          console.error(e);
+          toast.error('출고 확정에 실패했습니다. 다시 시도해 주세요.');
+          close();
+        }
+      };
+      open({
+        content: (
+          <ConfirmModal
+            title="출고 확정"
+            description={
+              '이 예약을 출고 이력으로 확정하시겠습니까?\n확정 시 스탬프가 적립되고 출고 이력으로 이동합니다.'
+            }
+            confirmLabel="출고 확정"
+            confirmingLabel="확정 중..."
+            onConfirm={handleConfirmAction}
+            onCancel={close}
+          />
+        ),
+        options: { dismissOnBackdrop: false },
+      });
+    },
+    [onConfirmReservation, onDeleteLog, open, close],
+  );
 
   const handleDelete = useCallback(
     (log: CustomersLogsResType[number]) => {
@@ -118,17 +157,26 @@ const CustomersDetailStampsHistories = ({
         paymentType?: PaymentTypeEnumType['value'];
         storeName: StoreTypeEnumType['value'];
         logMeta: StampLogMeta;
+        amount: number;
       }) => {
         try {
+          // 예약 이력은 아직 스탬프가 적립되지 않았으므로 개수 수정 허용
+          const nextAction = isReservation
+            ? values.amount === 0
+              ? 'no-stamp'
+              : `add-${values.amount}`
+            : undefined;
           const updated = await updateLogNote(
             log.id,
             values.note,
             values.paymentType,
             values.storeName,
             values.logMeta,
+            nextAction,
           );
           onUpdateLog(log.id, (item) => ({
             ...item,
+            action: updated.action,
             note: updated.note,
             jsonb: updated.jsonb,
             updated_at: updated.updated_at,
@@ -154,6 +202,8 @@ const CustomersDetailStampsHistories = ({
               log.jsonb?.storeName as StoreTypeEnumType['value'] | undefined
             }
             initialLogMeta={log.jsonb as StampLogMeta}
+            isStampAmountEditable={isReservation}
+            title={isReservation ? '출고 예약 수정' : '출고 이력 수정'}
             onSubmit={handleSubmit}
             onCancel={close}
           />
@@ -161,7 +211,7 @@ const CustomersDetailStampsHistories = ({
         options: { dismissOnBackdrop: false, dismissOnEsc: true },
       });
     },
-    [open, close, onUpdateLog],
+    [open, close, onUpdateLog, isReservation],
   );
 
   if (error) {
@@ -256,19 +306,30 @@ const CustomersDetailStampsHistories = ({
                     </div>
                   </div>
                   <div className="ml-3 flex-shrink-0 flex items-center gap-2">
-                    <Button
-                      variant="secondary"
-                      size="xs"
-                      onClick={() =>
-                        copyLogToClipboard(log, {
-                          name: targetUser.name,
-                          phone: targetUser.phone,
-                          gender: targetUser.gender,
-                        })
-                      }
-                    >
-                      복사
-                    </Button>
+                    {isReservation && onConfirmReservation && (
+                      <Button
+                        variant="primary"
+                        size="xs"
+                        onClick={() => handleConfirm(log)}
+                      >
+                        출고 확정
+                      </Button>
+                    )}
+                    {!isReservation && (
+                      <Button
+                        variant="secondary"
+                        size="xs"
+                        onClick={() =>
+                          copyLogToClipboard(log, {
+                            name: targetUser.name,
+                            phone: targetUser.phone,
+                            gender: targetUser.gender,
+                          })
+                        }
+                      >
+                        복사
+                      </Button>
+                    )}
                     {isAdmin && (
                       <Button
                         variant="danger"

--- a/src/app/(auth)/customers/[id]/_components/StampSection.tsx
+++ b/src/app/(auth)/customers/[id]/_components/StampSection.tsx
@@ -5,11 +5,14 @@ import toast from 'react-hot-toast';
 import StampCards from './StampCards';
 import {
   addStamp,
+  addReservationStamp,
   removeStamp,
   StampLogMeta,
 } from '@/app/_domains/_stamp/_services/stampService';
 import { PaymentTypeEnumType } from '@/app/_enums/enums';
 import { useModal } from '@/app/_contexts/ModalContext';
+import { useQueryClient } from '@tanstack/react-query';
+import { logKeys } from '@/app/_domains/_log/_queryKeys/logKeys';
 import StampConfirmModal from '../../_components/StampConfirmModal';
 import Button from '@/app/_components/Button';
 
@@ -23,6 +26,15 @@ interface StampSectionProps {
 const StampSection = ({ stampCount, target, onUpdate, onAddRemark }: StampSectionProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const { open, close } = useModal();
+  const queryClient = useQueryClient();
+
+  // 출고/예약 이력 목록 캐시를 무효화 (이력 페이지 + 고객 상세의 출고/예약 탭 모두 반영)
+  const invalidateLogLists = () => {
+    queryClient.invalidateQueries({ queryKey: logKeys.lists() });
+    queryClient.invalidateQueries({
+      queryKey: logKeys.byCustomerAll(target.id),
+    });
+  };
 
   const handleAdd = async (
     memo?: string,
@@ -34,10 +46,30 @@ const StampSection = ({ stampCount, target, onUpdate, onAddRemark }: StampSectio
       setIsLoading(true);
       await addStamp(target.id, amount, memo ?? '', paymentType, logMeta);
       onUpdate();
+      invalidateLogLists();
       toast.success(amount === 0 ? '미적립으로 기록되었습니다.' : `스탬프 ${amount}개 적립 완료!`);
     } catch (error) {
       console.error('스탬프 적립 실패:', error);
       toast.error('스탬프 적립에 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleReserve = async (
+    memo?: string,
+    paymentType?: PaymentTypeEnumType['value'],
+    amount: number = 0,
+    logMeta?: StampLogMeta,
+  ) => {
+    try {
+      setIsLoading(true);
+      await addReservationStamp(target.id, amount, memo ?? '', paymentType, logMeta);
+      invalidateLogLists();
+      toast.success('출고 예약으로 저장되었습니다.');
+    } catch (error) {
+      console.error('출고 예약 실패:', error);
+      toast.error('출고 예약에 실패했습니다.');
     } finally {
       setIsLoading(false);
     }
@@ -103,8 +135,14 @@ const StampSection = ({ stampCount, target, onUpdate, onAddRemark }: StampSectio
                       paymentType?: PaymentTypeEnumType['value'],
                       amount?: number,
                       logMeta?: StampLogMeta,
+                      _adjustDirection?: 'add' | 'remove',
+                      isReservation?: boolean,
                     ) => {
-                      await handleAdd(modalNote, paymentType, amount, logMeta);
+                      if (isReservation) {
+                        await handleReserve(modalNote, paymentType, amount, logMeta);
+                      } else {
+                        await handleAdd(modalNote, paymentType, amount, logMeta);
+                      }
                       close();
                     }}
                   />

--- a/src/app/(auth)/customers/[id]/page.tsx
+++ b/src/app/(auth)/customers/[id]/page.tsx
@@ -24,7 +24,10 @@ import CustomersDetailUpdateHistories from './_components/CustomersDetailUpdateH
 // import CustomersDetailRemarkHistories from './_components/CustomersDetailRemarkHistories';
 import CustomerAfterServices from './_components/CustomerAfterServices';
 import RemarkLogCreateModal from './_components/RemarkLogCreateModal';
-import { addStamp } from '@/app/_domains/_stamp/_services/stampService';
+import {
+  addStamp,
+  confirmReservationStamp,
+} from '@/app/_domains/_stamp/_services/stampService';
 // import { createLog } from '@/app/_domains/_log/_services/logService';
 import { PaymentTypeEnum } from '@/app/_enums/enums';
 import { customerKeys } from '@/app/_domains/_customer/_queryKeys/customerKeys';
@@ -116,6 +119,20 @@ export default function CustomerDetailPage() {
     } catch {
       toast.error('고객 정보 삭제에 실패했습니다.');
     }
+  };
+
+  const handleConfirmReservation = async (logId: string) => {
+    await confirmReservationStamp(logId);
+    // 확정 시 스탬프 개수 및 출고/예약 이력(고객 상세 탭 + 이력 페이지) 갱신
+    queryClient.invalidateQueries({
+      queryKey: customerKeys.detail(customerId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: logKeys.byCustomerAll(customerId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: logKeys.lists(),
+    });
   };
 
   const handleCreateRemarkLog = async (note: string) => {
@@ -218,6 +235,17 @@ export default function CustomerDetailPage() {
             >
               출고 이력
             </Button>
+            <Button
+              variant={
+                logCategory === LogCategoryEnum.RESERVATION.value
+                  ? 'primary'
+                  : 'secondary'
+              }
+              size="sm"
+              onClick={() => setLogCategory(LogCategoryEnum.RESERVATION.value)}
+            >
+              예약 이력
+            </Button>
             {/* <Button
               variant={logCategory === LogCategoryEnum.REMARK.value ? 'primary' : 'secondary'}
               size="sm"
@@ -238,7 +266,8 @@ export default function CustomerDetailPage() {
             </Button>
           </div>
           <div className="space-y-2.5">
-            {logCategory === LogCategoryEnum.STAMP.value && (
+            {(logCategory === LogCategoryEnum.STAMP.value ||
+              logCategory === LogCategoryEnum.RESERVATION.value) && (
               <CustomersDetailStampsHistories
                 targetUser={{
                   phone: customer.phone,
@@ -251,6 +280,10 @@ export default function CustomerDetailPage() {
                 isAdmin={isAdmin}
                 onDeleteLog={removeLog}
                 onUpdateLog={updateLog}
+                isReservation={
+                  logCategory === LogCategoryEnum.RESERVATION.value
+                }
+                onConfirmReservation={handleConfirmReservation}
               />
             )}
             {logCategory === LogCategoryEnum.CUSTOMER.value && (

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -29,6 +29,7 @@ export default function StampConfirmModal({
     amount?: number,
     logMeta?: StampLogMeta,
     adjustDirection?: 'add' | 'remove',
+    isReservation?: boolean,
   ) => Promise<void> | void;
   onCancel: () => void;
 }) {
@@ -40,9 +41,16 @@ export default function StampConfirmModal({
   const [amount, setAmount] = useState<number>(amountProp ?? (mode === 'adjust' ? 1 : 0));
   const [adjustDirection, setAdjustDirection] = useState<'add' | 'remove'>('remove');
   const [stampLog, setStampLog] = useState<StampLogValue | null>(null);
+  const [isReservation, setIsReservation] = useState(false);
 
   const title =
-    mode === 'add' ? '출고 이력 추가' : mode === 'adjust' ? '스탬프 조정' : '쿠폰 사용';
+    mode === 'add'
+      ? isReservation
+        ? '출고 예약 추가'
+        : '출고 이력 추가'
+      : mode === 'adjust'
+      ? '스탬프 조정'
+      : '쿠폰 사용';
 
   const adjustActionLabel = adjustDirection === 'add' ? '추가' : '차감';
 
@@ -63,6 +71,8 @@ export default function StampConfirmModal({
           stampLog.paymentType,
           stampLog.amount,
           stampLog.logMeta,
+          undefined,
+          isReservation,
         );
       } else if (mode === 'adjust') {
         await onConfirm(note, undefined, amount, undefined, adjustDirection);
@@ -93,6 +103,11 @@ export default function StampConfirmModal({
         <div className="bg-brand-50 rounded-lg p-4 border border-brand-200 space-y-2">
           {mode === 'add' && stampLog && (
             <>
+              {isReservation && (
+                <div className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700">
+                  예약 이력으로 저장됩니다
+                </div>
+              )}
               <div>
                 <span className="text-sm font-medium text-gray-600">매장:</span>
                 <p className="text-base font-semibold text-gray-900">
@@ -257,7 +272,36 @@ export default function StampConfirmModal({
         </div>
       )}
 
-      {mode === 'add' && <StampLogForm onChange={setStampLog} />}
+      {mode === 'add' && (
+        <>
+          <StampLogForm onChange={setStampLog} />
+
+          <div className="mt-5 flex items-center justify-between gap-3 rounded-lg border border-brand-200 bg-brand-50/60 px-4 py-3">
+            <div>
+              <p className="text-sm font-medium text-gray-800">출고 예약</p>
+              <p className="mt-0.5 text-xs text-gray-500">
+                예약으로 저장하면 스탬프는 적립되지 않고, 예약 이력에서 확정 시
+                출고 이력으로 반영됩니다.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={isReservation}
+              onClick={() => setIsReservation((v) => !v)}
+              className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
+                isReservation ? 'bg-brand-500' : 'bg-gray-300'
+              }`}
+            >
+              <span
+                className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+                  isReservation ? 'translate-x-5' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </div>
+        </>
+      )}
 
       {mode === 'use10' && (
         <div className="mb-6">

--- a/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
@@ -17,6 +17,8 @@ interface StampHistoryItemProps {
   onNavigate: () => void;
   isAdmin: boolean;
   onDelete: () => void;
+  onConfirm?: () => void;
+  showCopy?: boolean;
 }
 
 const StampHistoryItem = ({
@@ -25,6 +27,8 @@ const StampHistoryItem = ({
   onNavigate,
   isAdmin,
   onDelete,
+  onConfirm,
+  showCopy = true,
 }: StampHistoryItemProps) => {
   const { copyLogToClipboard } = useCopy();
 
@@ -54,7 +58,7 @@ const StampHistoryItem = ({
           )}
       </div>
 
-      <div className="flex-1 pl-3 ml-3 sm:pl-4 sm:ml-4 border-l border-brand-100">
+      <div className="flex-1 max-w-[600px] pl-3 ml-3 sm:pl-4 sm:ml-4 border-l border-brand-100">
         <div className="flex items-center gap-2">
           <Button variant="secondary" size="xs" onClick={onEdit}>
             ✏️
@@ -81,20 +85,27 @@ const StampHistoryItem = ({
         )}
       </div>
 
-      <div className="ml-4 flex items-center gap-2">
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={() =>
-            copyLogToClipboard(log, {
-              name: log.customers?.name,
-              phone: log.customers?.phone,
-              gender: log.customers?.gender,
-            })
-          }
-        >
-          복사
-        </Button>
+      <div className="ml-4 flex shrink-0 items-center gap-2">
+        {onConfirm && (
+          <Button variant="primary" size="sm" onClick={onConfirm}>
+            출고 확정
+          </Button>
+        )}
+        {showCopy && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() =>
+              copyLogToClipboard(log, {
+                name: log.customers?.name,
+                phone: log.customers?.phone,
+                gender: log.customers?.gender,
+              })
+            }
+          >
+            복사
+          </Button>
+        )}
         {isAdmin && (
           <Button variant="danger" size="sm" onClick={onDelete}>
             삭제

--- a/src/app/(auth)/histories/_components/StampHistories/index.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/index.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useCallback } from 'react';
 import {
+  LogCategoryEnum,
+  LogCategoryEnumType,
   PaymentTypeEnum,
   PaymentTypeEnumType,
   StoreTypeEnumType,
@@ -10,6 +12,10 @@ import {
   updateLogNote,
   deleteLog,
 } from '@/app/_domains/_log/_services/logService';
+import { confirmReservationStamp } from '@/app/_domains/_stamp/_services/stampService';
+import { useQueryClient } from '@tanstack/react-query';
+import { logKeys } from '@/app/_domains/_log/_queryKeys/logKeys';
+import { customerKeys } from '@/app/_domains/_customer/_queryKeys/customerKeys';
 import Loading from '@/app/_components/Loading';
 import Button from '@/app/_components/Button';
 import { Dropdown, DropdownOption } from '@/app/_components/Dropdown';
@@ -24,6 +30,7 @@ import { useUser } from '@/app/_contexts/UserContext';
 import { useModal } from '@/app/_contexts/ModalContext';
 import DeleteConfirmModal from '@/app/(auth)/_components/DeleteConfirmModal';
 import StampLogEditModal from '@/app/(auth)/_components/StampLogEditModal';
+import ConfirmModal from '@/app/(auth)/_components/ConfirmModal';
 import RemarkLogCreateModal from '@/app/(auth)/customers/[id]/_components/RemarkLogCreateModal';
 import type { StampLogMeta } from '@/app/_domains/_stamp/_services/stampService';
 
@@ -37,10 +44,19 @@ const paymentMethodOptions = [
   })),
 ];
 
-const StampHistories = () => {
+interface StampHistoriesProps {
+  category?: LogCategoryEnumType['value'];
+  isReservation?: boolean;
+}
+
+const StampHistories = ({
+  category = LogCategoryEnum.STAMP.value,
+  isReservation = false,
+}: StampHistoriesProps = {}) => {
   const router = useRouter();
   const { isAdmin } = useUser();
   const { open, close } = useModal();
+  const queryClient = useQueryClient();
 
   const [startDate, setStartDate] = useState<string | null>(null);
   const [endDate, setEndDate] = useState<string | null>(null);
@@ -54,7 +70,7 @@ const StampHistories = () => {
   const { items, updateItem, removeItem, isLoading, error, hasMore, load } =
     useLogs(
       PAGE_SIZE,
-      undefined,
+      category,
       dateRange,
       paymentMethod || null,
       searchKeyword || null,
@@ -117,17 +133,26 @@ const StampHistories = () => {
         paymentType?: PaymentTypeEnumType['value'];
         storeName: StoreTypeEnumType['value'];
         logMeta: StampLogMeta;
+        amount: number;
       }) => {
         try {
+          // 예약 이력은 아직 스탬프가 적립되지 않았으므로 개수 수정 허용
+          const nextAction = isReservation
+            ? values.amount === 0
+              ? 'no-stamp'
+              : `add-${values.amount}`
+            : undefined;
           const updated = await updateLogNote(
             log.id,
             values.note,
             values.paymentType,
             values.storeName,
             values.logMeta,
+            nextAction,
           );
           updateItem(log.id, (item) => ({
             ...item,
+            action: updated.action,
             note: updated.note,
             jsonb: updated.jsonb,
             updated_at: updated.updated_at,
@@ -153,6 +178,8 @@ const StampHistories = () => {
               log.jsonb?.storeName as StoreTypeEnumType['value'] | undefined
             }
             initialLogMeta={log.jsonb as StampLogMeta}
+            isStampAmountEditable={isReservation}
+            title={isReservation ? '출고 예약 수정' : '출고 이력 수정'}
             onSubmit={handleSubmit}
             onCancel={close}
           />
@@ -160,7 +187,7 @@ const StampHistories = () => {
         options: { dismissOnBackdrop: false, dismissOnEsc: true },
       });
     },
-    [open, close, updateItem],
+    [open, close, updateItem, isReservation],
   );
 
   const deleteItem = useCallback(
@@ -186,6 +213,50 @@ const StampHistories = () => {
       });
     },
     [removeItem, open, close],
+  );
+
+  const confirmReservation = useCallback(
+    (log: LogsResType) => {
+      const handleConfirm = async () => {
+        try {
+          await confirmReservationStamp(log.id);
+          removeItem(log.id);
+          // 이력 페이지 목록 + 고객 상세 탭(출고/예약) + 스탬프 개수를 모두 무효화
+          queryClient.invalidateQueries({ queryKey: logKeys.lists() });
+          if (log.customer_id) {
+            queryClient.invalidateQueries({
+              queryKey: logKeys.byCustomerAll(log.customer_id),
+            });
+            queryClient.invalidateQueries({
+              queryKey: customerKeys.detail(log.customer_id),
+            });
+          }
+          close();
+          toast.success('출고 이력으로 확정되었습니다.');
+        } catch (e) {
+          console.error('Failed to confirm reservation:', e);
+          toast.error('출고 확정에 실패했습니다. 다시 시도해 주세요.');
+          close();
+        }
+      };
+
+      open({
+        content: (
+          <ConfirmModal
+            title="출고 확정"
+            description={
+              '이 예약을 출고 이력으로 확정하시겠습니까?\n확정 시 스탬프가 적립되고 출고 이력으로 이동합니다.'
+            }
+            confirmLabel="출고 확정"
+            confirmingLabel="확정 중..."
+            onConfirm={handleConfirm}
+            onCancel={close}
+          />
+        ),
+        options: { dismissOnBackdrop: false },
+      });
+    },
+    [removeItem, open, close, queryClient],
   );
 
   const { itemsByDate, sortedDates } = groupLogsByDate(items);
@@ -259,7 +330,7 @@ const StampHistories = () => {
         </div>
       ) : (
         <div className="overflow-x-auto">
-          <div className="min-w-[1100px] space-y-4 sm:space-y-6 text-xs sm:text-sm">
+          <div className="w-max min-w-[1100px] space-y-4 sm:space-y-6 text-xs sm:text-sm">
             {sortedDates.map((dateKey) => {
               const logsOfDate = itemsByDate[dateKey];
 
@@ -288,6 +359,12 @@ const StampHistories = () => {
                         }
                         isAdmin={isAdmin}
                         onDelete={() => deleteItem(log)}
+                        onConfirm={
+                          isReservation
+                            ? () => confirmReservation(log)
+                            : undefined
+                        }
+                        showCopy={!isReservation}
                       />
                     ))}
                   </div>

--- a/src/app/(auth)/histories/page.tsx
+++ b/src/app/(auth)/histories/page.tsx
@@ -28,6 +28,16 @@ export default function HistoriesPage() {
               출고 이력
             </Button>
             <Button
+              onClick={() => setLogType(LogCategoryEnum.RESERVATION.value)}
+              variant={
+                logType === LogCategoryEnum.RESERVATION.value
+                  ? 'primary'
+                  : 'secondary'
+              }
+            >
+              예약 이력
+            </Button>
+            <Button
               onClick={() => setLogType(LogCategoryEnum.CUSTOMER.value)}
               variant={
                 logType === LogCategoryEnum.CUSTOMER.value
@@ -49,6 +59,11 @@ export default function HistoriesPage() {
         </div>
         {logType === LogCategoryEnum.STAMP.value ? (
           <StampHistories />
+        ) : logType === LogCategoryEnum.RESERVATION.value ? (
+          <StampHistories
+            category={LogCategoryEnum.RESERVATION.value}
+            isReservation
+          />
         ) : (
           <CustomerHistories />
         )}

--- a/src/app/_domains/_log/_queryKeys/logKeys.ts
+++ b/src/app/_domains/_log/_queryKeys/logKeys.ts
@@ -11,6 +11,8 @@ export const logKeys = {
   }) => [...logKeys.lists(), params] as const,
   byAfterService: (afterServiceId: number) =>
     ['logs', 'byAfterService', afterServiceId] as const,
+  byCustomerAll: (customerId: string) =>
+    ['logs', 'byCustomer', customerId] as const,
   byCustomer: (customerId: string, category: string) =>
     ['logs', 'byCustomer', customerId, category] as const,
 };

--- a/src/app/_domains/_log/_services/logService.ts
+++ b/src/app/_domains/_log/_services/logService.ts
@@ -207,6 +207,7 @@ export const updateLogNote = async (
   paymentType?: PaymentTypeEnumType['value'],
   storeName?: StoreTypeEnumType['value'],
   logMeta?: StampLogMeta,
+  action?: string,
 ) => {
   const { data: existing, error: fetchError } = await supabase
     .from('logs')
@@ -236,9 +237,12 @@ export const updateLogNote = async (
     }
   }
 
+  const updatePayload: Record<string, unknown> = { note, jsonb: nextJsonb };
+  if (action !== undefined) updatePayload.action = action;
+
   const { data, error } = await supabase
     .from('logs')
-    .update({ note, jsonb: nextJsonb })
+    .update(updatePayload)
     .eq('id', logId)
     .select()
     .single();

--- a/src/app/_domains/_stamp/_services/stampService.ts
+++ b/src/app/_domains/_stamp/_services/stampService.ts
@@ -39,15 +39,20 @@ export type StampLogMeta = {
 };
 
 /**
- * 스탬프 추가 (count 증가)
+ * action 문자열에서 스탬프 개수 추출 ('add-3' → 3, 'no-stamp' → 0)
  */
-export const addStamp = async (
-  customerId: string,
-  amount: number = 1,
-  note: string = '',
-  paymentType?: PaymentTypeEnumType['value'],
-  logMeta?: StampLogMeta,
-) => {
+const getStampAmountFromAction = (action: string) => {
+  if (action.startsWith('add-')) {
+    const amount = Number(action.replace('add-', ''));
+    return Number.isFinite(amount) ? amount : 0;
+  }
+  return 0;
+};
+
+/**
+ * 스탬프 카운트 적용 (로그 기록 없이 count만 증가)
+ */
+const applyStampCount = async (customerId: string, amount: number) => {
   // 먼저 해당 customer의 stamp 레코드가 있는지 확인
   const { data: existing } = await supabase
     .from('stamps')
@@ -55,12 +60,12 @@ export const addStamp = async (
     .eq('customer_id', customerId)
     .single();
 
-  let result;
-
   if (amount === 0) {
-    // 미적립: 스탬프 카운트 변경 없이 로그만 기록
-    result = existing ?? null;
-  } else if (existing) {
+    // 미적립: 스탬프 카운트 변경 없음
+    return existing ?? null;
+  }
+
+  if (existing) {
     // 기존 레코드가 있으면 count 증가
     const { data, error } = await supabase
       .from('stamps')
@@ -70,18 +75,31 @@ export const addStamp = async (
       .single();
 
     if (error) throw error;
-    result = data;
-  } else {
-    // 없으면 새로 생성
-    const { data, error } = await supabase
-      .from('stamps')
-      .insert({ customer_id: customerId, count: amount })
-      .select()
-      .single();
-
-    if (error) throw error;
-    result = data;
+    return data;
   }
+
+  // 없으면 새로 생성
+  const { data, error } = await supabase
+    .from('stamps')
+    .insert({ customer_id: customerId, count: amount })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+};
+
+/**
+ * 스탬프 추가 (count 증가)
+ */
+export const addStamp = async (
+  customerId: string,
+  amount: number = 1,
+  note: string = '',
+  paymentType?: PaymentTypeEnumType['value'],
+  logMeta?: StampLogMeta,
+) => {
+  const result = await applyStampCount(customerId, amount);
 
   // 로그 추가
   await createLog(
@@ -93,6 +111,59 @@ export const addStamp = async (
   );
 
   return result;
+};
+
+/**
+ * 출고 예약 (스탬프 카운트는 변경하지 않고 reservation 로그만 기록)
+ */
+export const addReservationStamp = async (
+  customerId: string,
+  amount: number = 0,
+  note: string = '',
+  paymentType?: PaymentTypeEnumType['value'],
+  logMeta?: StampLogMeta,
+) => {
+  return createLog(
+    LogCategoryEnum.RESERVATION.value,
+    customerId,
+    amount === 0 ? 'no-stamp' : `add-${amount}`,
+    note,
+    { paymentType, ...logMeta }
+  );
+};
+
+/**
+ * 예약 이력 확정 (스탬프 카운트를 적용하고 reservation → stamp 로그로 전환)
+ */
+export const confirmReservationStamp = async (logId: string) => {
+  const { data: log, error } = await supabase
+    .from('logs')
+    .select('*')
+    .eq('id', logId)
+    .single();
+
+  if (error) throw error;
+  if (!log) throw new Error('예약 이력을 찾을 수 없습니다');
+
+  const amount = getStampAmountFromAction(log.action);
+
+  if (amount > 0 && log.customer_id) {
+    await applyStampCount(log.customer_id, amount);
+  }
+
+  const { data: updated, error: updateError } = await supabase
+    .from('logs')
+    .update({
+      category: LogCategoryEnum.STAMP.value,
+      created_at: new Date().toISOString(),
+    })
+    .eq('id', logId)
+    .select()
+    .single();
+
+  if (updateError) throw updateError;
+
+  return updated;
 };
 
 /**

--- a/src/app/_enums/enums.ts
+++ b/src/app/_enums/enums.ts
@@ -85,6 +85,10 @@ export const LogCategoryEnum = {
     value: 'stamp',
     name: '스탬프',
   },
+  RESERVATION: {
+    value: 'reservation',
+    name: '예약',
+  },
   REMARK: {
     value: 'remark',
     name: '특이사항',


### PR DESCRIPTION
  ## 개요
  출고 이력을 "예약" 상태로 먼저 등록하고, 나중에 확인 후 확정하면 실제 출고 이력으로 전환되는 기능을
  추가했습니다.

  ## 주요 변경사항
  ### 예약 생성
  - 출고 이력 추가 모달 맨 아래에 **예약 토글** 추가
  - 토글 ON 시 스탬프는 적립하지 않고 `reservation` 카테고리 로그만 생성 (`addReservationStamp`)
  - 폼은 기존 출고 이력과 동일

  - **이력 페이지**와 **고객 상세** 모두 출고 이력 오른쪽에 `예약 이력` 탭 추가
  - 예약 행에는 `출고 확정` 버튼 제공, `복사` 버튼은 숨김
  - 고객 상세는 기존 행 레이아웃(xs 버튼)에 맞춰 스타일링

  ### 출고 확정
  - `confirmReservationStamp`: 스탬프 개수 적립 + 로그를 `reservation` → `stamp`로 전환,
  `created_at`을 확정 시각으로 갱신해 출고 이력 최상단에 노출
  
  ### 예약 수정
  - 예약은 아직 스탬프가 적립되지 않았으므로 **스탬프 개수 수정 허용** (`updateLogNote`에 action 갱신
  추가)
  
  ### 쿼리 캐시 무효화
  - 생성/확정 시 이력 페이지 목록(`logKeys.lists()`)과 고객 상세 탭(`logKeys.byCustomerAll`), 스탬프
  개수(`customerKeys.detail`)를 양방향으로 무효화
  
  ## 참고
  - DB `logs.category` 컬럼이 `reservation` 값을 허용해야 합니다. (CHECK 제약/enum 타입이 있다면
  마이그레이션 필요)
  
  ## 테스트
  - 타입체크 / 린트 통과