### PR TITLE
출고 이력 입력 개선 및 매뉴얼 관리 기능 추가

### DIFF
--- a/docs/manual_management.md
+++ b/docs/manual_management.md
@@ -1,0 +1,197 @@
+# 매뉴얼 관리 시스템
+
+---
+
+## 1. 카테고리 구조
+
+3단계 구조
+
+```
+탭 (고객 / 매장)        ← 하드코딩, DB에 없음
+  └ 상위 타입           ← 사용자 설정 (manual_top_categories)
+      └ 하위 타입       ← 사용자 설정 (manual_sub_categories)
+          └ 매뉴얼      ← 실제 내용 (manuals)
+```
+
+`고객` / `매장` 탭은 코드에 상수로 박아두고, 그 아래 상위 타입 / 하위 타입만 사용자가 추가·수정·삭제·순서 변경 가능.
+
+품목 관리(`item_categories`)와 다르게 카테고리가 2단계라서 테이블을 2개(`manual_top_categories`, `manual_sub_categories`)로 나눔. 트리 depth가 항상 정확히 2단계로 고정이라 self-reference(parent_id) 하나로 퉁치는 것보다 이렇게 나누는 게 FK 무결성 관리가 쉬움.
+
+---
+
+## 2. 테이블 구조
+
+### 1️⃣ manual_top_categories
+
+상위 타입 테이블. `탭`(고객/매장)에 종속됨.
+
+| 컬럼 | 타입 | 설명 |
+|------|------|------|
+| id | uuid PK | |
+| tab | text NOT NULL | `customer` \| `store` (하드코딩 값, CHECK 제약) |
+| name | text NOT NULL | 상위 타입명 |
+| order_index | int4 NOT NULL DEFAULT 0 | 정렬 순서 |
+| is_use | bool NOT NULL DEFAULT true | 사용 여부 (삭제 대신 비활성 처리) |
+| created_at | timestamptz DEFAULT now() | 생성 시간 |
+| updated_at | timestamptz DEFAULT now() | 수정 시간 |
+
+예시 (탭: 고객)
+
+| id | tab | name | order_index |
+|----|-----|------|-------------|
+| uuid-1 | customer | 기기 사용법 | 1 |
+| uuid-2 | customer | 액상 관련 | 2 |
+| uuid-3 | customer | 결제/멤버십 | 3 |
+
+---
+
+### 2️⃣ manual_sub_categories
+
+하위 타입 테이블. 상위 타입에 종속됨.
+
+| 컬럼 | 타입 | 설명 |
+|------|------|------|
+| id | uuid PK | |
+| top_category_id | uuid FK → manual_top_categories.id | 상위 타입 |
+| name | text NOT NULL | 하위 타입명 |
+| order_index | int4 NOT NULL DEFAULT 0 | 정렬 순서 |
+| is_use | bool NOT NULL DEFAULT true | 사용 여부 |
+| created_at | timestamptz DEFAULT now() | 생성 시간 |
+| updated_at | timestamptz DEFAULT now() | 수정 시간 |
+
+예시 (상위 타입: 기기 사용법)
+
+| id | top_category_id | name | order_index |
+|----|------------------|------|-------------|
+| uuid-a | uuid-1 | 전원 켜는 법 | 1 |
+| uuid-b | uuid-1 | 충전 방법 | 2 |
+| uuid-c | uuid-1 | 청소 방법 | 3 |
+
+---
+
+### 3️⃣ manuals
+
+실제 매뉴얼 콘텐츠. 하위 타입에 종속됨.
+
+| 컬럼 | 타입 | 설명 |
+|------|------|------|
+| id | uuid PK | |
+| sub_category_id | uuid FK → manual_sub_categories.id | 하위 타입 |
+| title | text NOT NULL | 제목 |
+| content | text NOT NULL | 본문 (에디터가 저장하는 포맷 그대로: html/markdown 등) |
+| order_index | int4 NOT NULL DEFAULT 0 | 정렬 순서 |
+| is_use | bool NOT NULL DEFAULT true | 사용 여부 |
+| created_at | timestamptz DEFAULT now() | 생성 시간 |
+| updated_at | timestamptz DEFAULT now() | 수정 시간 |
+
+---
+
+## 3. 관계도
+
+```
+manual_top_categories (tab = customer|store)
+│
+│ top_category_id
+▼
+manual_sub_categories
+│
+│ sub_category_id
+▼
+manuals
+```
+
+- manual_top_categories 1:N manual_sub_categories
+- manual_sub_categories 1:N manuals
+
+---
+
+## 4. 화면 흐름과 매핑
+
+고객 탭 → 매뉴얼 추가 클릭 시
+
+1. 상위 타입 선택 → `manual_top_categories WHERE tab = 'customer' AND is_use = true ORDER BY order_index`
+2. 선택한 상위 타입의 하위 타입 선택 → `manual_sub_categories WHERE top_category_id = :선택한id AND is_use = true ORDER BY order_index`
+3. 내용 입력 → `manuals`에 `sub_category_id`, `title`, `content` insert
+
+카테고리 설정 화면(품목 관리의 "품목 종류" 설정과 동일한 톤)에서는 탭별로 상위 타입 목록을 보여주고, 상위 타입을 펼치면 그 안에 속한 하위 타입 목록이 나오는 아코디언/트리 형태로 구성하면 됨.
+
+---
+
+## 5. SQL (Supabase에 그대로 실행)
+
+```sql
+-- 1. 상위 타입
+create table manual_top_categories (
+  id uuid primary key default gen_random_uuid(),
+  tab text not null check (tab in ('customer', 'store')),
+  name text not null,
+  order_index int4 not null default 0,
+  is_use bool not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index idx_manual_top_categories_tab
+  on manual_top_categories (tab, order_index);
+
+-- 2. 하위 타입
+create table manual_sub_categories (
+  id uuid primary key default gen_random_uuid(),
+  top_category_id uuid not null references manual_top_categories(id) on delete cascade,
+  name text not null,
+  order_index int4 not null default 0,
+  is_use bool not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index idx_manual_sub_categories_top_category_id
+  on manual_sub_categories (top_category_id, order_index);
+
+-- 3. 매뉴얼 본문
+create table manuals (
+  id uuid primary key default gen_random_uuid(),
+  sub_category_id uuid not null references manual_sub_categories(id) on delete restrict,
+  title text not null,
+  content text not null,
+  order_index int4 not null default 0,
+  is_use bool not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index idx_manuals_sub_category_id
+  on manuals (sub_category_id, order_index);
+
+-- updated_at 자동 갱신 트리거 (선택)
+create or replace function set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_manual_top_categories_updated_at
+  before update on manual_top_categories
+  for each row execute function set_updated_at();
+
+create trigger trg_manual_sub_categories_updated_at
+  before update on manual_sub_categories
+  for each row execute function set_updated_at();
+
+create trigger trg_manuals_updated_at
+  before update on manuals
+  for each row execute function set_updated_at();
+```
+
+`on delete cascade` / `on delete restrict`는 취향껏 조정 가능. 위 설정은 상위 타입 삭제 시 하위 타입까지 같이 지워지고(`cascade`), 매뉴얼이 남아있는 하위 타입은 삭제를 막는(`restrict`) 조합. 실무에서는 어차피 `is_use = false`로 비활성 처리하고 실제 delete는 잘 안 쓰게 될 거임.
+
+---
+
+## 6. 작업 진행 사항
+
+- [x] 테이블 설계 확정
+- [ ] 카테고리(상위/하위 타입) 관리 화면
+- [ ] 매뉴얼 목록/추가/수정/삭제 화면
+- [ ] 탭(고객/매장) 전환 UI

--- a/src/app/(auth)/_components/Header/_components/Nav.tsx
+++ b/src/app/(auth)/_components/Header/_components/Nav.tsx
@@ -3,32 +3,41 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-const Nav = () => {
-  const pathname = usePathname();
+const navLinks = [
+  { href: '/customers', label: '고객' },
+  { href: '/histories', label: '이력' },
+  { href: '/after-services', label: 'AS 현황' },
+  { href: '/comparison', label: '기기 비교' },
+  { href: '/items', label: '품목 관리' },
+  { href: '/manuals', label: '매뉴얼' },
+];
 
-  const navLinks = [
-    { href: '/customers', label: '고객' },
-    { href: '/histories', label: '이력' },
-    { href: '/after-services', label: 'AS 현황' },
-    { href: '/comparison', label: '기기 비교' },
-    { href: '/items', label: '품목 관리' },
-  ];
+type NavProps = {
+  orientation?: 'horizontal' | 'vertical';
+  onNavigate?: () => void;
+};
+
+const Nav = ({ orientation = 'horizontal', onNavigate }: NavProps) => {
+  const pathname = usePathname();
+  const isVertical = orientation === 'vertical';
 
   return (
-    <nav className="flex gap-0.5 sm:gap-2">
+    <nav className={isVertical ? 'flex flex-col gap-1.5' : 'flex gap-0.5 sm:gap-2'}>
       {navLinks.map((link) => {
         const isActive = pathname?.startsWith(link.href);
         return (
           <Link
             key={link.href}
             href={link.href}
+            onClick={onNavigate}
             className={`
-              px-2 py-1.5 sm:px-4 sm:py-2 rounded-lg font-medium
+              rounded-lg font-medium
               transition-colors duration-150
+              ${isVertical ? 'px-4 py-3 text-sm' : 'px-2 py-1.5 sm:px-4 sm:py-2'}
               ${
                 isActive
-                  ? 'text-brand-600 bg-white shadow-sm'
-                  : 'text-brand-700 hover:text-brand-600 hover:bg-white/50'
+                  ? 'text-brand-700 bg-white shadow-sm'
+                  : 'text-brand-700 hover:text-brand-600 hover:bg-white/60'
               }
             `}
           >

--- a/src/app/(auth)/_components/SideMenu/index.tsx
+++ b/src/app/(auth)/_components/SideMenu/index.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import Button from '@/app/_components/Button';
+import Loading from '@/app/_components/Loading';
+import { useUser } from '@/app/_contexts/UserContext';
+import Logo from '../Header/_components/Logo';
+import Nav from '../Header/_components/Nav';
+
+const SideMenu = ({ children }: { children: React.ReactNode }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { user, isLoading, logout } = useUser();
+
+  const closeMenu = () => setIsOpen(false);
+
+  const userPanel = (
+    <div className="rounded-lg border border-brand-100 bg-white/75 p-3 shadow-sm">
+      {isLoading ? (
+        <Loading size="sm" />
+      ) : user ? (
+        <div className="space-y-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-brand-400 to-brand-500 text-[10px] font-semibold text-white">
+              {user.oss_role}
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-brand-700">
+                {user.name}
+              </p>
+              <p className="truncate text-xs text-brand-500">{user.email}</p>
+            </div>
+          </div>
+          <Button size="xs" variant="secondary" className="w-full" onClick={logout}>
+            로그아웃
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-white">
+      <header className="sticky top-0 z-40 border-b border-brand-100 bg-brand-50/95 shadow-sm backdrop-blur header:hidden">
+        <div className="flex h-16 items-center justify-between px-4">
+          <Logo />
+          <button
+            type="button"
+            onClick={() => setIsOpen(true)}
+            className="flex h-10 w-10 items-center justify-center rounded-lg border border-brand-200 bg-white text-brand-700 shadow-sm"
+            aria-label="메뉴 열기"
+          >
+            <span className="space-y-1.5">
+              <span className="block h-0.5 w-5 rounded bg-current" />
+              <span className="block h-0.5 w-5 rounded bg-current" />
+              <span className="block h-0.5 w-5 rounded bg-current" />
+            </span>
+          </button>
+        </div>
+      </header>
+
+      <div
+        className={`fixed inset-0 z-50 header:hidden ${
+          isOpen ? 'pointer-events-auto' : 'pointer-events-none'
+        }`}
+      >
+        <button
+          type="button"
+          aria-label="메뉴 닫기"
+          onClick={closeMenu}
+          className={`absolute inset-0 bg-black/30 transition-opacity ${
+            isOpen ? 'opacity-100' : 'opacity-0'
+          }`}
+        />
+        <aside
+          className={`absolute inset-y-0 left-0 flex w-72 max-w-[85vw] flex-col border-r border-brand-100 bg-brand-50 shadow-xl transition-transform duration-200 ${
+            isOpen ? 'translate-x-0' : '-translate-x-full'
+          }`}
+        >
+          <div className="flex h-16 items-center justify-between border-b border-brand-100 px-4">
+            <Logo />
+            <button
+              type="button"
+              onClick={closeMenu}
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-brand-200 bg-white text-sm font-semibold text-brand-700 shadow-sm"
+              aria-label="메뉴 닫기"
+            >
+              X
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto px-3 py-5">
+            <Nav orientation="vertical" onNavigate={closeMenu} />
+          </div>
+          <div className="border-t border-brand-100 px-3 py-4">
+            {userPanel}
+          </div>
+        </aside>
+      </div>
+
+      <main className="min-h-screen">{children}</main>
+    </div>
+  );
+};
+
+export default SideMenu;

--- a/src/app/(auth)/customers/[id]/_components/StampSection.tsx
+++ b/src/app/(auth)/customers/[id]/_components/StampSection.tsx
@@ -219,7 +219,7 @@ const StampSection = ({ stampCount, target, onUpdate, onAddRemark }: StampSectio
             onClick={onAddRemark}
             disabled={isLoading}
           >
-            특이사항
+            고객 특이사항
           </Button>
         </div>
       </div>

--- a/src/app/(auth)/customers/[id]/_components/StampSection.tsx
+++ b/src/app/(auth)/customers/[id]/_components/StampSection.tsx
@@ -147,7 +147,7 @@ const StampSection = ({ stampCount, target, onUpdate, onAddRemark }: StampSectio
                     }}
                   />
                 ),
-                options: { dismissOnBackdrop: false },
+                options: { dismissOnBackdrop: false, size: 'max-w-xl' },
               })
             }
             disabled={isLoading}

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -7,11 +7,14 @@ import {
   PaymentTypeEnumType,
 } from '@/app/_enums/enums';
 import type { StampLogMeta } from '@/app/_domains/_stamp/_services/stampService';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useModal } from '@/app/_contexts/ModalContext';
 import StampLogForm, { StampLogValue } from './StampLogForm';
 import TargetCustomerCard from './TargetCustomerCard';
 
 const formatAmount = (value: number) => value.toLocaleString('ko-KR');
+
+const addStepLabels = ['기본 정보', '품목 · 금액', '최종 확인'] as const;
 
 export default function StampConfirmModal({
   target,
@@ -33,6 +36,7 @@ export default function StampConfirmModal({
   ) => Promise<void> | void;
   onCancel: () => void;
 }) {
+  const { setSize } = useModal();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
 
@@ -42,6 +46,19 @@ export default function StampConfirmModal({
   const [adjustDirection, setAdjustDirection] = useState<'add' | 'remove'>('remove');
   const [stampLog, setStampLog] = useState<StampLogValue | null>(null);
   const [isReservation, setIsReservation] = useState(false);
+
+  // 출고 이력 추가(mode === 'add') 전용 스텝 상태
+  const [addStep, setAddStep] = useState<1 | 2 | 3>(1);
+  const [formValidity, setFormValidity] = useState({
+    hasPaymentType: false,
+    hasItems: false,
+  });
+
+  // 2번 스텝(품목·금액)은 좌우 2단으로 보여줘야 해서 모달을 더 넓게
+  useEffect(() => {
+    if (mode !== 'add') return;
+    setSize(addStep === 2 ? 'max-w-5xl' : 'max-w-xl');
+  }, [mode, addStep, setSize]);
 
   const title =
     mode === 'add'
@@ -57,9 +74,7 @@ export default function StampConfirmModal({
   const labelTitle = '특이 사항';
   const labelText = ' (조정 사유 입력)';
 
-  const isConfirmDisabled =
-    (mode === 'use10' && breathType === '') ||
-    (mode === 'add' && stampLog === null);
+  const isConfirmDisabled = mode === 'use10' && breathType === '';
 
   const handleConfirm = async () => {
     try {
@@ -84,54 +99,227 @@ export default function StampConfirmModal({
     }
   };
 
-  const confirmContent = (
-    <div className="w-full flex flex-col min-h-0">
-      <h2 className="text-xl font-semibold text-gray-900 mb-4">{title} 확인</h2>
+  const reservationToggle = (
+    <div className="flex h-full items-center justify-between gap-3 rounded-lg border border-brand-200 bg-brand-50/60 px-4 py-3">
+      <div>
+        <p className="text-sm font-medium text-gray-800">출고 예약</p>
+        <p className="mt-0.5 text-xs text-gray-500">
+          예약으로 저장하면 스탬프는 적립되지 않고, 예약 이력에서 확정 시 출고
+          이력으로 반영됩니다.
+        </p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={isReservation}
+        onClick={() => setIsReservation((v) => !v)}
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
+          isReservation ? 'bg-brand-500' : 'bg-gray-300'
+        }`}
+      >
+        <span
+          className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+            isReservation ? 'translate-x-5' : 'translate-x-0.5'
+          }`}
+        />
+      </button>
+    </div>
+  );
 
-      <div className="overflow-y-auto min-h-0 flex-1 space-y-4">
-        {/* 대상 고객 */}
-        <TargetCustomerCard
-          name={target.name}
-          phone={target.phone}
-          note={target.note}
+  // ── 출고 이력 추가(mode === 'add') 전용 스텝 UI ──────────────────────────────
+  const stepIndicator = (
+    <div className="mb-5 flex items-start justify-center shrink-0">
+      {addStepLabels.map((label, idx) => {
+        const stepNumber = (idx + 1) as 1 | 2 | 3;
+        const isActive = addStep === stepNumber;
+        const isDone = addStep > stepNumber;
+        return (
+          <div key={label} className="flex items-start">
+            <div className="flex w-16 flex-col items-center gap-1.5">
+              <div
+                className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition-colors ${
+                  isDone
+                    ? 'bg-gradient-to-r from-brand-500 to-brand-600 text-white shadow-sm'
+                    : isActive
+                    ? 'bg-brand-100 text-brand-600 ring-2 ring-brand-400'
+                    : 'bg-gray-100 text-gray-400'
+                }`}
+              >
+                {isDone ? '✓' : stepNumber}
+              </div>
+              <span
+                className={`text-[11px] font-medium whitespace-nowrap ${
+                  isActive || isDone ? 'text-brand-700' : 'text-gray-400'
+                }`}
+              >
+                {label}
+              </span>
+            </div>
+            {stepNumber < 3 && (
+              <div
+                className={`mt-4 h-0.5 w-8 rounded-full transition-colors sm:w-12 ${
+                  isDone ? 'bg-brand-500' : 'bg-gray-200'
+                }`}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const addModeContent = (
+    <div className="relative w-full max-h-[calc(90vh-2rem)] min-h-0 flex flex-col">
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={isSubmitting}
+        aria-label="닫기"
+        className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+      >
+        ✕
+      </button>
+
+      <h2 className="text-xl font-semibold text-gray-900 mb-4 pr-8 shrink-0">{title}</h2>
+
+      {stepIndicator}
+
+      {/* 대상 고객: 모든 스텝에서 고정 노출 */}
+      <TargetCustomerCard
+        name={target.name}
+        phone={target.phone}
+        note={target.note}
+        className="shrink-0 mb-4"
+      />
+
+      <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+        <StampLogForm
+          layout="split"
+          step={addStep}
+          onChange={setStampLog}
+          onValidityChange={setFormValidity}
+          reservationSlot={reservationToggle}
         />
 
+        {addStep === 3 && (
+          <div className="space-y-3">
+            {isReservation && (
+              <div className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700">
+                예약 이력으로 저장됩니다
+              </div>
+            )}
+            <div className="bg-brand-50 rounded-lg p-4 border border-brand-200 space-y-2">
+              {stampLog && (
+                <>
+                  <div>
+                    <span className="text-sm font-medium text-gray-600">매장:</span>
+                    <p className="text-base font-semibold text-gray-900">
+                      {stampLog.storeLabel}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-sm font-medium text-gray-600">
+                      스탬프 개수:
+                    </span>
+                    <p className="text-base font-semibold text-gray-900">
+                      {stampLog.amount === 0 ? '미적립' : `${stampLog.amount}개`}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-sm font-medium text-gray-600">
+                      결제 유형:
+                    </span>
+                    <p className="text-base font-semibold text-gray-900">
+                      {stampLog.paymentTypeName}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-sm font-medium text-gray-600">금액:</span>
+                    <p className="text-base font-semibold text-gray-900">
+                      {stampLog.finalAmountExpression || '0'} ={' '}
+                      {formatAmount(stampLog.finalAmount)}
+                    </p>
+                  </div>
+                  {stampLog.note && (
+                    <div>
+                      <span className="text-sm font-medium text-gray-600">메모:</span>
+                      <p className="text-sm text-gray-900 whitespace-pre-wrap">
+                        {stampLog.note}
+                      </p>
+                    </div>
+                  )}
+                  {stampLog.logMeta.extraNote && (
+                    <div>
+                      <span className="text-sm font-medium text-gray-600">
+                        출고 특이사항:
+                      </span>
+                      <p className="text-sm text-gray-900 whitespace-pre-wrap">
+                        {stampLog.logMeta.extraNote}
+                      </p>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="shrink-0 flex items-center justify-end gap-3 pt-4 mt-4 border-t border-gray-200">
+        {addStep > 1 && (
+          <Button
+            variant="gray"
+            size="sm"
+            onClick={() => setAddStep((s) => (s === 3 ? 2 : 1))}
+            disabled={isSubmitting}
+          >
+            이전
+          </Button>
+        )}
+        {addStep < 3 ? (
+          <Button
+            size="sm"
+            disabled={
+              addStep === 1 ? !formValidity.hasPaymentType : !formValidity.hasItems
+            }
+            onClick={() => setAddStep((s) => (s === 1 ? 2 : 3))}
+          >
+            다음
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            disabled={!stampLog || isSubmitting}
+            onClick={handleConfirm}
+          >
+            {isSubmitting ? '처리 중...' : '확인'}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+
+  if (mode === 'add') {
+    return addModeContent;
+  }
+
+  const confirmContent = (
+    <div className="w-full flex flex-col min-h-0 max-h-[calc(90vh-2rem)]">
+      <h2 className="text-xl font-semibold text-gray-900 mb-4 shrink-0">
+        {title} 확인
+      </h2>
+
+      {/* 대상 고객: 스크롤 영역 밖에 고정 */}
+      <TargetCustomerCard
+        name={target.name}
+        phone={target.phone}
+        note={target.note}
+        className="shrink-0 mb-4"
+      />
+
+      <div className="overflow-y-auto min-h-0 flex-1 space-y-4">
         {/* 요약 정보 */}
         <div className="bg-brand-50 rounded-lg p-4 border border-brand-200 space-y-2">
-          {mode === 'add' && stampLog && (
-            <>
-              {isReservation && (
-                <div className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700">
-                  예약 이력으로 저장됩니다
-                </div>
-              )}
-              <div>
-                <span className="text-sm font-medium text-gray-600">매장:</span>
-                <p className="text-base font-semibold text-gray-900">
-                  {stampLog.storeLabel}
-                </p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-gray-600">스탬프 개수:</span>
-                <p className="text-base font-semibold text-gray-900">
-                  {stampLog.amount === 0 ? '미적립' : `${stampLog.amount}개`}
-                </p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-gray-600">결제 유형:</span>
-                <p className="text-base font-semibold text-gray-900">
-                  {stampLog.paymentTypeName}
-                </p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-gray-600">금액:</span>
-                <p className="text-base font-semibold text-gray-900">
-                  {stampLog.finalAmountExpression || '0'} ={' '}
-                  {formatAmount(stampLog.finalAmount)}
-                </p>
-              </div>
-            </>
-          )}
           {mode === 'adjust' && (
             <div>
               <span className="text-sm font-medium text-gray-600">
@@ -146,28 +334,16 @@ export default function StampConfirmModal({
               <p className="text-base font-semibold text-gray-900">10개 차감</p>
             </div>
           )}
-          {(mode === 'add' ? stampLog?.note : note) && (
+          {note && (
             <div>
               <span className="text-sm font-medium text-gray-600">메모:</span>
-              <p className="text-sm text-gray-900 whitespace-pre-wrap">
-                {mode === 'add' ? stampLog?.note : note}
-              </p>
-            </div>
-          )}
-          {mode === 'add' && stampLog?.logMeta.extraNote && (
-            <div>
-              <span className="text-sm font-medium text-gray-600">
-                출고 특이사항:
-              </span>
-              <p className="text-sm text-gray-900 whitespace-pre-wrap">
-                {stampLog.logMeta.extraNote}
-              </p>
+              <p className="text-sm text-gray-900 whitespace-pre-wrap">{note}</p>
             </div>
           )}
         </div>
       </div>
 
-      <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 mt-4">
+      <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 mt-4 shrink-0">
         <Button
           variant="gray"
           size="sm"
@@ -183,178 +359,166 @@ export default function StampConfirmModal({
     </div>
   );
 
-  // ── 입력 화면 ──────────────────────────────────────────────────────────────
+  // ── 입력 화면 (조정 / 쿠폰 사용) ────────────────────────────────────────────
   return (
     <>
-    <div
-      className={`w-full max-h-[calc(90vh-2rem)] min-h-0 flex-col ${
-        showConfirm ? 'hidden' : 'flex'
-      }`}
-    >
-      <div className="shrink-0 mb-4">
-        <h2 className="text-xl font-semibold text-gray-900 mb-3">{title}</h2>
+      <div
+        className={`w-full max-h-[calc(90vh-2rem)] min-h-0 flex-col ${
+          showConfirm ? 'hidden' : 'flex'
+        }`}
+      >
+        <div className="shrink-0 mb-4">
+          <h2 className="text-xl font-semibold text-gray-900 mb-3">{title}</h2>
 
-        <TargetCustomerCard
-          name={target.name}
-          phone={target.phone}
-          note={target.note}
-          className="mb-4"
-        />
+          <TargetCustomerCard
+            name={target.name}
+            phone={target.phone}
+            note={target.note}
+            className="mb-4"
+          />
 
-        {mode === 'use10' && (
-          <div className="text-center py-4">
-            <p className="text-gray-700 text-base leading-relaxed">
-              쿠폰을 사용 처리 하시겠습니까? (10개 차감)
-            </p>
-          </div>
-        )}
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-        {mode === 'adjust' && (
-          <div className="mb-4">
-          <span className="block text-sm font-medium text-gray-700 mb-2">
-            조정 유형 <span className="text-rose-600">*</span>
-          </span>
-          <div className="grid grid-cols-2 gap-2 mb-4">
-            <Button
-              type="button"
-              size="sm"
-              variant={adjustDirection === 'remove' ? 'primary' : 'gray'}
-              onClick={() => setAdjustDirection('remove')}
-            >
-              차감
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant={adjustDirection === 'add' ? 'primary' : 'gray'}
-              onClick={() => setAdjustDirection('add')}
-            >
-              추가
-            </Button>
-          </div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            {adjustActionLabel} 개수 <span className="text-rose-600">*</span>
-          </label>
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              value={amount}
-              onChange={(e) => {
-                const v = e.target.value;
-                if (v === '' || /^[0-9]+$/.test(v)) {
-                  setAmount(v === '' ? 1 : Math.max(1, Number(v)));
-                }
-              }}
-              className="w-16 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-center"
-            />
-            <button
-              type="button"
-              onClick={() => setAmount((v) => Math.max(1, v - 1))}
-              className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 active:bg-gray-100 transition-colors text-lg leading-none"
-            >
-              −
-            </button>
-            <button
-              type="button"
-              onClick={() => setAmount((v) => v + 1)}
-              className="w-8 h-8 flex items-center justify-center rounded-lg bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700 transition-colors text-lg leading-none"
-            >
-              +
-            </button>
-          </div>
-        </div>
-      )}
-
-      {mode === 'add' && (
-        <>
-          <StampLogForm onChange={setStampLog} />
-
-          <div className="mt-5 flex items-center justify-between gap-3 rounded-lg border border-brand-200 bg-brand-50/60 px-4 py-3">
-            <div>
-              <p className="text-sm font-medium text-gray-800">출고 예약</p>
-              <p className="mt-0.5 text-xs text-gray-500">
-                예약으로 저장하면 스탬프는 적립되지 않고, 예약 이력에서 확정 시
-                출고 이력으로 반영됩니다.
+          {mode === 'use10' && (
+            <div className="text-center py-4">
+              <p className="text-gray-700 text-base leading-relaxed">
+                쿠폰을 사용 처리 하시겠습니까? (10개 차감)
               </p>
             </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={isReservation}
-              onClick={() => setIsReservation((v) => !v)}
-              className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
-                isReservation ? 'bg-brand-500' : 'bg-gray-300'
-              }`}
-            >
-              <span
-                className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
-                  isReservation ? 'translate-x-5' : 'translate-x-0.5'
-                }`}
-              />
-            </button>
-          </div>
-        </>
-      )}
-
-      {mode === 'use10' && (
-        <div className="mb-6">
-          <span className="block text-sm font-medium text-gray-700 mb-3">
-            쿠폰 사용 유형
-          </span>
-          <div className="flex items-center gap-3">
-            <Button
-              type="button"
-              size="sm"
-              variant={breathType === BreathTypeEnum.MTL.value ? 'primary' : 'tertiary'}
-              className="flex-1 text-center"
-              onClick={() => {
-                setBreathType(BreathTypeEnum.MTL.value);
-                setNote('입호흡 쿠폰 사용');
-              }}
-            >
-              입호흡
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant={breathType === BreathTypeEnum.DTL.value ? 'primary' : 'tertiary'}
-              className="flex-1 text-center"
-              onClick={() => {
-                setBreathType(BreathTypeEnum.DTL.value);
-                setNote('폐호흡 쿠폰 사용');
-              }}
-            >
-              폐호흡
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant={breathType === BreathTypeEnum.CUSTOM.value ? 'primary' : 'tertiary'}
-              className="flex-1 text-center"
-              onClick={() => {
-                setBreathType(BreathTypeEnum.CUSTOM.value);
-                setNote('');
-              }}
-            >
-              직접 입력
-            </Button>
-          </div>
-
-          {breathType !== BreathTypeEnum.CUSTOM.value && (
-            <p className="mt-2 text-xs text-gray-500">
-              사용 유형을 선택하면 메모가 자동으로 입력됩니다.
-            </p>
           )}
-          {breathType === BreathTypeEnum.CUSTOM.value && (
-            <div className="mt-3">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                메모 직접 입력
-              </label>
-              <span className="text-xs text-gray-500 whitespace-pre-line">
-                (예: [액상 이름] [30/60]ml [숫자] 병, 쿠폰 사용)
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+          {mode === 'adjust' && (
+            <div className="mb-4">
+              <span className="block text-sm font-medium text-gray-700 mb-2">
+                조정 유형 <span className="text-rose-600">*</span>
               </span>
+              <div className="grid grid-cols-2 gap-2 mb-4">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={adjustDirection === 'remove' ? 'primary' : 'gray'}
+                  onClick={() => setAdjustDirection('remove')}
+                >
+                  차감
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={adjustDirection === 'add' ? 'primary' : 'gray'}
+                  onClick={() => setAdjustDirection('add')}
+                >
+                  추가
+                </Button>
+              </div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {adjustActionLabel} 개수 <span className="text-rose-600">*</span>
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={amount}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === '' || /^[0-9]+$/.test(v)) {
+                      setAmount(v === '' ? 1 : Math.max(1, Number(v)));
+                    }
+                  }}
+                  className="w-16 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-center"
+                />
+                <button
+                  type="button"
+                  onClick={() => setAmount((v) => Math.max(1, v - 1))}
+                  className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 active:bg-gray-100 transition-colors text-lg leading-none"
+                >
+                  −
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setAmount((v) => v + 1)}
+                  className="w-8 h-8 flex items-center justify-center rounded-lg bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700 transition-colors text-lg leading-none"
+                >
+                  +
+                </button>
+              </div>
+            </div>
+          )}
+
+          {mode === 'use10' && (
+            <div className="mb-6">
+              <span className="block text-sm font-medium text-gray-700 mb-3">
+                쿠폰 사용 유형
+              </span>
+              <div className="flex items-center gap-3">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={breathType === BreathTypeEnum.MTL.value ? 'primary' : 'tertiary'}
+                  className="flex-1 text-center"
+                  onClick={() => {
+                    setBreathType(BreathTypeEnum.MTL.value);
+                    setNote('입호흡 쿠폰 사용');
+                  }}
+                >
+                  입호흡
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={breathType === BreathTypeEnum.DTL.value ? 'primary' : 'tertiary'}
+                  className="flex-1 text-center"
+                  onClick={() => {
+                    setBreathType(BreathTypeEnum.DTL.value);
+                    setNote('폐호흡 쿠폰 사용');
+                  }}
+                >
+                  폐호흡
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={breathType === BreathTypeEnum.CUSTOM.value ? 'primary' : 'tertiary'}
+                  className="flex-1 text-center"
+                  onClick={() => {
+                    setBreathType(BreathTypeEnum.CUSTOM.value);
+                    setNote('');
+                  }}
+                >
+                  직접 입력
+                </Button>
+              </div>
+
+              {breathType !== BreathTypeEnum.CUSTOM.value && (
+                <p className="mt-2 text-xs text-gray-500">
+                  사용 유형을 선택하면 메모가 자동으로 입력됩니다.
+                </p>
+              )}
+              {breathType === BreathTypeEnum.CUSTOM.value && (
+                <div className="mt-3">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    메모 직접 입력
+                  </label>
+                  <span className="text-xs text-gray-500 whitespace-pre-line">
+                    (예: [액상 이름] [30/60]ml [숫자] 병, 쿠폰 사용)
+                  </span>
+                  <textarea
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-colors text-xs"
+                    placeholder="위에 해당되는 내용을 입력해주세요."
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {mode === 'adjust' && (
+            <div className="mb-6">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                {labelTitle}
+                <span className="text-xs text-gray-500 whitespace-pre-line">
+                  {labelText}
+                </span>
+              </label>
               <textarea
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
@@ -364,40 +528,17 @@ export default function StampConfirmModal({
             </div>
           )}
         </div>
-      )}
 
-      {mode === 'adjust' && (
-        <div className="mb-6">
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            {labelTitle}
-            <span className="text-xs text-gray-500 whitespace-pre-line">
-              {labelText}
-            </span>
-          </label>
-          <textarea
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-colors text-xs"
-            placeholder="위에 해당되는 내용을 입력해주세요."
-          />
+        <div className="shrink-0 flex justify-end items-center gap-3 pt-4 mt-4 border-t border-gray-200">
+          <Button variant="gray" size="sm" onClick={onCancel}>
+            취소
+          </Button>
+          <Button disabled={isConfirmDisabled} onClick={() => setShowConfirm(true)} size="sm">
+            확인
+          </Button>
         </div>
-      )}
       </div>
-
-      <div className="shrink-0 flex justify-end gap-3 pt-4 mt-4 border-t border-gray-200">
-        <Button variant="gray" size="sm" onClick={onCancel}>
-          취소
-        </Button>
-        <Button
-          disabled={isConfirmDisabled}
-          onClick={() => setShowConfirm(true)}
-          size="sm"
-        >
-          확인
-        </Button>
-      </div>
-    </div>
-    {showConfirm && confirmContent}
+      {showConfirm && confirmContent}
     </>
   );
 }

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -38,6 +38,7 @@ const paymentTypesByStore = {
 const remarkOptions = [
   { value: '', name: '미입력' },
   { value: 'service', name: '서비스' },
+  { value: 'demo', name: '시연용' },
   { value: 'custom', name: '메모 직접 입력' },
   { value: 'price_adjust', name: '가격 조정' },
 ] as const;
@@ -77,6 +78,12 @@ export type StampLogFormInitialValue = {
 };
 
 const formatAmount = (value: number) => value.toLocaleString('ko-KR');
+const parseSignedAmount = (value: string) => {
+  if (value === '' || value === '-') return 0;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
 
 export default function StampLogForm({
   onChange,
@@ -100,7 +107,7 @@ export default function StampLogForm({
   const [quantity, setQuantity] = useState(1);
   const [remarkType, setRemarkType] = useState<RemarkOptionValue>('');
   const [customRemark, setCustomRemark] = useState('');
-  const [priceAdjustAmount, setPriceAdjustAmount] = useState(0);
+  const [priceAdjustAmount, setPriceAdjustAmount] = useState('0');
   const [priceAdjustMemo, setPriceAdjustMemo] = useState('');
   const [draftLines, setDraftLines] = useState<DraftStampLogLine[]>(
     () =>
@@ -148,7 +155,7 @@ export default function StampLogForm({
       : '';
   const itemNote = draftLines.map((line) => line.lineText).join(', ');
   const generatedNote = [discountLine, itemNote].filter(Boolean).join(' ');
-  const finalAmount = Math.max(totalAmount - activeDiscountAmount, 0);
+  const finalAmount = totalAmount - activeDiscountAmount;
   const amountExpression = draftLines
     .map((line) => formatAmount(line.amount))
     .join(' + ');
@@ -163,7 +170,7 @@ export default function StampLogForm({
     setQuantity(1);
     setRemarkType('');
     setCustomRemark('');
-    setPriceAdjustAmount(0);
+    setPriceAdjustAmount('0');
     setPriceAdjustMemo('');
   };
 
@@ -273,6 +280,7 @@ export default function StampLogForm({
     if (!selectedItem || quantity < 1) return;
 
     const price = selectedItem.selling_price ?? 0;
+    const adjustedPrice = parseSignedAmount(priceAdjustAmount);
     const priceAdjustmentMemo = priceAdjustMemo.trim() || '가격 조정';
     const remark =
       remarkType === 'custom'
@@ -282,13 +290,17 @@ export default function StampLogForm({
         : remarkType === ''
         ? ''
         : remarkOptions.find((option) => option.value === remarkType)?.name ?? '';
+    const isFreeRemark = remarkType === 'service' || remarkType === 'demo';
     const lineAmount =
-      remarkType === 'service'
+      isFreeRemark
         ? 0
         : remarkType === 'price_adjust'
-        ? priceAdjustAmount * quantity
+        ? adjustedPrice * quantity
         : price * quantity;
-    const remarkText = remark;
+    const remarkText =
+      remarkType === 'price_adjust'
+        ? `${remark}, ${formatAmount(adjustedPrice)}원`
+        : remark;
     const lineText = `${selectedItem.item_name} ${quantity}개${
       remarkText ? ` (${remarkText})` : ''
     }`;
@@ -303,7 +315,7 @@ export default function StampLogForm({
         quantity,
         unitPrice: price,
         adjustedUnitPrice:
-          remarkType === 'price_adjust' ? priceAdjustAmount : null,
+          remarkType === 'price_adjust' ? adjustedPrice : null,
         amount: lineAmount,
         remark,
         lineText,
@@ -632,10 +644,11 @@ export default function StampLogForm({
                   value={priceAdjustAmount}
                   onChange={(e) => {
                     const v = e.target.value;
-                    if (v === '' || /^[0-9]+$/.test(v)) {
-                      setPriceAdjustAmount(v === '' ? 0 : Number(v));
+                    if (/^-?[0-9]*$/.test(v)) {
+                      setPriceAdjustAmount(v);
                     }
                   }}
+                  inputMode="numeric"
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-right"
                   placeholder="금액"
                 />
@@ -661,10 +674,10 @@ export default function StampLogForm({
           <p className="text-xs text-gray-500">
             {selectedItem
               ? `${selectedItem.item_name} / ${formatAmount(
-                  remarkType === 'service'
+                  remarkType === 'service' || remarkType === 'demo'
                     ? 0
                     : remarkType === 'price_adjust'
-                    ? priceAdjustAmount * quantity
+                    ? parseSignedAmount(priceAdjustAmount) * quantity
                     : (selectedItem.selling_price ?? 0) * quantity,
                 )}원`
               : '품목을 선택하면 메모와 금액이 생성됩니다.'}

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -89,10 +89,35 @@ export default function StampLogForm({
   onChange,
   initialValue,
   isStampAmountEditable = true,
+  layout = 'stacked',
+  leftPanelExtra,
+  rightPanelExtra,
+  step,
+  onValidityChange,
+  reservationSlot,
 }: {
   onChange: (value: StampLogValue | null) => void;
   initialValue?: StampLogFormInitialValue;
   isStampAmountEditable?: boolean;
+  /**
+   * 'stacked' (기본): 기존처럼 모든 섹션을 한 줄로 쌓아서 표시
+   * 'split': 매장명/결제유형/스탬프개수/할인은 좌측, 품목/금액/특이사항은 우측 2단 레이아웃
+   */
+  layout?: 'stacked' | 'split';
+  /** layout이 'split'일 때 좌측 패널 최상단에 렌더링할 요소 (예: 대상 고객 카드) */
+  leftPanelExtra?: React.ReactNode;
+  /** layout이 'split'일 때 우측 패널 최하단에 렌더링할 요소 (예: 출고 예약 토글) */
+  rightPanelExtra?: React.ReactNode;
+  /**
+   * layout이 'split'일 때만 사용. 값이 있으면 2단 레이아웃 대신 스텝별 필드만 노출:
+   * 1 → 매장명/결제유형/스탬프개수, 2 → 품목선택/품목목록/할인/금액/특이사항
+   * (내부 상태 보존을 위해 컴포넌트는 계속 마운트된 채로 CSS로만 숨김)
+   */
+  step?: 1 | 2 | 3;
+  /** paymentType, 품목 선택 여부가 바뀔 때마다 호출 (스텝 이동 가능 여부 판단용) */
+  onValidityChange?: (info: { hasPaymentType: boolean; hasItems: boolean }) => void;
+  /** step 모드에서 2번 스텝의 출고 특이사항 입력 오른쪽에 함께 렌더링할 요소 (예: 출고 예약 토글) */
+  reservationSlot?: React.ReactNode;
 }) {
   const [paymentType, setPaymentType] = useState<
     PaymentTypeEnumType['value'] | ''
@@ -264,6 +289,17 @@ export default function StampLogForm({
     extraNote,
   ]);
 
+  // 스텝 UI에서 "다음" 버튼 활성화 여부를 부모가 판단할 수 있도록 알림
+  const onValidityChangeRef = useRef(onValidityChange);
+  onValidityChangeRef.current = onValidityChange;
+
+  useEffect(() => {
+    onValidityChangeRef.current?.({
+      hasPaymentType: paymentType !== '',
+      hasItems: draftLines.length > 0,
+    });
+  }, [paymentType, draftLines]);
+
   const handleItemSelect = (item: ItemType) => {
     setSelectedItem(item);
     setItemSearch('');
@@ -388,96 +424,101 @@ export default function StampLogForm({
     previousLineRectsRef.current = new Map();
   }, [draftLines]);
 
-  return (
-    <div className="space-y-5">
-      <div>
-        <span className="block text-sm font-medium mb-2">
-          매장명 <span className="text-rose-600">*</span>
-        </span>
-        <div className="grid grid-cols-2 gap-2">
-          {Object.values(StoreTypeEnum).map((option) => (
-            <Button
-              key={option.value}
-              type="button"
-              size="sm"
-              variant={storeName === option.value ? 'primary' : 'gray'}
-              onClick={() => {
-                setStoreName(option.value);
-                setPaymentType('');
-              }}
-            >
-              {option.name}
-            </Button>
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <span className="block text-sm font-medium mb-2">
-          결제 유형 <span className="text-rose-600">*</span>
-        </span>
-        <div className="grid grid-cols-3 gap-2">
-          {paymentTypeOptions.map((option) => (
-            <Button
-              key={option.value}
-              type="button"
-              size="sm"
-              variant={paymentType === option.value ? 'primary' : 'gray'}
-              onClick={() => setPaymentType(option.value)}
-            >
-              {option.name}
-            </Button>
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          스탬프 개수 <span className="text-rose-600">*</span>
-        </label>
-        <div className="flex items-center gap-2">
-          <input
-            type="text"
-            value={amount}
-            onChange={(e) => {
-              if (!isStampAmountEditable) return;
-              const v = e.target.value;
-              if (v === '' || /^[0-9]+$/.test(v)) {
-                setAmount(v === '' ? 0 : Number(v));
-              }
+  const storeField = (
+    <div>
+      <span className="block text-sm font-medium mb-2">
+        매장명 <span className="text-rose-600">*</span>
+      </span>
+      <div className="grid grid-cols-2 gap-2">
+        {Object.values(StoreTypeEnum).map((option) => (
+          <Button
+            key={option.value}
+            type="button"
+            size="sm"
+            variant={storeName === option.value ? 'primary' : 'gray'}
+            onClick={() => {
+              setStoreName(option.value);
+              setPaymentType('');
             }}
-            disabled={!isStampAmountEditable}
-            className="w-16 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-center disabled:bg-gray-100 disabled:text-gray-500"
-          />
-          <button
-            type="button"
-            onClick={() => setAmount((v) => Math.max(0, v - 1))}
-            disabled={!isStampAmountEditable}
-            className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 active:bg-gray-100 transition-colors text-lg leading-none disabled:cursor-not-allowed disabled:opacity-40"
           >
-            −
-          </button>
-          <button
-            type="button"
-            onClick={() => setAmount((v) => v + 1)}
-            disabled={!isStampAmountEditable}
-            className="w-8 h-8 flex items-center justify-center rounded-lg bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700 transition-colors text-lg leading-none disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            +
-          </button>
-        </div>
-        {!isStampAmountEditable ? (
-          <p className="mt-1.5 text-xs text-gray-400">
-            수정 시 스탬프 개수는 변경되지 않습니다.
-          </p>
-        ) : amount === 0 && (
-          <p className="mt-1.5 text-xs text-gray-400">
-            0개 입력 시 <span className="font-medium text-gray-500">미적립</span>
-            으로 기록됩니다.
-          </p>
-        )}
+            {option.name}
+          </Button>
+        ))}
       </div>
+    </div>
+  );
 
+  const paymentField = (
+    <div>
+      <span className="block text-sm font-medium mb-2">
+        결제 유형 <span className="text-rose-600">*</span>
+      </span>
+      <div className="grid grid-cols-3 gap-2">
+        {paymentTypeOptions.map((option) => (
+          <Button
+            key={option.value}
+            type="button"
+            size="sm"
+            variant={paymentType === option.value ? 'primary' : 'gray'}
+            onClick={() => setPaymentType(option.value)}
+          >
+            {option.name}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+
+  const stampCountField = (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">
+        스탬프 개수 <span className="text-rose-600">*</span>
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={amount}
+          onChange={(e) => {
+            if (!isStampAmountEditable) return;
+            const v = e.target.value;
+            if (v === '' || /^[0-9]+$/.test(v)) {
+              setAmount(v === '' ? 0 : Number(v));
+            }
+          }}
+          disabled={!isStampAmountEditable}
+          className="w-16 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-center disabled:bg-gray-100 disabled:text-gray-500"
+        />
+        <button
+          type="button"
+          onClick={() => setAmount((v) => Math.max(0, v - 1))}
+          disabled={!isStampAmountEditable}
+          className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 active:bg-gray-100 transition-colors text-lg leading-none disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          −
+        </button>
+        <button
+          type="button"
+          onClick={() => setAmount((v) => v + 1)}
+          disabled={!isStampAmountEditable}
+          className="w-8 h-8 flex items-center justify-center rounded-lg bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700 transition-colors text-lg leading-none disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          +
+        </button>
+      </div>
+      {!isStampAmountEditable ? (
+        <p className="mt-1.5 text-xs text-gray-400">
+          수정 시 스탬프 개수는 변경되지 않습니다.
+        </p>
+      ) : amount === 0 && (
+        <p className="mt-1.5 text-xs text-gray-400">
+          0개 입력 시 <span className="font-medium text-gray-500">미적립</span>
+          으로 기록됩니다.
+        </p>
+      )}
+    </div>
+  );
+
+  const itemSelectionField = (
       <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 space-y-3">
         <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_150px]">
           <div>
@@ -692,13 +733,17 @@ export default function StampLogForm({
           </Button>
         </div>
       </div>
+  );
 
-      <div>
-        <span className="block text-sm font-medium text-gray-700 mb-2">
-          품목 목록 <span className="text-rose-600">*</span>
-        </span>
-        <div className="min-h-24 rounded-lg bg-gray-50 p-3">
-          {draftLines.length === 0 ? (
+  const itemListLabel = (
+    <span className="block text-sm font-medium text-gray-700 mb-2">
+      품목 목록 <span className="text-rose-600">*</span>
+    </span>
+  );
+
+  const itemListContent = (
+    <>
+      {draftLines.length === 0 ? (
             <p className="text-sm text-gray-400">추가된 품목이 없습니다.</p>
           ) : (
             <div className="space-y-2">
@@ -765,13 +810,26 @@ export default function StampLogForm({
               ))}
             </div>
           )}
-        </div>
-      </div>
+    </>
+  );
 
+  const itemListField = step ? (
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+        {itemListLabel}
+        <div className="min-h-24">{itemListContent}</div>
+      </div>
+  ) : (
+      <div>
+        {itemListLabel}
+        <div className="min-h-24 rounded-lg bg-gray-50 p-3">{itemListContent}</div>
+      </div>
+  );
+
+  const discountField = (
       <div>
         <span className="block text-sm font-medium text-gray-700 mb-2">할인</span>
-        <div className="space-y-3">
-          <div className="grid grid-cols-3 gap-2">
+        <div className="flex items-center gap-2">
+          <div className="grid flex-1 grid-cols-3 gap-2">
             {discountOptions.map((option) => (
               <Button
                 key={option.value}
@@ -784,7 +842,7 @@ export default function StampLogForm({
               </Button>
             ))}
           </div>
-          <div className="flex items-center gap-1">
+          <div className="flex shrink-0 items-center gap-1">
             <input
               type="text"
               value={discountAmount}
@@ -794,14 +852,16 @@ export default function StampLogForm({
                   setDiscountAmount(v === '' ? 0 : Number(v));
                 }
               }}
-              className="w-28 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-right"
+              className="w-24 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-right"
               placeholder="금액"
             />
             <span className="text-sm text-gray-600">원</span>
           </div>
         </div>
       </div>
+  );
 
+  const amountField = (
       <div>
         <span className="block text-sm font-medium text-gray-700 mb-2">금액</span>
         <div className="rounded-lg bg-gray-50 px-3 py-3">
@@ -810,7 +870,9 @@ export default function StampLogForm({
           </p>
         </div>
       </div>
+  );
 
+  const extraNoteField = (
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-2">
           출고 특이사항
@@ -823,7 +885,76 @@ export default function StampLogForm({
           placeholder="배달지주소 , 네이버톡톡 : 아이디"
         />
       </div>
+  );
 
+  if (layout === 'split') {
+    // 스텝 UI 모드: step 값이 있으면 2단 레이아웃 대신 스텝별 필드만 노출.
+    // 컴포넌트는 계속 마운트된 채로 CSS로만 보이거나 숨겨지므로, 스텝을 오가도
+    // 매장명/결제유형/품목/할인 등 입력 상태가 그대로 유지된다.
+    if (step) {
+      return (
+        <div className="space-y-5">
+          <div className={step === 1 ? 'space-y-5' : 'hidden'}>
+            {storeField}
+            {paymentField}
+            {stampCountField}
+          </div>
+          <div className={step === 2 ? 'space-y-5' : 'hidden'}>
+            <div className="grid grid-cols-1 gap-x-6 gap-y-5 lg:grid-cols-2 lg:items-start">
+              <div className="min-w-0">{itemSelectionField}</div>
+              <div className="min-w-0">{itemListField}</div>
+            </div>
+            <div className="grid grid-cols-1 gap-x-6 gap-y-5 lg:grid-cols-2 lg:items-start">
+              <div className="min-w-0">{discountField}</div>
+              <div className="min-w-0">{amountField}</div>
+            </div>
+            <div className="grid grid-cols-1 gap-x-6 gap-y-5 lg:grid-cols-2 lg:items-start">
+              <div className="min-w-0 w-full">{extraNoteField}</div>
+              <div className="min-w-0">{reservationSlot}</div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-5">
+        <div className="lg:sticky lg:top-0 lg:z-10 lg:bg-white lg:pb-4 lg:border-b lg:border-gray-100">
+          <div className="grid grid-cols-1 gap-x-8 gap-y-5 lg:grid-cols-2 lg:items-stretch">
+            <div className="min-w-0">{leftPanelExtra}</div>
+            <div className="min-w-0">{itemSelectionField}</div>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-x-8 gap-y-5 lg:grid-cols-2 lg:items-start">
+          <div className="min-w-0 space-y-5">
+            {storeField}
+            {paymentField}
+            {stampCountField}
+            {discountField}
+          </div>
+          <div className="min-w-0 space-y-5">
+            {itemListField}
+            {amountField}
+            {extraNoteField}
+            {rightPanelExtra}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {leftPanelExtra}
+      {storeField}
+      {paymentField}
+      {stampCountField}
+      {itemSelectionField}
+      {itemListField}
+      {discountField}
+      {amountField}
+      {extraNoteField}
+      {rightPanelExtra}
     </div>
   );
 }

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -22,12 +22,14 @@ const ovapePaymentTypes = [
   PaymentTypeEnum.KAKAOTALK,
   PaymentTypeEnum.CASH_RECEIPT,
   PaymentTypeEnum.TRANSFER_CASH_RECEIPT,
+  PaymentTypeEnum.SHIPMENT_REMARK,
 ];
 
 const eguVapePaymentTypes = [
   PaymentTypeEnum.EGU_CARD,
   PaymentTypeEnum.EGU_TRANSFER,
   PaymentTypeEnum.EGU_CASH_RECEIPT,
+  PaymentTypeEnum.SHIPMENT_REMARK,
 ];
 
 const paymentTypesByStore = {

--- a/src/app/(auth)/customers/_components/TargetCustomerCard.tsx
+++ b/src/app/(auth)/customers/_components/TargetCustomerCard.tsx
@@ -7,17 +7,19 @@ export default function TargetCustomerCard({
   phone,
   note,
   className = '',
+  label = '대상 고객',
 }: {
   name: string;
   phone: string;
   note?: string | null;
   className?: string;
+  label?: string;
 }) {
   return (
     <div className={`bg-gray-100 rounded-lg p-4 ${className}`}>
       <div className="flex items-center gap-2 mb-2">
         <div className="w-2 h-2 bg-brand-500 rounded-full" />
-        <span className="text-sm font-medium text-gray-700">대상 고객</span>
+        <span className="text-sm font-medium text-gray-700">{label}</span>
       </div>
       <p className="text-lg font-semibold text-gray-900">{name}</p>
       <p className="text-sm text-gray-600">{formatPhoneNumber(phone)}</p>

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,4 +1,5 @@
 import Header from './_components/Header';
+import SideMenu from './_components/SideMenu';
 import { UserProvider } from '@/app/_contexts/UserContext';
 
 export default function CustomersLayout({
@@ -8,8 +9,10 @@ export default function CustomersLayout({
 }) {
   return (
     <UserProvider requireAuth>
-      <Header />
-      {children}
+      <div className="hidden header:block">
+        <Header />
+      </div>
+      <SideMenu>{children}</SideMenu>
     </UserProvider>
   );
 }

--- a/src/app/(auth)/manuals/_components/ManualCategoryManageModal/index.tsx
+++ b/src/app/(auth)/manuals/_components/ManualCategoryManageModal/index.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import Button from '@/app/_components/Button';
+import Loading from '@/app/_components/Loading';
+import { useManualCategories } from '@/app/_domains/_manual/_hooks/useManualCategories';
+
+interface ManualCategoryManageModalProps {
+  tab: string;
+  tabLabel: string;
+  onClose: () => void;
+}
+
+type EditingState = { id: string; name: string };
+
+const getErrorCode = (err: unknown) => (err as { code?: string })?.code;
+
+const ManualCategoryManageModal = ({
+  tab,
+  tabLabel,
+  onClose,
+}: ManualCategoryManageModalProps) => {
+  const {
+    topCategories,
+    subCategoriesByTop,
+    isLoading,
+    isSubmitting,
+    addTopCategory,
+    editTopCategory,
+    removeTopCategory,
+    moveTopCategory,
+    addSubCategory,
+    editSubCategory,
+    removeSubCategory,
+    moveSubCategory,
+  } = useManualCategories(tab);
+
+  const [expandedTopId, setExpandedTopId] = useState<string | null>(null);
+  const [newTopName, setNewTopName] = useState('');
+  const [newSubName, setNewSubName] = useState('');
+  const [editingTop, setEditingTop] = useState<EditingState | null>(null);
+  const [editingSub, setEditingSub] = useState<EditingState | null>(null);
+
+  const toggleExpand = (topId: string) => {
+    setExpandedTopId((prev) => (prev === topId ? null : topId));
+    setNewSubName('');
+    setEditingSub(null);
+  };
+
+  // ==========================================================================
+  // 상위 타입
+  // ==========================================================================
+
+  const handleAddTop = async () => {
+    if (!newTopName.trim()) return;
+    try {
+      await addTopCategory(newTopName.trim());
+      setNewTopName('');
+      toast.success('상위 카테고리가 추가되었습니다.');
+    } catch {
+      toast.error('상위 카테고리 추가에 실패했습니다.');
+    }
+  };
+
+  const handleSaveTop = async (id: string) => {
+    if (!editingTop || !editingTop.name.trim()) return;
+    try {
+      await editTopCategory(id, editingTop.name.trim());
+      setEditingTop(null);
+      toast.success('상위 카테고리가 수정되었습니다.');
+    } catch {
+      toast.error('상위 카테고리 수정에 실패했습니다.');
+    }
+  };
+
+  const handleDeleteTop = async (id: string) => {
+    try {
+      await removeTopCategory(id);
+      if (expandedTopId === id) setExpandedTopId(null);
+      toast.success('상위 카테고리가 삭제되었습니다.');
+    } catch (err) {
+      if (getErrorCode(err) === '23503') {
+        toast.error('하위 카테고리에 연결된 매뉴얼이 있어 삭제할 수 없습니다.');
+      } else {
+        toast.error('상위 카테고리 삭제에 실패했습니다.');
+      }
+    }
+  };
+
+  // ==========================================================================
+  // 하위 타입
+  // ==========================================================================
+
+  const handleAddSub = async (topId: string) => {
+    if (!newSubName.trim()) return;
+    try {
+      await addSubCategory(topId, newSubName.trim());
+      setNewSubName('');
+      toast.success('하위 카테고리가 추가되었습니다.');
+    } catch {
+      toast.error('하위 카테고리 추가에 실패했습니다.');
+    }
+  };
+
+  const handleSaveSub = async (id: string) => {
+    if (!editingSub || !editingSub.name.trim()) return;
+    try {
+      await editSubCategory(id, editingSub.name.trim());
+      setEditingSub(null);
+      toast.success('하위 카테고리가 수정되었습니다.');
+    } catch {
+      toast.error('하위 카테고리 수정에 실패했습니다.');
+    }
+  };
+
+  const handleDeleteSub = async (id: string) => {
+    try {
+      await removeSubCategory(id);
+      toast.success('하위 카테고리가 삭제되었습니다.');
+    } catch (err) {
+      if (getErrorCode(err) === '23503') {
+        toast.error('연결된 매뉴얼이 있어 삭제할 수 없습니다.');
+      } else {
+        toast.error('하위 카테고리 삭제에 실패했습니다.');
+      }
+    }
+  };
+
+  return (
+    <div className="w-full flex flex-col min-h-0">
+      <h2 className="text-lg font-semibold mb-4 shrink-0">
+        카테고리 관리 <span className="text-sm font-normal text-gray-500">({tabLabel})</span>
+      </h2>
+
+      <div className="overflow-y-auto min-h-0 flex-1">
+        {isLoading ? (
+          <Loading size="sm" text="불러오는 중..." />
+        ) : topCategories.length === 0 ? (
+          <p className="text-sm text-gray-400 text-center py-6">
+            등록된 상위 카테고리가 없습니다.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topCategories.map((top, topIdx) => {
+              const subs = subCategoriesByTop[top.id] ?? [];
+              const isExpanded = expandedTopId === top.id;
+
+              return (
+                <div
+                  key={top.id}
+                  className="border border-gray-100 rounded-lg overflow-hidden"
+                >
+                  {/* 상위 타입 행 */}
+                  <div
+                    onClick={() => {
+                      if (editingTop?.id !== top.id) toggleExpand(top.id);
+                    }}
+                    className={`flex items-center gap-2 px-3 py-2.5 bg-gray-50 transition-colors ${
+                      editingTop?.id === top.id
+                        ? ''
+                        : 'cursor-pointer hover:bg-gray-100'
+                    }`}
+                  >
+                    <div
+                      className="flex gap-1 shrink-0"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => moveTopCategory(top.id, 'up')}
+                        disabled={topIdx === 0 || isSubmitting}
+                        className="disabled:opacity-30 text-gray-400 hover:text-gray-700 text-xs"
+                      >
+                        ▲
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveTopCategory(top.id, 'down')}
+                        disabled={topIdx === topCategories.length - 1 || isSubmitting}
+                        className="disabled:opacity-30 text-gray-400 hover:text-gray-700 text-xs"
+                      >
+                        ▼
+                      </button>
+                    </div>
+
+                    {editingTop?.id === top.id ? (
+                      <div
+                        className="flex flex-1 items-center gap-2"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <input
+                          type="text"
+                          value={editingTop.name}
+                          onChange={(e) =>
+                            setEditingTop({ ...editingTop, name: e.target.value })
+                          }
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleSaveTop(top.id);
+                          }}
+                          autoFocus
+                          className="flex-1 px-2 py-1 text-sm border border-brand-200 rounded focus:outline-none focus:ring-2 focus:ring-brand-300"
+                        />
+                        <Button
+                          size="xs"
+                          disabled={isSubmitting}
+                          onClick={() => handleSaveTop(top.id)}
+                        >
+                          저장
+                        </Button>
+                        <Button
+                          size="xs"
+                          variant="gray"
+                          onClick={() => setEditingTop(null)}
+                        >
+                          취소
+                        </Button>
+                      </div>
+                    ) : (
+                      <>
+                        <span className="flex-1 flex items-center gap-1.5 text-sm font-medium text-gray-800">
+                          {top.name}
+                          {subs.length > 0 && (
+                            <span className="text-gray-400 font-normal">
+                              ({subs.length})
+                            </span>
+                          )}
+                          <span className="text-gray-400 text-base leading-none flex items-center">
+                            {isExpanded ? '▾' : '▸'}
+                          </span>
+                        </span>
+                        <div
+                          className="flex gap-1 shrink-0"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Button
+                            size="xs"
+                            variant="gray"
+                            onClick={() =>
+                              setEditingTop({ id: top.id, name: top.name })
+                            }
+                          >
+                            수정
+                          </Button>
+                          <Button
+                            size="xs"
+                            variant="danger"
+                            disabled={isSubmitting}
+                            onClick={() => handleDeleteTop(top.id)}
+                          >
+                            삭제
+                          </Button>
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  {/* 하위 타입 목록 */}
+                  {isExpanded && (
+                    <div className="pl-8 pr-3 py-2 flex flex-col gap-1 bg-white border-t border-gray-100">
+                      {subs.length === 0 ? (
+                        <p className="text-xs text-gray-400 py-1">
+                          등록된 하위 카테고리가 없습니다.
+                        </p>
+                      ) : (
+                        subs.map((sub, subIdx) => (
+                          <div
+                            key={sub.id}
+                            className="flex items-center gap-2 px-2 py-1.5 rounded bg-gray-50/70"
+                          >
+                            <div className="flex gap-1 shrink-0">
+                              <button
+                                type="button"
+                                onClick={() => moveSubCategory(top.id, sub.id, 'up')}
+                                disabled={subIdx === 0 || isSubmitting}
+                                className="disabled:opacity-30 text-gray-400 hover:text-gray-700 text-xs"
+                              >
+                                ▲
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => moveSubCategory(top.id, sub.id, 'down')}
+                                disabled={subIdx === subs.length - 1 || isSubmitting}
+                                className="disabled:opacity-30 text-gray-400 hover:text-gray-700 text-xs"
+                              >
+                                ▼
+                              </button>
+                            </div>
+
+                            {editingSub?.id === sub.id ? (
+                              <>
+                                <input
+                                  type="text"
+                                  value={editingSub.name}
+                                  onChange={(e) =>
+                                    setEditingSub({
+                                      ...editingSub,
+                                      name: e.target.value,
+                                    })
+                                  }
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter') handleSaveSub(sub.id);
+                                  }}
+                                  autoFocus
+                                  className="flex-1 px-2 py-1 text-sm border border-brand-200 rounded focus:outline-none focus:ring-2 focus:ring-brand-300"
+                                />
+                                <Button
+                                  size="xs"
+                                  disabled={isSubmitting}
+                                  onClick={() => handleSaveSub(sub.id)}
+                                >
+                                  저장
+                                </Button>
+                                <Button
+                                  size="xs"
+                                  variant="gray"
+                                  onClick={() => setEditingSub(null)}
+                                >
+                                  취소
+                                </Button>
+                              </>
+                            ) : (
+                              <>
+                                <span className="flex-1 text-sm text-gray-700">
+                                  {sub.name}
+                                </span>
+                                <Button
+                                  size="xs"
+                                  variant="gray"
+                                  onClick={() =>
+                                    setEditingSub({ id: sub.id, name: sub.name })
+                                  }
+                                >
+                                  수정
+                                </Button>
+                                <Button
+                                  size="xs"
+                                  variant="danger"
+                                  disabled={isSubmitting}
+                                  onClick={() => handleDeleteSub(sub.id)}
+                                >
+                                  삭제
+                                </Button>
+                              </>
+                            )}
+                          </div>
+                        ))
+                      )}
+
+                      <div className="flex gap-2 pt-1">
+                        <input
+                          type="text"
+                          value={newSubName}
+                          onChange={(e) => setNewSubName(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleAddSub(top.id);
+                          }}
+                          placeholder="새 하위 카테고리 이름"
+                          className="flex-1 px-3 py-1.5 text-sm border border-brand-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-300"
+                        />
+                        <Button
+                          size="xs"
+                          disabled={isSubmitting || !newSubName.trim()}
+                          onClick={() => handleAddSub(top.id)}
+                        >
+                          추가
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* 새 상위 카테고리 추가 */}
+      <div className="flex gap-2 pt-3 mt-3 border-t border-gray-100 shrink-0">
+        <input
+          type="text"
+          value={newTopName}
+          onChange={(e) => setNewTopName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleAddTop();
+          }}
+          placeholder="새 상위 카테고리 이름"
+          className="flex-1 px-3 py-1.5 text-sm border border-brand-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-300"
+        />
+        <Button
+          size="sm"
+          onClick={handleAddTop}
+          disabled={isSubmitting || !newTopName.trim()}
+        >
+          추가
+        </Button>
+      </div>
+
+      <div className="flex justify-end pt-3 shrink-0">
+        <Button size="sm" variant="gray" onClick={onClose}>
+          닫기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ManualCategoryManageModal;

--- a/src/app/(auth)/manuals/_components/ManualCreateModal/index.tsx
+++ b/src/app/(auth)/manuals/_components/ManualCreateModal/index.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import toast from 'react-hot-toast';
+import Button from '@/app/_components/Button';
+import { Dropdown, DropdownOption } from '@/app/_components/Dropdown';
+import TagHelpTooltip from '@/app/_components/TagHelpTooltip';
+import TaggedContent from '@/app/_components/TaggedContent';
+import {
+  ManualTopCategoryType,
+  ManualSubCategoryType,
+  ManualType,
+} from '@/app/_domains/_manual/_types/manual.types';
+
+const schema = z.object({
+  topCategoryId: z
+    .string()
+    .trim()
+    .min(1, { message: '상위 카테고리를 선택하세요.' }),
+  subCategoryId: z
+    .string()
+    .trim()
+    .min(1, { message: '하위 카테고리를 선택하세요.' }),
+  title: z
+    .string()
+    .trim()
+    .min(1, { message: '제목을 입력하세요.' })
+    .max(200),
+  content: z
+    .string()
+    .trim()
+    .min(1, { message: '내용을 입력하세요.' })
+    .max(5000),
+});
+
+export type ManualFormValues = z.infer<typeof schema>;
+
+interface ManualCreateModalProps {
+  topCategories: ManualTopCategoryType[];
+  subCategoriesByTop: Record<string, ManualSubCategoryType[]>;
+  onSubmit: (values: ManualFormValues) => Promise<void>;
+  onCancel: () => void;
+  editManual?: ManualType;
+}
+
+const ManualCreateModal = ({
+  topCategories,
+  subCategoriesByTop,
+  onSubmit,
+  onCancel,
+  editManual,
+}: ManualCreateModalProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isEdit = !!editManual;
+
+  const defaultTopCategoryId =
+    editManual?.manual_sub_categories?.top_category_id ?? '';
+  const defaultSubCategoryId = editManual?.sub_category_id ?? '';
+
+  const {
+    handleSubmit,
+    control,
+    watch,
+    setValue,
+    register,
+    formState: { errors },
+  } = useForm<ManualFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      topCategoryId: defaultTopCategoryId,
+      subCategoryId: defaultSubCategoryId,
+      title: editManual?.title ?? '',
+      content: editManual?.content ?? '',
+    },
+  });
+
+  const topCategoryId = watch('topCategoryId');
+  const content = watch('content');
+
+  const topCategoryOptions = topCategories.map((c) => ({
+    label: c.name,
+    value: c.id,
+  }));
+  const subCategoryOptions = (subCategoriesByTop[topCategoryId] ?? []).map(
+    (c) => ({ label: c.name, value: c.id }),
+  );
+
+  return (
+    <form
+      onSubmit={handleSubmit(async (values) => {
+        try {
+          setIsSubmitting(true);
+          await onSubmit(values);
+        } catch (err) {
+          toast.error(
+            err instanceof Error ? err.message : '저장에 실패했습니다.',
+          );
+        } finally {
+          setIsSubmitting(false);
+        }
+      })}
+      className="flex flex-col gap-4"
+    >
+      <h2 className="text-base font-semibold text-gray-900">
+        {isEdit ? '매뉴얼 수정' : '매뉴얼 추가'}
+      </h2>
+
+      <div className="flex flex-col gap-3 overflow-y-auto max-h-[65vh] pr-1">
+        {/* 상위 카테고리 */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-gray-700">
+            상위 카테고리 <span className="text-rose-500">*</span>
+          </label>
+          <Controller
+            name="topCategoryId"
+            control={control}
+            render={({ field }) => (
+              <Dropdown controlledValue={field.value}>
+                <Dropdown.Trigger>
+                  {topCategoryOptions.find((o) => o.value === field.value)
+                    ?.label ?? '선택하세요'}
+                </Dropdown.Trigger>
+                <Dropdown.Content>
+                  {topCategoryOptions.length === 0 ? (
+                    <div className="px-4 py-2 text-sm text-gray-400">
+                      등록된 카테고리가 없습니다.
+                    </div>
+                  ) : (
+                    topCategoryOptions.map((option) => (
+                      <Dropdown.Item
+                        key={option.value}
+                        option={option}
+                        onSelect={(o: DropdownOption) => {
+                          field.onChange(String(o.value));
+                          setValue('subCategoryId', '');
+                        }}
+                      />
+                    ))
+                  )}
+                </Dropdown.Content>
+              </Dropdown>
+            )}
+          />
+          {errors.topCategoryId && (
+            <p className="text-xs text-rose-500">
+              {errors.topCategoryId.message}
+            </p>
+          )}
+        </div>
+
+        {/* 하위 카테고리 */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-gray-700">
+            하위 카테고리 <span className="text-rose-500">*</span>
+          </label>
+          <Controller
+            name="subCategoryId"
+            control={control}
+            render={({ field }) => (
+              <Dropdown controlledValue={field.value} disabled={!topCategoryId}>
+                <Dropdown.Trigger>
+                  {subCategoryOptions.find((o) => o.value === field.value)
+                    ?.label ??
+                    (topCategoryId
+                      ? '선택하세요'
+                      : '상위 카테고리를 먼저 선택하세요')}
+                </Dropdown.Trigger>
+                <Dropdown.Content>
+                  {subCategoryOptions.length === 0 ? (
+                    <div className="px-4 py-2 text-sm text-gray-400">
+                      등록된 하위 카테고리가 없습니다.
+                    </div>
+                  ) : (
+                    subCategoryOptions.map((option) => (
+                      <Dropdown.Item
+                        key={option.value}
+                        option={option}
+                        onSelect={(o: DropdownOption) =>
+                          field.onChange(String(o.value))
+                        }
+                      />
+                    ))
+                  )}
+                </Dropdown.Content>
+              </Dropdown>
+            )}
+          />
+          {errors.subCategoryId && (
+            <p className="text-xs text-rose-500">
+              {errors.subCategoryId.message}
+            </p>
+          )}
+        </div>
+
+        {/* 제목 */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-gray-700">
+            제목 <span className="text-rose-500">*</span>
+          </label>
+          <input
+            {...register('title')}
+            type="text"
+            placeholder="제목을 입력하세요"
+            className="px-3 py-2 text-sm border border-brand-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-300"
+          />
+          {errors.title && (
+            <p className="text-xs text-rose-500">{errors.title.message}</p>
+          )}
+        </div>
+
+        {/* 내용 */}
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-gray-700">
+              내용 <span className="text-rose-500">*</span>
+            </label>
+            <TagHelpTooltip />
+          </div>
+          <textarea
+            {...register('content')}
+            rows={6}
+            placeholder="매뉴얼 내용을 입력하세요"
+            className="px-3 py-2 text-sm border border-brand-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-300 resize-none font-mono"
+          />
+          {errors.content && (
+            <p className="text-xs text-rose-500">{errors.content.message}</p>
+          )}
+
+          {content?.trim() && (
+            <div className="mt-1">
+              <p className="text-xs font-medium text-gray-500 mb-1">
+                미리보기
+              </p>
+              <div className="px-3 py-2 border border-gray-100 rounded-lg bg-gray-50">
+                <TaggedContent
+                  content={content}
+                  className="text-sm text-gray-800"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2 border-t border-gray-100">
+        <Button type="button" variant="gray" size="sm" onClick={onCancel}>
+          취소
+        </Button>
+        <Button type="submit" size="sm" disabled={isSubmitting}>
+          {isSubmitting ? '저장 중...' : isEdit ? '수정' : '추가'}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default ManualCreateModal;

--- a/src/app/(auth)/manuals/_components/ManualDetailModal/index.tsx
+++ b/src/app/(auth)/manuals/_components/ManualDetailModal/index.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Button from '@/app/_components/Button';
+import TaggedContent from '@/app/_components/TaggedContent';
+import { ManualType } from '@/app/_domains/_manual/_types/manual.types';
+
+interface ManualDetailModalProps {
+  manual: ManualType;
+  onClose: () => void;
+}
+
+const ManualDetailModal = ({ manual, onClose }: ManualDetailModalProps) => {
+  const topName = manual.manual_sub_categories?.manual_top_categories?.name;
+  const subName = manual.manual_sub_categories?.name;
+
+  return (
+    <div className="w-full flex flex-col min-h-0">
+      {(topName || subName) && (
+        <div className="mb-2 shrink-0">
+          <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md bg-brand-50 text-brand-700 text-xs font-medium">
+            {topName}
+            {topName && subName && (
+              <span className="text-brand-300 font-normal">›</span>
+            )}
+            {subName && <span className="font-normal">{subName}</span>}
+          </span>
+        </div>
+      )}
+      <h2 className="flex items-baseline gap-1.5 mb-4 shrink-0">
+        <span className="text-xs font-normal text-gray-400">제목:</span>
+        <span className="text-lg font-semibold text-gray-900">
+          {manual.title}
+        </span>
+      </h2>
+
+      <div className="overflow-y-auto min-h-0 flex-1 px-3 py-2.5 border border-gray-100 rounded-lg bg-gray-50">
+        <TaggedContent
+          content={manual.content}
+          className="text-sm text-gray-800 leading-relaxed"
+        />
+      </div>
+
+      <div className="flex justify-end pt-4 border-t border-gray-200 mt-6 shrink-0">
+        <Button size="sm" variant="gray" onClick={onClose}>
+          닫기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ManualDetailModal;

--- a/src/app/(auth)/manuals/_components/ManualList/index.tsx
+++ b/src/app/(auth)/manuals/_components/ManualList/index.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import Button from '@/app/_components/Button';
+import Loading from '@/app/_components/Loading';
+import {
+  useManuals,
+  ManualFilters,
+} from '@/app/_domains/_manual/_hooks/useManuals';
+import { ManualType } from '@/app/_domains/_manual/_types/manual.types';
+
+interface ManualListProps {
+  filters?: ManualFilters;
+  isAdmin?: boolean;
+  onView?: (manual: ManualType) => void;
+  onEdit?: (manual: ManualType) => void;
+  onDelete?: (manual: ManualType) => void;
+}
+
+const ManualList = ({
+  filters,
+  isAdmin = false,
+  onView,
+  onEdit,
+  onDelete,
+}: ManualListProps) => {
+  const {
+    manuals,
+    isLoading,
+    isLoadingMore,
+    error,
+    loadMore,
+    hasMore,
+    totalCount,
+  } = useManuals(filters);
+
+  if (isLoading) {
+    return <Loading size="lg" text="매뉴얼 목록 불러오는 중..." />;
+  }
+
+  if (error) {
+    return (
+      <div className="flex justify-center items-center py-20">
+        <p className="text-red-500">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-10">
+      <div className="flex justify-start items-center mb-3">
+        <div className="text-xs sm:text-sm text-gray-600">
+          <span className="font-semibold text-brand-600">{manuals.length}</span>
+          {totalCount !== undefined && totalCount > 0 && (
+            <>
+              {' / '}
+              <span className="font-semibold text-gray-600">{totalCount}</span>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="bg-white rounded-lg shadow-sm border border-brand-100 overflow-hidden overflow-x-auto">
+        <table className="w-full min-w-[900px] divide-y divide-brand-100 table-auto">
+          <thead className="bg-gradient-to-r from-brand-50 to-brand-100">
+            <tr>
+              <th className="px-3 sm:px-6 py-2 sm:py-3 text-left text-xs sm:text-sm font-semibold text-brand-700 whitespace-nowrap">
+                No
+              </th>
+              {isAdmin && (
+                <th className="px-3 sm:px-6 py-2 sm:py-3 text-left text-xs sm:text-sm font-semibold text-brand-700 whitespace-nowrap">
+                  작업
+                </th>
+              )}
+              <th className="px-3 sm:px-6 py-2 sm:py-3 text-left text-xs sm:text-sm font-semibold text-brand-700 whitespace-nowrap">
+                상위 카테고리
+              </th>
+              <th className="px-3 sm:px-6 py-2 sm:py-3 text-left text-xs sm:text-sm font-semibold text-brand-700 whitespace-nowrap">
+                하위 카테고리
+              </th>
+              <th className="px-3 sm:px-6 py-2 sm:py-3 text-left text-xs sm:text-sm font-semibold text-brand-700 whitespace-nowrap">
+                제목
+              </th>
+              <th className="px-3 sm:px-6 py-2 sm:py-3 text-left text-xs sm:text-sm font-semibold text-brand-700 whitespace-nowrap max-w-xs">
+                내용
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-brand-50">
+            {manuals.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={isAdmin ? 6 : 5}
+                  className="px-3 sm:px-6 py-10 text-center text-gray-500 text-xs sm:text-sm"
+                >
+                  매뉴얼 데이터가 없습니다.
+                </td>
+              </tr>
+            ) : (
+              manuals.map((manual, index) => (
+                <tr
+                  key={manual.id}
+                  className="hover:bg-brand-50/50 transition-colors cursor-pointer"
+                  onClick={() => onView?.(manual)}
+                >
+                  <td className="px-3 sm:px-6 py-2 sm:py-3 text-xs sm:text-sm text-gray-700 whitespace-nowrap">
+                    {index + 1}
+                  </td>
+                  {isAdmin && (
+                    <td
+                      className="px-3 sm:px-6 py-2 sm:py-3 whitespace-nowrap space-x-1"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Button size="xs" variant="gray" onClick={() => onEdit?.(manual)}>
+                        수정
+                      </Button>
+                      <Button size="xs" variant="danger" onClick={() => onDelete?.(manual)}>
+                        삭제
+                      </Button>
+                    </td>
+                  )}
+                  <td className="px-3 sm:px-6 py-2 sm:py-3 text-xs sm:text-sm whitespace-nowrap">
+                    {manual.manual_sub_categories?.manual_top_categories ? (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-md bg-brand-50 text-brand-700 text-[11px] sm:text-xs font-medium">
+                        {manual.manual_sub_categories.manual_top_categories.name}
+                      </span>
+                    ) : (
+                      <span className="text-gray-400">-</span>
+                    )}
+                  </td>
+                  <td className="px-3 sm:px-6 py-2 sm:py-3 text-xs sm:text-sm whitespace-nowrap">
+                    {manual.manual_sub_categories ? (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-md bg-gray-100 text-gray-600 text-[11px] sm:text-xs font-medium">
+                        {manual.manual_sub_categories.name}
+                      </span>
+                    ) : (
+                      <span className="text-gray-400">-</span>
+                    )}
+                  </td>
+                  <td className="px-3 sm:px-6 py-2 sm:py-3 text-xs sm:text-sm text-gray-900 whitespace-nowrap font-medium">
+                    {manual.title}
+                  </td>
+                  <td className="px-3 sm:px-6 py-2 sm:py-3 text-xs sm:text-sm text-gray-700 max-w-xs">
+                    <p className="truncate">{manual.content}</p>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {hasMore && (
+        <div className="flex justify-center mt-6">
+          <Button
+            size="sm"
+            onClick={loadMore}
+            disabled={isLoadingMore}
+            variant="secondary"
+          >
+            {isLoadingMore ? '불러오는 중...' : '더 불러오기'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ManualList;

--- a/src/app/(auth)/manuals/_components/ManualSearchBox/index.tsx
+++ b/src/app/(auth)/manuals/_components/ManualSearchBox/index.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import Button from '@/app/_components/Button';
+import { Dropdown, DropdownOption } from '@/app/_components/Dropdown';
+import {
+  ManualTopCategoryType,
+  ManualSubCategoryType,
+} from '@/app/_domains/_manual/_types/manual.types';
+import { ManualSearchCondition } from '@/app/_domains/_manual/_queryKeys/manualKeys';
+
+interface ManualSearchBoxProps {
+  topCategories: ManualTopCategoryType[];
+  subCategoriesByTop: Record<string, ManualSubCategoryType[]>;
+  onSearch?: (filters: {
+    subCategoryId?: string;
+    subCategoryIds?: string[];
+    searchConditions?: ManualSearchCondition[];
+  }) => void;
+}
+
+const searchTargetOptions = [
+  { label: '제목', value: 'title' },
+  { label: '내용', value: 'content' },
+];
+
+const getTargetLabel = (value: string) =>
+  searchTargetOptions.find((o) => o.value === value)?.label ?? value;
+
+const ManualSearchBox = ({
+  topCategories,
+  subCategoriesByTop,
+  onSearch,
+}: ManualSearchBoxProps) => {
+  const [topCategoryId, setTopCategoryId] = useState('');
+  const [subCategoryId, setSubCategoryId] = useState('');
+  const [searchTarget, setSearchTarget] = useState('title');
+  const [keyword, setKeyword] = useState('');
+  const [conditions, setConditions] = useState<ManualSearchCondition[]>([]);
+
+  // 상위 타입이 바뀌면(더 이상 유효하지 않으면) 하위 타입 선택 초기화
+  useEffect(() => {
+    if (!topCategoryId) {
+      setSubCategoryId('');
+      return;
+    }
+    const siblings = subCategoriesByTop[topCategoryId] ?? [];
+    if (!siblings.some((s) => s.id === subCategoryId)) {
+      setSubCategoryId('');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topCategoryId]);
+
+  const topCategoryOptions = [
+    { label: '전체', value: '' },
+    ...topCategories.map((c) => ({ label: c.name, value: c.id })),
+  ];
+
+  const subCategoryOptions = [
+    { label: '전체', value: '' },
+    ...(subCategoriesByTop[topCategoryId] ?? []).map((c) => ({
+      label: c.name,
+      value: c.id,
+    })),
+  ];
+
+  const resolveCategoryFilter = (nextTopId: string, nextSubId: string) => {
+    if (nextSubId) {
+      return { subCategoryId: nextSubId, subCategoryIds: undefined };
+    }
+    if (nextTopId) {
+      return {
+        subCategoryId: undefined,
+        subCategoryIds: (subCategoriesByTop[nextTopId] ?? []).map((s) => s.id),
+      };
+    }
+    return { subCategoryId: undefined, subCategoryIds: undefined };
+  };
+
+  const fireSearch = (
+    nextTopId: string,
+    nextSubId: string,
+    nextConditions: ManualSearchCondition[],
+  ) => {
+    onSearch?.({
+      ...resolveCategoryFilter(nextTopId, nextSubId),
+      searchConditions: nextConditions.length ? nextConditions : undefined,
+    });
+  };
+
+  const handleAddCondition = () => {
+    if (!keyword.trim()) return;
+    if (conditions.some((c) => c.searchTarget === searchTarget)) {
+      toast.error(`"${getTargetLabel(searchTarget)}" 필터를 제거 후 다시 검색해주세요.`);
+      return;
+    }
+    const next = [
+      ...conditions,
+      { searchTarget, searchKeyword: keyword.trim() },
+    ];
+    setConditions(next);
+    setKeyword('');
+    fireSearch(topCategoryId, subCategoryId, next);
+  };
+
+  const handleRemoveCondition = (index: number) => {
+    const next = conditions.filter((_, i) => i !== index);
+    setConditions(next);
+    fireSearch(topCategoryId, subCategoryId, next);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === 'Enter') handleAddCondition();
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-brand-100 p-4 sm:p-6">
+      <div className="flex flex-col gap-4 text-xs sm:text-sm">
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-end gap-3 sm:gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label className="font-medium text-gray-600">카테고리</label>
+            <div className="w-full sm:w-[180px]">
+              <Dropdown controlledValue={topCategoryId}>
+                <Dropdown.Trigger>
+                  {topCategoryOptions.find((o) => o.value === topCategoryId)?.label ?? '전체'}
+                </Dropdown.Trigger>
+                <Dropdown.Content>
+                  {topCategoryOptions.map((option, i) => (
+                    <Dropdown.Item
+                      key={`top-${i}-${option.value}`}
+                      option={option}
+                      onSelect={(o: DropdownOption) => {
+                        const newTopId = String(o.value);
+                        setTopCategoryId(newTopId);
+                        setSubCategoryId('');
+                        fireSearch(newTopId, '', conditions);
+                      }}
+                    />
+                  ))}
+                </Dropdown.Content>
+              </Dropdown>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="font-medium text-gray-600">하위 카테고리</label>
+            <div className="w-full sm:w-[180px]">
+              <Dropdown controlledValue={subCategoryId}>
+                <Dropdown.Trigger>
+                  {subCategoryOptions.find((o) => o.value === subCategoryId)?.label ?? '전체'}
+                </Dropdown.Trigger>
+                <Dropdown.Content>
+                  {subCategoryOptions.map((option, i) => (
+                    <Dropdown.Item
+                      key={`sub-${i}-${option.value}`}
+                      option={option}
+                      onSelect={(o: DropdownOption) => {
+                        const newSubId = String(o.value);
+                        setSubCategoryId(newSubId);
+                        fireSearch(topCategoryId, newSubId, conditions);
+                      }}
+                    />
+                  ))}
+                </Dropdown.Content>
+              </Dropdown>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="font-medium text-gray-600">검색 조건</label>
+            <div className="w-full sm:w-[160px]">
+              <Dropdown>
+                <Dropdown.Trigger>
+                  {searchTargetOptions.find((o) => o.value === searchTarget)?.label}
+                </Dropdown.Trigger>
+                <Dropdown.Content>
+                  {searchTargetOptions.map((option) => (
+                    <Dropdown.Item
+                      key={option.value}
+                      option={option}
+                      onSelect={(o: DropdownOption) =>
+                        setSearchTarget(o.value as string)
+                      }
+                    />
+                  ))}
+                </Dropdown.Content>
+              </Dropdown>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 sm:gap-3 pt-2 border-t border-gray-100">
+          <div className="flex-1">
+            <input
+              type="text"
+              placeholder="검색어를 입력하세요"
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="w-full px-3 py-1.5 sm:px-4 sm:py-2 border border-brand-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-300 focus:border-transparent text-xs sm:text-sm"
+            />
+          </div>
+          <Button onClick={handleAddCondition} size="sm">
+            검색
+          </Button>
+        </div>
+
+        {conditions.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {conditions.map((cond, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-1.5 px-3 py-1 bg-brand-50 text-brand-700 border border-brand-200 rounded-full text-xs"
+              >
+                {getTargetLabel(cond.searchTarget)} = &quot;{cond.searchKeyword}&quot;
+                <button
+                  type="button"
+                  onClick={() => handleRemoveCondition(i)}
+                  className="text-brand-400 hover:text-brand-600 font-bold leading-none cursor-pointer"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ManualSearchBox;

--- a/src/app/(auth)/manuals/page.tsx
+++ b/src/app/(auth)/manuals/page.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import Button from '@/app/_components/Button';
+import { useModal } from '@/app/_contexts/ModalContext';
+import { useUser } from '@/app/_contexts/UserContext';
+import { ManualTabEnum, ManualTabEnumType } from '@/app/_enums/enums';
+import { useManualCategories } from '@/app/_domains/_manual/_hooks/useManualCategories';
+import {
+  createManual,
+  updateManual,
+  deleteManual,
+} from '@/app/_domains/_manual/_services/manualService';
+import { manualKeys, ManualFilters } from '@/app/_domains/_manual/_queryKeys/manualKeys';
+import { ManualType } from '@/app/_domains/_manual/_types/manual.types';
+import DeleteConfirmModal from '@/app/(auth)/_components/DeleteConfirmModal';
+import ManualSearchBox from './_components/ManualSearchBox';
+import ManualList from './_components/ManualList';
+import ManualCreateModal, {
+  ManualFormValues,
+} from './_components/ManualCreateModal';
+import ManualDetailModal from './_components/ManualDetailModal';
+import ManualCategoryManageModal from './_components/ManualCategoryManageModal';
+
+const ManualsPage = () => {
+  const queryClient = useQueryClient();
+  const { open, close } = useModal();
+  const { isAdmin } = useUser();
+
+  const [tab, setTab] = useState<ManualTabEnumType['value']>(
+    ManualTabEnum.CUSTOMER.value,
+  );
+  const [filters, setFilters] = useState<ManualFilters>({});
+
+  const { topCategories, subCategoriesByTop } = useManualCategories(tab);
+
+  const tabLabel =
+    Object.values(ManualTabEnum).find((t) => t.value === tab)?.name ?? '';
+
+  const handleChangeTab = (nextTab: ManualTabEnumType['value']) => {
+    setTab(nextTab);
+    setFilters({});
+  };
+
+  const handleSearch = (newFilters: ManualFilters) => {
+    setFilters(newFilters);
+  };
+
+  // 카테고리 필터를 선택하지 않았을 때는 현재 탭(고객/매장)에 속한
+  // 하위 카테고리로만 범위를 한정해, 다른 탭의 매뉴얼이 섞여 보이지 않도록 한다.
+  const effectiveFilters = useMemo<ManualFilters>(() => {
+    if (filters.subCategoryId || filters.subCategoryIds !== undefined) {
+      return filters;
+    }
+    const tabSubCategoryIds = Object.values(subCategoriesByTop).flatMap(
+      (subs) => subs.map((s) => s.id),
+    );
+    return { ...filters, subCategoryIds: tabSubCategoryIds };
+  }, [filters, subCategoriesByTop]);
+
+  const invalidateManuals = () =>
+    queryClient.invalidateQueries({ queryKey: manualKeys.lists() });
+
+  const handleManualSubmit = async (values: ManualFormValues) => {
+    await createManual({
+      subCategoryId: values.subCategoryId,
+      title: values.title,
+      content: values.content,
+    });
+    toast.success('매뉴얼이 추가되었습니다.');
+    close();
+    invalidateManuals();
+  };
+
+  const handleManualEdit = (manual: ManualType) => {
+    open({
+      content: (
+        <ManualCreateModal
+          topCategories={topCategories}
+          subCategoriesByTop={subCategoriesByTop}
+          editManual={manual}
+          onSubmit={async (values) => {
+            await updateManual(manual.id, {
+              subCategoryId: values.subCategoryId,
+              title: values.title,
+              content: values.content,
+            });
+            toast.success('매뉴얼이 수정되었습니다.');
+            close();
+            invalidateManuals();
+          }}
+          onCancel={close}
+        />
+      ),
+      options: { dismissOnBackdrop: false, dismissOnEsc: true },
+    });
+  };
+
+  const handleManualDelete = (manual: ManualType) => {
+    open({
+      content: (
+        <DeleteConfirmModal
+          title="매뉴얼 삭제"
+          description={`"${manual.title}" 매뉴얼을 삭제하시겠습니까?`}
+          onConfirm={async () => {
+            await deleteManual(manual.id);
+            toast.success('매뉴얼이 삭제되었습니다.');
+            close();
+            invalidateManuals();
+          }}
+          onCancel={close}
+        />
+      ),
+      options: { dismissOnBackdrop: false },
+    });
+  };
+
+  const handleManualView = (manual: ManualType) => {
+    open({
+      content: <ManualDetailModal manual={manual} onClose={close} />,
+      options: { dismissOnBackdrop: true, dismissOnEsc: true },
+    });
+  };
+
+  const handleOpenCategoryManage = () => {
+    open({
+      content: (
+        <ManualCategoryManageModal tab={tab} tabLabel={tabLabel} onClose={close} />
+      ),
+      options: { dismissOnBackdrop: false, dismissOnEsc: true },
+    });
+  };
+
+  const handleOpenManualCreate = () => {
+    open({
+      content: (
+        <ManualCreateModal
+          topCategories={topCategories}
+          subCategoriesByTop={subCategoriesByTop}
+          onSubmit={handleManualSubmit}
+          onCancel={close}
+        />
+      ),
+      options: { dismissOnBackdrop: false, dismissOnEsc: true },
+    });
+  };
+
+  return (
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-10 mb-10">
+      <div className="bg-white rounded-lg shadow-sm border border-brand-100 p-6">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between mb-4 pb-3 border-b border-brand-100">
+          <div className="flex gap-1 sm:gap-3">
+            {Object.values(ManualTabEnum).map((t) => (
+              <Button
+                key={t.value}
+                onClick={() => handleChangeTab(t.value)}
+                variant={tab === t.value ? 'primary' : 'secondary'}
+              >
+                {t.name}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <ManualSearchBox
+            key={tab}
+            topCategories={topCategories}
+            subCategoriesByTop={subCategoriesByTop}
+            onSearch={handleSearch}
+          />
+
+          {isAdmin && (
+            <div className="flex justify-end gap-2">
+              <Button size="sm" variant="gray" onClick={handleOpenCategoryManage}>
+                카테고리 관리
+              </Button>
+              <Button size="sm" onClick={handleOpenManualCreate}>
+                매뉴얼 추가
+              </Button>
+            </div>
+          )}
+
+          <ManualList
+            filters={effectiveFilters}
+            isAdmin={isAdmin}
+            onView={handleManualView}
+            onEdit={isAdmin ? handleManualEdit : undefined}
+            onDelete={isAdmin ? handleManualDelete : undefined}
+          />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ManualsPage;

--- a/src/app/_components/TagHelpTooltip/index.tsx
+++ b/src/app/_components/TagHelpTooltip/index.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+const TagHelpTooltip = () => {
+  return (
+    <div className="relative group">
+      <span className="w-5 h-5 rounded-full bg-gray-200 text-gray-500 text-xs font-bold flex items-center justify-center cursor-default select-none">
+        ?
+      </span>
+      <div className="absolute left-0 top-6 z-50 hidden group-hover:block w-60 bg-gray-800 text-white text-xs rounded-lg p-3 shadow-lg leading-relaxed">
+        <p className="font-semibold mb-1.5">서식 태그 사용법</p>
+        <p>
+          <span className="text-red-400">&lt;red&gt;</span>텍스트
+          <span className="text-red-400">&lt;/red&gt;</span> →{' '}
+          <span className="text-red-400">빨간색</span>
+        </p>
+        <p>
+          <span className="text-gray-300">&lt;bold&gt;</span>텍스트
+          <span className="text-gray-300">&lt;/bold&gt;</span> →{' '}
+          <span className="font-extrabold">굵게</span>
+        </p>
+        <p>
+          <span className="text-gray-300">&lt;line&gt;</span>텍스트
+          <span className="text-gray-300">&lt;/line&gt;</span> →{' '}
+          <span className="line-through">취소선</span>
+        </p>
+        <p>
+          <span className="text-blue-400">&lt;link url=&quot;URL&quot;&gt;</span>
+          텍스트<span className="text-blue-400">&lt;/link&gt;</span> →{' '}
+          <span className="text-blue-400 underline">링크</span>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default TagHelpTooltip;

--- a/src/app/_components/TaggedContent/index.tsx
+++ b/src/app/_components/TaggedContent/index.tsx
@@ -1,0 +1,76 @@
+import { Fragment } from 'react';
+
+const TAG_SPLIT_REGEX =
+  /(<red>.*?<\/red>|<bold>.*?<\/bold>|<line>.*?<\/line>|<link url="[^"]*">.*?<\/link>)/g;
+
+const renderLine = (line: string, lineKey: string) => {
+  const parts = line.split(TAG_SPLIT_REGEX);
+  if (parts.length === 1) return line;
+
+  return parts.map((part, i) => {
+    const key = `${lineKey}-${i}`;
+
+    const redMatch = part.match(/^<red>(.*)<\/red>$/);
+    if (redMatch) {
+      return (
+        <span key={key} className="text-red-500">
+          {redMatch[1]}
+        </span>
+      );
+    }
+
+    const boldMatch = part.match(/^<bold>(.*)<\/bold>$/);
+    if (boldMatch) {
+      return (
+        <span key={key} className="font-extrabold">
+          {boldMatch[1]}
+        </span>
+      );
+    }
+
+    const lineMatch = part.match(/^<line>(.*)<\/line>$/);
+    if (lineMatch) {
+      return (
+        <span key={key} className="line-through">
+          {lineMatch[1]}
+        </span>
+      );
+    }
+
+    const linkMatch = part.match(/^<link url="([^"]*)">(.*)<\/link>$/);
+    if (linkMatch) {
+      return (
+        <a
+          key={key}
+          href={linkMatch[1]}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 underline underline-offset-2 hover:text-blue-700"
+        >
+          {linkMatch[2]}
+        </a>
+      );
+    }
+
+    return <Fragment key={key}>{part || null}</Fragment>;
+  });
+};
+
+interface TaggedContentProps {
+  content: string;
+  className?: string;
+}
+
+const TaggedContent = ({ content, className = '' }: TaggedContentProps) => {
+  const lines = content.split('\n');
+
+  return (
+    <div className={className}>
+      {lines.map((line, i) => (
+        <p key={i}>{line ? renderLine(line, String(i)) : ' '}</p>
+      ))}
+    </div>
+  );
+};
+
+export default TaggedContent;

--- a/src/app/_contexts/ModalContext.tsx
+++ b/src/app/_contexts/ModalContext.tsx
@@ -15,6 +15,8 @@ import { lockScroll, unlockScroll } from '@/app/_utils/scrollLock';
 type ModalOptions = {
   dismissOnBackdrop?: boolean;
   dismissOnEsc?: boolean;
+  /** 모달 너비를 지정하는 Tailwind max-width 클래스 (기본값: 'max-w-md') */
+  size?: string;
 };
 
 type OpenModalArgs = {
@@ -26,13 +28,18 @@ type ModalContextType = {
   open: (args: OpenModalArgs) => void;
   close: () => void;
   isOpen: boolean;
+  /** 열려 있는 모달의 너비를 동적으로 변경 (예: 폼 내용에 따라 넓혀야 할 때) */
+  setSize: (size: string) => void;
 };
+
+const DEFAULT_MODAL_SIZE = 'max-w-md';
 
 const ModalContext = createContext<ModalContextType | undefined>(undefined);
 
 export function ModalProvider({ children }: { children: React.ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
   const [content, setContent] = useState<React.ReactNode>(null);
+  const [size, setSize] = useState<string>(DEFAULT_MODAL_SIZE);
   const [options, setOptions] = useState<ModalOptions>({
     dismissOnBackdrop: true,
     dismissOnEsc: true,
@@ -68,6 +75,7 @@ export function ModalProvider({ children }: { children: React.ReactNode }) {
     ({ content: node, options: opts }: OpenModalArgs) => {
       setContent(node);
       if (opts) setOptions((prev) => ({ ...prev, ...opts }));
+      setSize(opts?.size ?? DEFAULT_MODAL_SIZE);
       setIsOpen(true);
     },
     []
@@ -77,9 +85,13 @@ export function ModalProvider({ children }: { children: React.ReactNode }) {
     setIsOpen(false);
     // Optionally clear content after close animation; instant for simplicity
     setContent(null);
+    setSize(DEFAULT_MODAL_SIZE);
   }, []);
 
-  const value = useMemo(() => ({ open, close, isOpen }), [open, close, isOpen]);
+  const value = useMemo(
+    () => ({ open, close, isOpen, setSize }),
+    [open, close, isOpen, setSize]
+  );
 
   return (
     <ModalContext.Provider value={value}>
@@ -94,7 +106,9 @@ export function ModalProvider({ children }: { children: React.ReactNode }) {
                 if (options.dismissOnBackdrop !== false) close();
               }}
             />
-            <div className="relative z-[2001] max-h-[90vh] w-[90vw] max-w-md flex flex-col rounded-lg bg-white p-4 shadow-xl">
+            <div
+              className={`relative z-[2001] max-h-[90vh] w-[90vw] ${size} flex flex-col rounded-lg bg-white p-4 shadow-xl`}
+            >
               {content}
             </div>
           </div>,

--- a/src/app/_domains/_log/_hooks/useCopy.ts
+++ b/src/app/_domains/_log/_hooks/useCopy.ts
@@ -57,12 +57,16 @@ const buildAmountFormula = (
         : typeof item.unitPrice === 'number'
         ? item.unitPrice
         : 0;
-    if (amount <= 0 || effectiveUnitPrice <= 0) continue;
+    if (amount === 0 || effectiveUnitPrice === 0) continue;
     const quantity =
       typeof item.quantity === 'number' && item.quantity > 0
         ? item.quantity
         : 1;
-    parts.push(`+${effectiveUnitPrice}${quantity > 1 ? `*${quantity}` : ''}`);
+    const sign = effectiveUnitPrice < 0 ? '-' : '+';
+    const absoluteUnitPrice = Math.abs(effectiveUnitPrice);
+    parts.push(
+      `${sign}${absoluteUnitPrice}${quantity > 1 ? `*${quantity}` : ''}`
+    );
   }
 
   if (parts.length === 0) {

--- a/src/app/_domains/_manual/_hooks/useManualCategories.ts
+++ b/src/app/_domains/_manual/_hooks/useManualCategories.ts
@@ -1,0 +1,166 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getManualCategoryTree,
+  createManualTopCategory,
+  updateManualTopCategory,
+  updateManualTopCategoryOrders,
+  deleteManualTopCategory,
+  createManualSubCategory,
+  updateManualSubCategory,
+  updateManualSubCategoryOrders,
+  deleteManualSubCategory,
+} from '../_services/manualCategoryService';
+import { manualKeys } from '../_queryKeys/manualKeys';
+
+export const useManualCategories = (tab: string) => {
+  const queryClient = useQueryClient();
+
+  const { data, isPending: isLoading } = useQuery({
+    queryKey: manualKeys.categoryTree(tab),
+    queryFn: () => getManualCategoryTree(tab),
+  });
+
+  const topCategories = data?.topCategories ?? [];
+  const subCategoriesByTop = data?.subCategoriesByTop ?? {};
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: manualKeys.categoryTree(tab) });
+
+  // ==========================================================================
+  // 상위 타입
+  // ==========================================================================
+
+  const addTopMutation = useMutation({
+    mutationFn: (name: string) =>
+      createManualTopCategory({ tab, name, orderIndex: topCategories.length + 1 }),
+    onSuccess: invalidate,
+  });
+
+  const editTopMutation = useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) =>
+      updateManualTopCategory({ id, name }),
+    onSuccess: invalidate,
+  });
+
+  const removeTopMutation = useMutation({
+    mutationFn: (id: string) => deleteManualTopCategory(id),
+    onSuccess: invalidate,
+  });
+
+  const moveTopMutation = useMutation({
+    mutationFn: async ({
+      id,
+      direction,
+    }: {
+      id: string;
+      direction: 'up' | 'down';
+    }) => {
+      const idx = topCategories.findIndex((c) => c.id === id);
+      if (direction === 'up' && idx <= 0) return;
+      if (direction === 'down' && idx >= topCategories.length - 1) return;
+
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      const a = topCategories[idx];
+      const b = topCategories[swapIdx];
+
+      await updateManualTopCategoryOrders([
+        { id: a.id, order_index: b.order_index },
+        { id: b.id, order_index: a.order_index },
+      ]);
+    },
+    onSuccess: invalidate,
+  });
+
+  // ==========================================================================
+  // 하위 타입
+  // ==========================================================================
+
+  const addSubMutation = useMutation({
+    mutationFn: ({
+      topCategoryId,
+      name,
+    }: {
+      topCategoryId: string;
+      name: string;
+    }) => {
+      const siblings = subCategoriesByTop[topCategoryId] ?? [];
+      return createManualSubCategory({
+        topCategoryId,
+        name,
+        orderIndex: siblings.length + 1,
+      });
+    },
+    onSuccess: invalidate,
+  });
+
+  const editSubMutation = useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) =>
+      updateManualSubCategory({ id, name }),
+    onSuccess: invalidate,
+  });
+
+  const removeSubMutation = useMutation({
+    mutationFn: (id: string) => deleteManualSubCategory(id),
+    onSuccess: invalidate,
+  });
+
+  const moveSubMutation = useMutation({
+    mutationFn: async ({
+      topCategoryId,
+      id,
+      direction,
+    }: {
+      topCategoryId: string;
+      id: string;
+      direction: 'up' | 'down';
+    }) => {
+      const siblings = subCategoriesByTop[topCategoryId] ?? [];
+      const idx = siblings.findIndex((c) => c.id === id);
+      if (direction === 'up' && idx <= 0) return;
+      if (direction === 'down' && idx >= siblings.length - 1) return;
+
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      const a = siblings[idx];
+      const b = siblings[swapIdx];
+
+      await updateManualSubCategoryOrders([
+        { id: a.id, order_index: b.order_index },
+        { id: b.id, order_index: a.order_index },
+      ]);
+    },
+    onSuccess: invalidate,
+  });
+
+  const isSubmitting =
+    addTopMutation.isPending ||
+    editTopMutation.isPending ||
+    removeTopMutation.isPending ||
+    moveTopMutation.isPending ||
+    addSubMutation.isPending ||
+    editSubMutation.isPending ||
+    removeSubMutation.isPending ||
+    moveSubMutation.isPending;
+
+  return {
+    topCategories,
+    subCategoriesByTop,
+    isLoading,
+    isSubmitting,
+    addTopCategory: (name: string) => addTopMutation.mutateAsync(name),
+    editTopCategory: (id: string, name: string) =>
+      editTopMutation.mutateAsync({ id, name }),
+    removeTopCategory: (id: string) => removeTopMutation.mutateAsync(id),
+    moveTopCategory: (id: string, direction: 'up' | 'down') =>
+      moveTopMutation.mutateAsync({ id, direction }),
+    addSubCategory: (topCategoryId: string, name: string) =>
+      addSubMutation.mutateAsync({ topCategoryId, name }),
+    editSubCategory: (id: string, name: string) =>
+      editSubMutation.mutateAsync({ id, name }),
+    removeSubCategory: (id: string) => removeSubMutation.mutateAsync(id),
+    moveSubCategory: (
+      topCategoryId: string,
+      id: string,
+      direction: 'up' | 'down',
+    ) => moveSubMutation.mutateAsync({ topCategoryId, id, direction }),
+  };
+};

--- a/src/app/_domains/_manual/_hooks/useManuals.ts
+++ b/src/app/_domains/_manual/_hooks/useManuals.ts
@@ -1,0 +1,54 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getManuals, getManualsCount } from '../_services/manualService';
+import { manualKeys, ManualFilters } from '../_queryKeys/manualKeys';
+
+export type { ManualFilters };
+
+const PAGE_SIZE = 20;
+
+export const useManuals = (filters?: ManualFilters) => {
+  const {
+    data,
+    isPending,
+    isError,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
+    queryKey: manualKeys.list(filters),
+    queryFn: async ({ pageParam }) => {
+      const f = {
+        subCategoryId: filters?.subCategoryId,
+        subCategoryIds: filters?.subCategoryIds,
+        searchConditions: filters?.searchConditions,
+      };
+      if (pageParam === 0) {
+        const [manuals, totalCount] = await Promise.all([
+          getManuals(PAGE_SIZE, 0, f),
+          getManualsCount(f),
+        ]);
+        return { manuals, totalCount };
+      }
+      const manuals = await getManuals(PAGE_SIZE, pageParam as number, f);
+      return { manuals, totalCount: undefined };
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.manuals.length < PAGE_SIZE) return undefined;
+      return allPages.reduce((sum, page) => sum + page.manuals.length, 0);
+    },
+    initialPageParam: 0,
+  });
+
+  const manuals = data?.pages.flatMap((p) => p.manuals) ?? [];
+  const totalCount = data?.pages[0]?.totalCount;
+
+  return {
+    manuals,
+    isLoading: isPending,
+    isLoadingMore: isFetchingNextPage,
+    error: isError ? '데이터를 불러오는데 실패했습니다.' : '',
+    loadMore: () => fetchNextPage(),
+    hasMore: hasNextPage ?? false,
+    totalCount,
+  };
+};

--- a/src/app/_domains/_manual/_queryKeys/manualKeys.ts
+++ b/src/app/_domains/_manual/_queryKeys/manualKeys.ts
@@ -1,0 +1,17 @@
+export type ManualSearchCondition = {
+  searchTarget: string;
+  searchKeyword: string;
+};
+
+export type ManualFilters = {
+  subCategoryId?: string;
+  subCategoryIds?: string[];
+  searchConditions?: ManualSearchCondition[];
+};
+
+export const manualKeys = {
+  all: () => ['manuals'] as const,
+  lists: () => [...manualKeys.all(), 'list'] as const,
+  list: (filters?: ManualFilters) => [...manualKeys.lists(), filters ?? null] as const,
+  categoryTree: (tab?: string) => [...manualKeys.all(), 'categoryTree', tab ?? null] as const,
+};

--- a/src/app/_domains/_manual/_services/manualCategoryService.ts
+++ b/src/app/_domains/_manual/_services/manualCategoryService.ts
@@ -1,0 +1,207 @@
+import supabase from '@/libs/supabaseClient';
+import {
+  ManualTopCategoryType,
+  ManualSubCategoryType,
+  ManualCategoryTree,
+} from '../_types/manual.types';
+
+// ============================================================================
+// 상위 타입
+// ============================================================================
+
+export const getManualTopCategories = async (
+  tab: string,
+): Promise<ManualTopCategoryType[]> => {
+  const { data, error } = await supabase
+    .from('manual_top_categories')
+    .select('*')
+    .eq('tab', tab)
+    .order('order_index', { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+};
+
+export const createManualTopCategory = async ({
+  tab,
+  name,
+  orderIndex,
+}: {
+  tab: string;
+  name: string;
+  orderIndex: number;
+}): Promise<ManualTopCategoryType> => {
+  const { data, error } = await supabase
+    .from('manual_top_categories')
+    .insert({ tab, name, order_index: orderIndex })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+};
+
+export const updateManualTopCategory = async ({
+  id,
+  name,
+}: {
+  id: string;
+  name: string;
+}): Promise<void> => {
+  const { error } = await supabase
+    .from('manual_top_categories')
+    .update({ name, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) throw error;
+};
+
+export const updateManualTopCategoryOrders = async (
+  orders: { id: string; order_index: number }[],
+): Promise<void> => {
+  const updates = orders.map(({ id, order_index }) =>
+    supabase
+      .from('manual_top_categories')
+      .update({ order_index })
+      .eq('id', id),
+  );
+
+  const results = await Promise.all(updates);
+  for (const { error } of results) {
+    if (error) throw error;
+  }
+};
+
+export const deleteManualTopCategory = async (id: string): Promise<void> => {
+  const { error } = await supabase
+    .from('manual_top_categories')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+};
+
+// ============================================================================
+// 하위 타입
+// ============================================================================
+
+export const getManualSubCategories = async (
+  topCategoryId: string,
+): Promise<ManualSubCategoryType[]> => {
+  const { data, error } = await supabase
+    .from('manual_sub_categories')
+    .select('*')
+    .eq('top_category_id', topCategoryId)
+    .order('order_index', { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+};
+
+export const createManualSubCategory = async ({
+  topCategoryId,
+  name,
+  orderIndex,
+}: {
+  topCategoryId: string;
+  name: string;
+  orderIndex: number;
+}): Promise<ManualSubCategoryType> => {
+  const { data, error } = await supabase
+    .from('manual_sub_categories')
+    .insert({ top_category_id: topCategoryId, name, order_index: orderIndex })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+};
+
+export const updateManualSubCategory = async ({
+  id,
+  name,
+}: {
+  id: string;
+  name: string;
+}): Promise<void> => {
+  const { error } = await supabase
+    .from('manual_sub_categories')
+    .update({ name, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) throw error;
+};
+
+export const updateManualSubCategoryOrders = async (
+  orders: { id: string; order_index: number }[],
+): Promise<void> => {
+  const updates = orders.map(({ id, order_index }) =>
+    supabase
+      .from('manual_sub_categories')
+      .update({ order_index })
+      .eq('id', id),
+  );
+
+  const results = await Promise.all(updates);
+  for (const { error } of results) {
+    if (error) throw error;
+  }
+};
+
+export const deleteManualSubCategory = async (id: string): Promise<void> => {
+  const { error } = await supabase
+    .from('manual_sub_categories')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+};
+
+// ============================================================================
+// 카테고리 트리 (탭 기준)
+// ============================================================================
+
+export const getManualCategoryTree = async (
+  tab: string,
+): Promise<ManualCategoryTree> => {
+  const topCategories = await getManualTopCategories(tab);
+  if (topCategories.length === 0) {
+    return { topCategories: [], subCategoriesByTop: {} };
+  }
+
+  const { data, error } = await supabase
+    .from('manual_sub_categories')
+    .select('*')
+    .in(
+      'top_category_id',
+      topCategories.map((c) => c.id),
+    )
+    .order('order_index', { ascending: true });
+
+  if (error) throw error;
+
+  const subCategoriesByTop: Record<string, ManualSubCategoryType[]> = {};
+  (data ?? []).forEach((sub) => {
+    if (!subCategoriesByTop[sub.top_category_id]) {
+      subCategoriesByTop[sub.top_category_id] = [];
+    }
+    subCategoriesByTop[sub.top_category_id].push(sub);
+  });
+
+  return { topCategories, subCategoriesByTop };
+};
+
+export const getManualCountBySubCategory = async (): Promise<
+  Record<string, number>
+> => {
+  const { data, error } = await supabase.from('manuals').select('sub_category_id');
+  if (error) throw error;
+
+  const counts: Record<string, number> = {};
+  (data ?? []).forEach((m) => {
+    if (m.sub_category_id) {
+      counts[m.sub_category_id] = (counts[m.sub_category_id] || 0) + 1;
+    }
+  });
+  return counts;
+};

--- a/src/app/_domains/_manual/_services/manualService.ts
+++ b/src/app/_domains/_manual/_services/manualService.ts
@@ -1,0 +1,107 @@
+import supabase from '@/libs/supabaseClient';
+import { ManualType } from '../_types/manual.types';
+import { ManualSearchCondition } from '../_queryKeys/manualKeys';
+
+type ManualFiltersParam = {
+  subCategoryId?: string;
+  subCategoryIds?: string[];
+  searchConditions?: ManualSearchCondition[];
+};
+
+const SELECT_QUERY = '*, manual_sub_categories(*, manual_top_categories(*))';
+
+// 존재할 수 없는 uuid: top 카테고리는 선택했지만 하위 카테고리가 하나도 없는 경우
+// .in('sub_category_id', []) 는 PostgREST 에러를 유발하므로 대신 이 값으로 필터링해 0건을 반환한다.
+const NONE_UUID = '00000000-0000-0000-0000-000000000000';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const applyManualFilters = (query: any, filters?: ManualFiltersParam): any => {
+  let next = query;
+
+  if (filters?.subCategoryId) {
+    next = next.eq('sub_category_id', filters.subCategoryId);
+  } else if (filters?.subCategoryIds !== undefined) {
+    next =
+      filters.subCategoryIds.length > 0
+        ? next.in('sub_category_id', filters.subCategoryIds)
+        : next.eq('sub_category_id', NONE_UUID);
+  }
+
+  if (filters?.searchConditions?.length) {
+    for (const cond of filters.searchConditions) {
+      next = next.ilike(cond.searchTarget, `%${cond.searchKeyword}%`);
+    }
+  }
+
+  return next;
+};
+
+const buildQuery = (filters?: ManualFiltersParam) =>
+  applyManualFilters(supabase.from('manuals').select(SELECT_QUERY), filters);
+
+export const getManuals = async (
+  limit: number,
+  offset: number,
+  filters?: ManualFiltersParam,
+): Promise<ManualType[]> => {
+  const { data, error } = await buildQuery(filters)
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) throw error;
+  return (data ?? []) as unknown as ManualType[];
+};
+
+export const getManualsCount = async (
+  filters?: ManualFiltersParam,
+): Promise<number> => {
+  const query = applyManualFilters(
+    supabase.from('manuals').select('*', { count: 'exact', head: true }),
+    filters,
+  );
+
+  const { count, error } = await query;
+  if (error) throw error;
+  return count ?? 0;
+};
+
+export const createManual = async (values: {
+  subCategoryId: string;
+  title: string;
+  content: string;
+}): Promise<void> => {
+  const { error } = await supabase.from('manuals').insert({
+    sub_category_id: values.subCategoryId,
+    title: values.title,
+    content: values.content,
+    is_use: true,
+  });
+
+  if (error) throw error;
+};
+
+export const updateManual = async (
+  id: string,
+  values: {
+    subCategoryId: string;
+    title: string;
+    content: string;
+  },
+): Promise<void> => {
+  const { error } = await supabase
+    .from('manuals')
+    .update({
+      sub_category_id: values.subCategoryId,
+      title: values.title,
+      content: values.content,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id);
+
+  if (error) throw error;
+};
+
+export const deleteManual = async (id: string): Promise<void> => {
+  const { error } = await supabase.from('manuals').delete().eq('id', id);
+  if (error) throw error;
+};

--- a/src/app/_domains/_manual/_types/manual.types.ts
+++ b/src/app/_domains/_manual/_types/manual.types.ts
@@ -1,0 +1,40 @@
+export type ManualTopCategoryType = {
+  id: string;
+  tab: string;
+  name: string;
+  order_index: number;
+  is_use: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ManualSubCategoryType = {
+  id: string;
+  top_category_id: string;
+  name: string;
+  order_index: number;
+  is_use: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ManualType = {
+  id: string;
+  sub_category_id: string;
+  title: string;
+  content: string;
+  order_index: number;
+  is_use: boolean;
+  created_at: string;
+  updated_at: string;
+  manual_sub_categories:
+    | (ManualSubCategoryType & {
+        manual_top_categories: ManualTopCategoryType | null;
+      })
+    | null;
+};
+
+export type ManualCategoryTree = {
+  topCategories: ManualTopCategoryType[];
+  subCategoriesByTop: Record<string, ManualSubCategoryType[]>;
+};

--- a/src/app/_enums/enums.ts
+++ b/src/app/_enums/enums.ts
@@ -39,6 +39,10 @@ export const PaymentTypeEnum = {
   },
   REMARK: {
     value: 'remark',
+    name: '고객 특이사항',
+  },
+  SHIPMENT_REMARK: {
+    value: 'shipment_remark',
     name: '특이사항',
   },
   KAKAOTALK: {
@@ -202,3 +206,17 @@ export const AfterServiceItemTypeEnum = {
 
 export type AfterServiceItemTypeEnumType =
   (typeof AfterServiceItemTypeEnum)[keyof typeof AfterServiceItemTypeEnum];
+
+export const ManualTabEnum = {
+  CUSTOMER: {
+    value: 'customer',
+    name: '고객',
+  },
+  STORE: {
+    value: 'store',
+    name: '매장',
+  },
+} as const;
+
+export type ManualTabEnumType =
+  (typeof ManualTabEnum)[keyof typeof ManualTabEnum];


### PR DESCRIPTION
## 변경사항
- 출고 이력 추가/수정 플로우를 스텝형 UI로 개선
- 품목 특이사항에 `시연용` 옵션 추가 및 0원 처리
- 가격 조정 금액에 음수 입력 지원
- 가격 조정 품목 메모에 조정 금액 표기
- 복사 기능에서 음수 가격 조정 금액이 수식에 반영되도록 수정
- 결제 유형 라벨 정리 및 출고 이력용 `특이사항` 결제 유형 추가
- 모바일에서 SideMenu 기반 내비게이션 적용, 데스크톱은 기존 Header 유지
- 매뉴얼 관리 페이지 및 관련 컴포넌트/서비스/훅 추가

## 검증
- `npm run lint` 통과
- 기존 lint warning 8개는 유지