### PR TITLE
Show customer note in stamp modals and refine history UI

### DIFF
--- a/src/app/(auth)/_components/HistoriesComponents/LogActorInfo.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/LogActorInfo.tsx
@@ -16,11 +16,12 @@ const LogActorInfo = ({
   const displayDate = isModified ? updated_at : created_at;
 
   const dateText = new Date(displayDate).toLocaleString('ko-KR', {
-    year: 'numeric',
+    year: '2-digit',
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
+    hour12: false,
   });
 
   return (

--- a/src/app/(auth)/_components/HistoriesComponents/PaymentTypeLabel.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/PaymentTypeLabel.tsx
@@ -18,7 +18,7 @@ const PaymentTypeLabel = ({ jsonb }: { jsonb: Record<string, unknown> }) => {
     : undefined;
 
   return (
-    <span className="ml-2 inline-flex items-center rounded-full bg-gray-100 text-gray-500 text-xs font-medium px-2 py-1">
+    <span className="ml-2 inline-flex items-center rounded-full bg-gray-100 text-gray-500 text-xs font-medium px-1.5 py-1">
       {paymentTypeName}
     </span>
   );

--- a/src/app/(auth)/_components/HistoriesComponents/StoreLabel.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/StoreLabel.tsx
@@ -23,7 +23,7 @@ const StoreLabel = ({ jsonb }: { jsonb: Record<string, unknown> }) => {
 
   return (
     <span
-      className={`ml-2 inline-flex items-center rounded-full text-xs font-medium px-2 py-1 ${style}`}
+      className={`ml-2 inline-flex items-center rounded-full text-xs font-medium px-1.5 py-1 ${style}`}
     >
       {storeName}
     </span>

--- a/src/app/(auth)/customers/[id]/_components/CustomersDetailRemarkHistories/index.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomersDetailRemarkHistories/index.tsx
@@ -223,8 +223,9 @@ const CustomersDetailRemarkHistories = ({
                           size="xs"
                           onClick={() => handleDelete(log)}
                           disabled={isSaving}
+                          aria-label="삭제"
                         >
-                          삭제
+                          🗑️
                         </Button>
                       )}
                     </div>

--- a/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
@@ -269,16 +269,18 @@ const CustomersDetailStampsHistories = ({
                       </div>
                     )}
                   </div>
-                  <div className="flex items-center gap-1">
-                    {log.jsonb && 'storeName' in log.jsonb && (
-                      <StoreLabel jsonb={log.jsonb} />
-                    )}
-                    {log.jsonb && 'paymentType' in log.jsonb && (
-                      <PaymentTypeLabel jsonb={log.jsonb} />
-                    )}
+                  <div className="flex flex-col items-center gap-1">
+                    <div className="flex items-center gap-0.5">
+                      {log.jsonb && 'storeName' in log.jsonb && (
+                        <StoreLabel jsonb={log.jsonb} />
+                      )}
+                      {log.jsonb && 'paymentType' in log.jsonb && (
+                        <PaymentTypeLabel jsonb={log.jsonb} />
+                      )}
+                    </div>
                     {typeof log.jsonb?.totalAmount === 'number' &&
                       log.jsonb.totalAmount > 0 && (
-                        <span className="ml-2 inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 text-xs font-semibold px-2 py-1">
+                        <span className="inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 text-xs font-semibold px-2 py-1">
                           {log.jsonb.totalAmount.toLocaleString('ko-KR')}원
                         </span>
                       )}
@@ -335,8 +337,9 @@ const CustomersDetailStampsHistories = ({
                         variant="danger"
                         size="xs"
                         onClick={() => handleDelete(log)}
+                        aria-label="삭제"
                       >
-                        삭제
+                        🗑️
                       </Button>
                     )}
                   </div>

--- a/src/app/(auth)/customers/[id]/_components/CustomersDetailUpdateHistories/index.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomersDetailUpdateHistories/index.tsx
@@ -114,8 +114,9 @@ const CustomersDetailUpdateHistories = ({
                       variant="danger"
                       size="xs"
                       onClick={() => handleDelete(log)}
+                      aria-label="삭제"
                     >
-                      삭제
+                      🗑️
                     </Button>
                   )}
                 </div>

--- a/src/app/(auth)/customers/[id]/_components/StampSection.tsx
+++ b/src/app/(auth)/customers/[id]/_components/StampSection.tsx
@@ -18,7 +18,7 @@ import Button from '@/app/_components/Button';
 
 interface StampSectionProps {
   stampCount: number;
-  target: { id: string; name: string; phone: string };
+  target: { id: string; name: string; phone: string; note?: string | null };
   onUpdate: () => void;
   onAddRemark: () => void;
 }
@@ -127,7 +127,7 @@ const StampSection = ({ stampCount, target, onUpdate, onAddRemark }: StampSectio
               open({
                 content: (
                   <StampConfirmModal
-                    target={{ name: target.name, phone: target.phone }}
+                    target={{ name: target.name, phone: target.phone, note: target.note }}
                     mode="add"
                     onCancel={close}
                     onConfirm={async (
@@ -162,7 +162,7 @@ const StampSection = ({ stampCount, target, onUpdate, onAddRemark }: StampSectio
               open({
                 content: (
                   <StampConfirmModal
-                    target={{ name: target.name, phone: target.phone }}
+                    target={{ name: target.name, phone: target.phone, note: target.note }}
                     mode="use10"
                     onCancel={close}
                     onConfirm={async (modalNote?: string) => {
@@ -186,7 +186,7 @@ const StampSection = ({ stampCount, target, onUpdate, onAddRemark }: StampSectio
               open({
                 content: (
                   <StampConfirmModal
-                    target={{ name: target.name, phone: target.phone }}
+                    target={{ name: target.name, phone: target.phone, note: target.note }}
                     mode="adjust"
                     onCancel={close}
                     onConfirm={async (

--- a/src/app/(auth)/customers/[id]/page.tsx
+++ b/src/app/(auth)/customers/[id]/page.tsx
@@ -203,6 +203,7 @@ export default function CustomerDetailPage() {
               id: customerId,
               name: customer.name,
               phone: customer.phone,
+              note: customer.note,
             }}
             onUpdate={handleUpdate}
             onAddRemark={() =>

--- a/src/app/(auth)/customers/_components/CustomerCreateModal.tsx
+++ b/src/app/(auth)/customers/_components/CustomerCreateModal.tsx
@@ -33,6 +33,7 @@ const schema = z.object({
     .max(500, { message: '메모는 500자 이하로 입력하세요.' })
     .optional(),
   isStampAdd: z.boolean(),
+  isReservation: z.boolean(),
 });
 
 type FormValues = z.infer<typeof schema>;
@@ -82,10 +83,12 @@ export default function CustomerCreateModal({
       gender: 'male',
       note: '',
       isStampAdd: false,
+      isReservation: false,
     },
   });
 
   const isStampAdd = watch('isStampAdd');
+  const isReservation = watch('isReservation');
 
   // 출고 이력 추가를 선택한 경우 출고 폼이 유효해야 제출 가능
   const canSubmit = isValid && (!isStampAdd || stampLog !== null);
@@ -101,7 +104,11 @@ export default function CustomerCreateModal({
     if (!canSubmit) {
       return;
     }
-    setFormData({ ...values, stampLog: values.isStampAdd ? stampLog : null });
+    setFormData({
+      ...values,
+      isReservation: values.isStampAdd ? values.isReservation : false,
+      stampLog: values.isStampAdd ? stampLog : null,
+    });
     setShowConfirm(true);
 
     canSubmitRef.current = true;
@@ -170,9 +177,14 @@ export default function CustomerCreateModal({
           {formData.isStampAdd && formData.stampLog && (
             <div className="bg-brand-50 rounded-lg p-4 mb-6 border border-brand-200">
               <h3 className="text-sm font-semibold text-brand-700 mb-3">
-                출고 이력 정보
+                {formData.isReservation ? '출고 예약 정보' : '출고 이력 정보'}
               </h3>
               <div className="space-y-2">
+                {formData.isReservation && (
+                  <div className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700">
+                    예약 이력으로 저장됩니다
+                  </div>
+                )}
                 <div>
                   <span className="text-sm font-medium text-gray-600">매장:</span>
                   <p className="text-base font-semibold text-gray-900">
@@ -369,6 +381,37 @@ export default function CustomerCreateModal({
         {!!isStampAdd && (
           <div className="pt-2 border-t border-gray-200">
             <StampLogForm onChange={setStampLog} />
+
+            <Controller
+              name="isReservation"
+              control={control}
+              render={({ field }) => (
+                <div className="mt-5 flex items-center justify-between gap-3 rounded-lg border border-brand-200 bg-brand-50/60 px-4 py-3">
+                  <div>
+                    <p className="text-sm font-medium text-gray-800">출고 예약</p>
+                    <p className="mt-0.5 text-xs text-gray-500">
+                      예약으로 저장하면 스탬프는 적립되지 않고, 예약 이력에서 확정 시
+                      출고 이력으로 반영됩니다.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={field.value}
+                    onClick={() => field.onChange(!field.value)}
+                    className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
+                      field.value ? 'bg-brand-500' : 'bg-gray-300'
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+                        field.value ? 'translate-x-5' : 'translate-x-0.5'
+                      }`}
+                    />
+                  </button>
+                </div>
+              )}
+            />
           </div>
         )}
       </div>

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -7,9 +7,9 @@ import {
   PaymentTypeEnumType,
 } from '@/app/_enums/enums';
 import type { StampLogMeta } from '@/app/_domains/_stamp/_services/stampService';
-import { formatPhoneNumber } from '@/app/_utils/utils';
 import { useState } from 'react';
 import StampLogForm, { StampLogValue } from './StampLogForm';
+import TargetCustomerCard from './TargetCustomerCard';
 
 const formatAmount = (value: number) => value.toLocaleString('ko-KR');
 
@@ -20,7 +20,7 @@ export default function StampConfirmModal({
   onConfirm,
   onCancel,
 }: {
-  target: { name: string; phone: string };
+  target: { name: string; phone: string; note?: string | null };
   mode: 'add' | 'adjust' | 'use10';
   amount?: number;
   onConfirm: (
@@ -90,14 +90,11 @@ export default function StampConfirmModal({
 
       <div className="overflow-y-auto min-h-0 flex-1 space-y-4">
         {/* 대상 고객 */}
-        <div className="bg-gray-100 rounded-lg p-4">
-          <div className="flex items-center gap-2 mb-2">
-            <div className="w-2 h-2 bg-brand-500 rounded-full" />
-            <span className="text-sm font-medium text-gray-700">대상 고객</span>
-          </div>
-          <p className="text-lg font-semibold text-gray-900">{target.name}</p>
-          <p className="text-sm text-gray-600">{formatPhoneNumber(target.phone)}</p>
-        </div>
+        <TargetCustomerCard
+          name={target.name}
+          phone={target.phone}
+          note={target.note}
+        />
 
         {/* 요약 정보 */}
         <div className="bg-brand-50 rounded-lg p-4 border border-brand-200 space-y-2">
@@ -197,14 +194,12 @@ export default function StampConfirmModal({
       <div className="shrink-0 mb-4">
         <h2 className="text-xl font-semibold text-gray-900 mb-3">{title}</h2>
 
-        <div className="bg-gray-100 rounded-lg p-4 mb-4">
-          <div className="flex items-center gap-2 mb-2">
-            <div className="w-2 h-2 bg-brand-500 rounded-full" />
-            <span className="text-sm font-medium text-gray-700">대상 고객</span>
-          </div>
-          <p className="text-lg font-semibold text-gray-900">{target.name}</p>
-          <p className="text-sm text-gray-600">{formatPhoneNumber(target?.phone)}</p>
-        </div>
+        <TargetCustomerCard
+          name={target.name}
+          phone={target.phone}
+          note={target.note}
+          className="mb-4"
+        />
 
         {mode === 'use10' && (
           <div className="text-center py-4">

--- a/src/app/(auth)/customers/_components/TargetCustomerCard.tsx
+++ b/src/app/(auth)/customers/_components/TargetCustomerCard.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { formatPhoneNumber } from '@/app/_utils/utils';
+
+export default function TargetCustomerCard({
+  name,
+  phone,
+  note,
+  className = '',
+}: {
+  name: string;
+  phone: string;
+  note?: string | null;
+  className?: string;
+}) {
+  return (
+    <div className={`bg-gray-100 rounded-lg p-4 ${className}`}>
+      <div className="flex items-center gap-2 mb-2">
+        <div className="w-2 h-2 bg-brand-500 rounded-full" />
+        <span className="text-sm font-medium text-gray-700">대상 고객</span>
+      </div>
+      <p className="text-lg font-semibold text-gray-900">{name}</p>
+      <p className="text-sm text-gray-600">{formatPhoneNumber(phone)}</p>
+      {note && (
+        <p className="mt-2 text-sm text-gray-700 whitespace-pre-wrap">
+          <span className="font-medium text-gray-600">특이사항: </span>
+          {note}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/customers/page.tsx
+++ b/src/app/(auth)/customers/page.tsx
@@ -9,7 +9,10 @@ import { createCustomer } from '@/app/_domains/_customer/_services/customerServi
 import toast from 'react-hot-toast';
 import { useState } from 'react';
 import Button from '@/app/_components/Button';
-import { addStamp } from '@/app/_domains/_stamp/_services/stampService';
+import {
+  addStamp,
+  addReservationStamp,
+} from '@/app/_domains/_stamp/_services/stampService';
 import { useQueryClient } from '@tanstack/react-query';
 import { customerKeys } from '@/app/_domains/_customer/_queryKeys/customerKeys';
 import { logKeys } from '@/app/_domains/_log/_queryKeys/logKeys';
@@ -57,14 +60,25 @@ export default function CustomersPage() {
         const stampLog = values.stampLog;
         const amount = stampLog.amount;
         try {
-          await addStamp(
-            data.id,
-            amount,
-            stampLog.note,
-            stampLog.paymentType,
-            stampLog.logMeta,
-          );
-          toast.success(amount === 0 ? '미적립으로 기록되었습니다.' : `스탬프 ${amount}개 적립 완료!`);
+          if (values.isReservation) {
+            await addReservationStamp(
+              data.id,
+              amount,
+              stampLog.note,
+              stampLog.paymentType,
+              stampLog.logMeta,
+            );
+            toast.success('출고 예약으로 기록되었습니다.');
+          } else {
+            await addStamp(
+              data.id,
+              amount,
+              stampLog.note,
+              stampLog.paymentType,
+              stampLog.logMeta,
+            );
+            toast.success(amount === 0 ? '미적립으로 기록되었습니다.' : `스탬프 ${amount}개 적립 완료!`);
+          }
         } catch (stampError) {
           console.error('스탬프 추가 실패:', stampError);
           toast.error(

--- a/src/app/(auth)/histories/_components/CustomerHistories/CustomerHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/CustomerHistories/CustomerHistoryItem.tsx
@@ -42,8 +42,9 @@ const CustomerHistoryItem = ({ log, onNavigate, isAdmin, onDelete }: CustomerHis
             variant="danger"
             size="sm"
             onClick={onDelete}
+            aria-label="삭제"
           >
-            삭제
+            🗑️
           </Button>
         )}
       </div>

--- a/src/app/(auth)/histories/_components/RemarkHistories/RemarkHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/RemarkHistories/RemarkHistoryItem.tsx
@@ -130,8 +130,9 @@ const RemarkHistoryItem = ({
             size="sm"
             onClick={onDelete}
             disabled={isSaving}
+            aria-label="삭제"
           >
-            삭제
+            🗑️
           </Button>
         )}
       </div>

--- a/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
@@ -43,16 +43,18 @@ const StampHistoryItem = ({
         />
       </div>
 
-      <div className="flex items-center gap-1">
-        {log.jsonb && 'storeName' in log.jsonb && (
-          <StoreLabel jsonb={log.jsonb} />
-        )}
-        {log.jsonb && 'paymentType' in log.jsonb && (
-          <PaymentTypeLabel jsonb={log.jsonb} />
-        )}
+      <div className="flex flex-col items-center gap-1">
+        <div className="flex items-center gap-0.5">
+          {log.jsonb && 'storeName' in log.jsonb && (
+            <StoreLabel jsonb={log.jsonb} />
+          )}
+          {log.jsonb && 'paymentType' in log.jsonb && (
+            <PaymentTypeLabel jsonb={log.jsonb} />
+          )}
+        </div>
         {typeof log.jsonb?.totalAmount === 'number' &&
           log.jsonb.totalAmount > 0 && (
-            <span className="ml-2 inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 text-xs font-semibold px-2 py-1">
+            <span className="inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 text-xs font-semibold px-2 py-1">
               {log.jsonb.totalAmount.toLocaleString('ko-KR')}원
             </span>
           )}
@@ -107,8 +109,8 @@ const StampHistoryItem = ({
           </Button>
         )}
         {isAdmin && (
-          <Button variant="danger" size="sm" onClick={onDelete}>
-            삭제
+          <Button variant="danger" size="sm" onClick={onDelete} aria-label="삭제">
+            🗑️
           </Button>
         )}
       </div>


### PR DESCRIPTION
- Add customer note (특이사항) below phone in outbound/coupon/adjust modals
- Extract shared TargetCustomerCard for the 대상 고객 card
- Add 출고 예약 toggle to the customer create modal's outbound section
- Stack store/payment/price vertically (store+payment on one line) and center
- Tighten label padding and spacing
- Show 2-digit year and 24h time in log actor info
- Replace delete buttons with trash icon