### PR TITLE
[0730] 출고 이력·스태프 오픈·입고 관리 기능 개선

### DIFF
--- a/docs/daily_closing_report.sql
+++ b/docs/daily_closing_report.sql
@@ -98,12 +98,42 @@ create table if not exists public.daily_closing_checklist_items (
   label text not null check (length(trim(label)) > 0),
   sort_order integer not null default 0,
   is_required boolean not null default false,
+  is_opening_gate boolean not null default false,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
 
 alter table public.daily_closing_checklist_items
-  add column if not exists is_required boolean not null default false;
+  add column if not exists is_required boolean not null default false,
+  add column if not exists is_opening_gate boolean not null default false;
+
+create table if not exists public.daily_opening_checklist_progress (
+  business_date date primary key,
+  checks jsonb not null default '{}'::jsonb,
+  updated_by uuid not null references auth.users(id),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.daily_opening_checklist_progress enable row level security;
+
+drop policy if exists "authenticated users can read opening checklist progress"
+  on public.daily_opening_checklist_progress;
+create policy "authenticated users can read opening checklist progress"
+  on public.daily_opening_checklist_progress for select
+  to authenticated using (true);
+
+drop policy if exists "authenticated users can insert opening checklist progress"
+  on public.daily_opening_checklist_progress;
+create policy "authenticated users can insert opening checklist progress"
+  on public.daily_opening_checklist_progress for insert
+  to authenticated with check (auth.uid() = updated_by);
+
+drop policy if exists "authenticated users can update opening checklist progress"
+  on public.daily_opening_checklist_progress;
+create policy "authenticated users can update opening checklist progress"
+  on public.daily_opening_checklist_progress for update
+  to authenticated using (true)
+  with check (auth.uid() = updated_by);
 
 alter table public.daily_closing_checklist_items enable row level security;
 
@@ -181,6 +211,12 @@ from (
 where not exists (
   select 1 from public.daily_closing_checklist_items
 );
+
+update public.daily_closing_checklist_items
+set is_opening_gate = true,
+    updated_at = now()
+where phase = 'opening'
+  and sort_order between 0 and 3;
 
 drop function if exists public.complete_daily_closing_report(
   date, text, text, jsonb, jsonb, text, text, integer, integer, integer

--- a/docs/inventory_purchase_adjustments.sql
+++ b/docs/inventory_purchase_adjustments.sql
@@ -1,0 +1,288 @@
+-- 입고별 할인·지불 참고 내역
+-- Supabase SQL Editor에서 이 파일 전체를 실행해 주세요.
+
+create table if not exists public.inventory_purchase_adjustment_categories (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  kind text not null check (kind in ('discount', 'payment')),
+  sort_order integer not null default 0,
+  is_active boolean not null default true,
+  created_by uuid not null references auth.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (kind, name)
+);
+
+create table if not exists public.inventory_purchase_order_adjustments (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.inventory_purchase_orders(id) on delete cascade,
+  category_id uuid references public.inventory_purchase_adjustment_categories(id) on delete set null,
+  category_name text not null,
+  kind text not null check (kind in ('discount', 'payment')),
+  amount integer not null check (amount >= 0),
+  note text,
+  created_by uuid not null references auth.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (order_id, category_id)
+);
+
+create index if not exists inventory_purchase_order_adjustments_order_idx
+  on public.inventory_purchase_order_adjustments(order_id);
+
+alter table public.inventory_purchase_adjustment_categories enable row level security;
+alter table public.inventory_purchase_order_adjustments enable row level security;
+
+drop policy if exists "authenticated read purchase adjustment categories"
+  on public.inventory_purchase_adjustment_categories;
+drop policy if exists "admins read purchase adjustment categories"
+  on public.inventory_purchase_adjustment_categories;
+create policy "admins read purchase adjustment categories"
+  on public.inventory_purchase_adjustment_categories for select
+  to authenticated using (
+    exists (
+      select 1 from public.users
+      where users.id = auth.uid() and users.oss_role = 'admin'
+    )
+  );
+
+drop policy if exists "authenticated read purchase order adjustments"
+  on public.inventory_purchase_order_adjustments;
+drop policy if exists "admins read purchase order adjustments"
+  on public.inventory_purchase_order_adjustments;
+create policy "admins read purchase order adjustments"
+  on public.inventory_purchase_order_adjustments for select
+  to authenticated using (
+    exists (
+      select 1 from public.users
+      where users.id = auth.uid() and users.oss_role = 'admin'
+    )
+  );
+
+create or replace function public.save_inventory_purchase_adjustment_category(
+  p_id uuid,
+  p_name text,
+  p_kind text
+) returns uuid
+language plpgsql security definer set search_path=public as $$
+declare
+  v_id uuid;
+begin
+  if not exists (
+    select 1 from public.users
+    where id = auth.uid() and oss_role = 'admin'
+  ) then
+    raise exception 'ADMIN_REQUIRED';
+  end if;
+  if btrim(coalesce(p_name, '')) = '' then
+    raise exception 'CATEGORY_NAME_REQUIRED';
+  end if;
+  if p_kind not in ('discount', 'payment') then
+    raise exception 'INVALID_CATEGORY_KIND';
+  end if;
+
+  if p_id is null then
+    insert into public.inventory_purchase_adjustment_categories
+      (name, kind, sort_order, created_by)
+    values (
+      btrim(p_name),
+      p_kind,
+      coalesce((
+        select max(sort_order) + 1
+        from public.inventory_purchase_adjustment_categories
+        where kind = p_kind
+      ), 0),
+      auth.uid()
+    )
+    returning id into v_id;
+  else
+    update public.inventory_purchase_adjustment_categories
+    set name = btrim(p_name),
+        kind = p_kind,
+        is_active = true,
+        updated_at = now()
+    where id = p_id
+    returning id into v_id;
+  end if;
+  return v_id;
+end;
+$$;
+
+create or replace function public.deactivate_inventory_purchase_adjustment_category(
+  p_id uuid
+) returns void
+language plpgsql security definer set search_path=public as $$
+begin
+  if not exists (
+    select 1 from public.users
+    where id = auth.uid() and oss_role = 'admin'
+  ) then
+    raise exception 'ADMIN_REQUIRED';
+  end if;
+  update public.inventory_purchase_adjustment_categories
+  set is_active = false, updated_at = now()
+  where id = p_id;
+end;
+$$;
+
+create or replace function public.save_inventory_purchase_order_adjustments(
+  p_order_id uuid,
+  p_adjustments jsonb
+) returns void
+language plpgsql security definer set search_path=public as $$
+begin
+  if not exists (
+    select 1 from public.users
+    where id = auth.uid() and oss_role = 'admin'
+  ) then
+    raise exception 'ADMIN_REQUIRED';
+  end if;
+  if not exists (
+    select 1 from public.inventory_purchase_orders where id = p_order_id
+  ) then
+    raise exception 'PURCHASE_ORDER_NOT_FOUND';
+  end if;
+
+  delete from public.inventory_purchase_order_adjustments
+  where order_id = p_order_id;
+
+  insert into public.inventory_purchase_order_adjustments (
+    order_id,
+    category_id,
+    category_name,
+    kind,
+    amount,
+    note,
+    created_by
+  )
+  select
+    p_order_id,
+    nullif(item->>'category_id', '')::uuid,
+    btrim(item->>'category_name'),
+    item->>'kind',
+    greatest(0, coalesce((item->>'amount')::integer, 0)),
+    nullif(btrim(item->>'note'), ''),
+    auth.uid()
+  from jsonb_array_elements(coalesce(p_adjustments, '[]'::jsonb)) item
+  where btrim(coalesce(item->>'category_name', '')) <> ''
+    and item->>'kind' in ('discount', 'payment');
+end;
+$$;
+
+revoke all on function public.save_inventory_purchase_adjustment_category(uuid, text, text) from public;
+revoke all on function public.deactivate_inventory_purchase_adjustment_category(uuid) from public;
+revoke all on function public.save_inventory_purchase_order_adjustments(uuid, jsonb) from public;
+grant execute on function public.save_inventory_purchase_adjustment_category(uuid, text, text) to authenticated;
+grant execute on function public.deactivate_inventory_purchase_adjustment_category(uuid) to authenticated;
+grant execute on function public.save_inventory_purchase_order_adjustments(uuid, jsonb) to authenticated;
+
+drop function if exists public.update_inventory_purchase_order_details(uuid, uuid, date, text, jsonb);
+
+create or replace function public.update_inventory_purchase_order_details(
+  p_order_id uuid,
+  p_supplier_id uuid,
+  p_ordered_on date,
+  p_note text,
+  p_lines jsonb,
+  p_receipts jsonb
+) returns void
+language plpgsql security definer set search_path=public as $$
+declare
+  v_line jsonb;
+  v_existing public.inventory_purchase_order_lines%rowtype;
+  v_receipt jsonb;
+  v_order_status text;
+begin
+  if not exists (
+    select 1 from public.users
+    where id = auth.uid() and oss_role = 'admin'
+  ) then
+    raise exception 'ADMIN_REQUIRED';
+  end if;
+  if not exists (
+    select 1 from public.inventory_suppliers
+    where id = p_supplier_id
+  ) then
+    raise exception 'SUPPLIER_NOT_FOUND';
+  end if;
+
+  select status into v_order_status
+  from public.inventory_purchase_orders
+  where id = p_order_id
+  for update;
+  if not found then
+    raise exception 'PURCHASE_ORDER_NOT_FOUND';
+  end if;
+
+  update public.inventory_purchase_orders
+  set supplier_id = p_supplier_id,
+      ordered_on = p_ordered_on,
+      note = nullif(btrim(coalesce(p_note, '')), ''),
+      updated_at = now()
+  where id = p_order_id;
+
+  for v_line in
+    select value from jsonb_array_elements(coalesce(p_lines, '[]'::jsonb))
+  loop
+    select * into v_existing
+    from public.inventory_purchase_order_lines
+    where id = (v_line->>'id')::uuid
+      and order_id = p_order_id
+    for update;
+
+    if not found then
+      raise exception 'PURCHASE_ORDER_LINE_NOT_FOUND';
+    end if;
+    if coalesce((v_line->>'ordered_quantity')::integer, 0) < greatest(1, v_existing.received_quantity) then
+      raise exception 'ORDERED_QUANTITY_BELOW_RECEIVED';
+    end if;
+    if v_existing.received_quantity > 0
+      and btrim(v_line->>'item_name') <> v_existing.item_name then
+      raise exception 'RECEIVED_ITEM_NAME_IMMUTABLE';
+    end if;
+
+    update public.inventory_purchase_order_lines
+    set item_name = btrim(v_line->>'item_name'),
+        ordered_quantity = (v_line->>'ordered_quantity')::integer,
+        pending_quantity = greatest(
+          (v_line->>'ordered_quantity')::integer - received_quantity,
+          0
+        ),
+        unit_price = nullif(v_line->>'unit_price', '')::integer,
+        note = nullif(btrim(coalesce(v_line->>'note', '')), '')
+    where id = v_existing.id;
+  end loop;
+
+  for v_receipt in
+    select value from jsonb_array_elements(coalesce(p_receipts, '[]'::jsonb))
+  loop
+    update public.inventory_purchase_receipts
+    set arrived_on = (v_receipt->>'arrived_on')::date,
+        note = nullif(btrim(coalesce(v_receipt->>'note', '')), '')
+    where id = (v_receipt->>'id')::uuid
+      and order_id = p_order_id
+      and reversed_at is null;
+  end loop;
+
+  if v_order_status not in ('closed', 'cancelled') then
+    update public.inventory_purchase_orders
+    set status = case
+      when not exists (
+        select 1 from public.inventory_purchase_order_lines
+        where order_id = p_order_id
+          and received_quantity < ordered_quantity
+      ) then 'completed'
+      when exists (
+        select 1 from public.inventory_purchase_order_lines
+        where order_id = p_order_id and received_quantity > 0
+      ) then 'partial'
+      else 'pending'
+    end,
+    updated_at = now()
+    where id = p_order_id;
+  end if;
+end;
+$$;
+
+revoke all on function public.update_inventory_purchase_order_details(uuid, uuid, date, text, jsonb, jsonb) from public;
+grant execute on function public.update_inventory_purchase_order_details(uuid, uuid, date, text, jsonb, jsonb) to authenticated;

--- a/docs/staff_opening_gate.sql
+++ b/docs/staff_opening_gate.sql
@@ -1,0 +1,41 @@
+-- 스태프 영업 시작 체크리스트 잠금 기능
+-- Supabase SQL Editor에서 이 파일 전체를 한 번 실행해 주세요.
+
+alter table public.daily_closing_checklist_items
+  add column if not exists is_opening_gate boolean not null default false;
+
+create table if not exists public.daily_opening_checklist_progress (
+  business_date date primary key,
+  checks jsonb not null default '{}'::jsonb,
+  updated_by uuid not null references auth.users(id),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.daily_opening_checklist_progress enable row level security;
+
+drop policy if exists "authenticated users can read opening checklist progress"
+  on public.daily_opening_checklist_progress;
+create policy "authenticated users can read opening checklist progress"
+  on public.daily_opening_checklist_progress for select
+  to authenticated using (true);
+
+drop policy if exists "authenticated users can insert opening checklist progress"
+  on public.daily_opening_checklist_progress;
+create policy "authenticated users can insert opening checklist progress"
+  on public.daily_opening_checklist_progress for insert
+  to authenticated with check (auth.uid() = updated_by);
+
+drop policy if exists "authenticated users can update opening checklist progress"
+  on public.daily_opening_checklist_progress;
+create policy "authenticated users can update opening checklist progress"
+  on public.daily_opening_checklist_progress for update
+  to authenticated using (true)
+  with check (auth.uid() = updated_by);
+
+-- 현재 출근·교대 확인의 1~4번을 최초 오픈 조건으로 지정한다.
+-- 이후에는 체크리스트 관리 화면에서 항목별로 변경할 수 있다.
+update public.daily_closing_checklist_items
+set is_opening_gate = true,
+    updated_at = now()
+where phase = 'opening'
+  and sort_order between 0 and 3;

--- a/src/app/(auth)/_components/Header/_components/Nav.tsx
+++ b/src/app/(auth)/_components/Header/_components/Nav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import toast from 'react-hot-toast';
 import Button from '@/app/_components/Button';
 import { useUser } from '@/app/_contexts/UserContext';
+import { useStaffOpening } from '@/app/_contexts/StaffOpeningContext';
 import supabase from '@/libs/supabaseClient';
 
 type GroupKey = 'customer' | 'product' | 'store';
@@ -37,6 +38,7 @@ type NavProps = { orientation?: 'horizontal' | 'vertical'; onNavigate?: () => vo
 const Nav = ({ orientation = 'horizontal', onNavigate }: NavProps) => {
   const pathname = usePathname();
   const { isAdmin } = useUser();
+  const { isLocked, step: staffOpeningStep } = useStaffOpening();
   const [menuItems, setMenuItems] = useState(defaultMenuItems);
   const [openGroup, setOpenGroup] = useState<GroupKey | null>(null);
   const [inventorySubmenuOpen, setInventorySubmenuOpen] = useState(false);
@@ -76,12 +78,31 @@ const Nav = ({ orientation = 'horizontal', onNavigate }: NavProps) => {
     };
   }, [openGroup]);
 
-  const visibleMenuItems = useMemo(() => menuItems.filter((item) => isAdmin || item.href !== '/items'), [isAdmin, menuItems]);
-  const groupedItems = useMemo(() => groupOrder.map((key) => ({
-    key,
-    label: groupLabels[key],
-    links: visibleMenuItems.filter((item) => item.group_key === key).sort((a, b) => a.sort_order - b.sort_order),
-  })), [visibleMenuItems]);
+  const visibleMenuItems = useMemo(
+    () =>
+      menuItems.filter(
+        (item) =>
+          (isAdmin || item.href !== '/items') &&
+          (!isLocked ||
+            item.href === '/work-journal' ||
+            item.href === '/cash-management' ||
+            (staffOpeningStep === 'checklist' && item.href === '/reports')),
+      ),
+    [isAdmin, isLocked, menuItems, staffOpeningStep],
+  );
+  const groupedItems = useMemo(
+    () =>
+      groupOrder
+        .map((key) => ({
+          key,
+          label: groupLabels[key],
+          links: visibleMenuItems
+            .filter((item) => item.group_key === key)
+            .sort((a, b) => a.sort_order - b.sort_order),
+        }))
+        .filter((group) => group.links.length > 0),
+    [visibleMenuItems],
+  );
   const closeAfterNavigate = () => { setOpenGroup(null); onNavigate?.(); };
 
   const moveDraft = (href: string, direction: -1 | 1) => {

--- a/src/app/(auth)/_components/HistoriesComponents/LogActorInfo.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/LogActorInfo.tsx
@@ -24,7 +24,26 @@ const LogActorInfo = ({
   const userDisplay =
     createdWorkerName || users?.name || users?.email || '알 수 없음';
 
-  const isModified = Boolean(modifiedWorkerName && modifiedAt);
+  const storedModificationHistory = Array.isArray(jsonb?.modificationHistory)
+    ? jsonb.modificationHistory.filter(
+        (
+          item,
+        ): item is {
+          workerName: string;
+          modifiedAt: string;
+        } =>
+          typeof item === 'object' &&
+          item !== null &&
+          typeof (item as Record<string, unknown>).workerName === 'string' &&
+          typeof (item as Record<string, unknown>).modifiedAt === 'string',
+      )
+    : [];
+  const modificationHistory =
+    storedModificationHistory.length > 0
+      ? storedModificationHistory
+      : modifiedWorkerName && modifiedAt
+        ? [{ workerName: modifiedWorkerName, modifiedAt }]
+        : [];
   const formatDate = (value: string) => new Date(value).toLocaleString('ko-KR', {
     year: '2-digit',
     month: '2-digit',
@@ -34,21 +53,30 @@ const LogActorInfo = ({
     hour12: false,
   });
   const createdDateText = formatDate(created_at);
-  const modifiedDateText = modifiedAt ? formatDate(modifiedAt) : '';
 
   return (
-    <>
+    <div>
       <div className="text-xs text-gray-500">
         작업자 · <span className="font-medium text-gray-700">{userDisplay}</span>
       </div>
       <div className="mt-0.5 text-xs text-gray-400">{createdDateText}</div>
-      {isModified && (
-        <div className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-500">
-          수정 · <span className="font-medium">{modifiedWorkerName}</span>
-          <span className="ml-1">{modifiedDateText}</span>
+      {modificationHistory.map((history, index) => (
+        <div
+          key={`${history.modifiedAt}-${history.workerName}-${index}`}
+          className="mt-1"
+        >
+          <div className="text-xs text-gray-500">
+            수정{' '}
+            <span className="font-medium text-gray-700">
+              {history.workerName}
+            </span>
+          </div>
+          <div className="mt-0.5 text-xs text-gray-400">
+            {formatDate(history.modifiedAt)}
+          </div>
         </div>
-      )}
-    </>
+      ))}
+    </div>
   );
 };
 

--- a/src/app/(auth)/_components/StaffOpeningProgressBanner.tsx
+++ b/src/app/(auth)/_components/StaffOpeningProgressBanner.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Button from "@/app/_components/Button";
+import { useStaffOpening } from "@/app/_contexts/StaffOpeningContext";
+
+export default function StaffOpeningProgressBanner() {
+  const router = useRouter();
+  const { step } = useStaffOpening();
+
+  if (step !== "cash" && step !== "checklist") return null;
+
+  const isChecklistStep = step === "checklist";
+
+  return (
+    <section className="flex flex-col gap-4 rounded-xl border border-amber-200 bg-amber-50/70 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:p-5">
+      <div>
+        <div className="mb-2 flex flex-wrap items-center gap-2 text-xs font-bold">
+          <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-emerald-700">
+            1 출근 완료
+          </span>
+          <span
+            className={`rounded-full px-2.5 py-1 ${
+              isChecklistStep
+                ? "bg-emerald-100 text-emerald-700"
+                : "bg-amber-200 text-amber-800"
+            }`}
+          >
+            2 시작 시재
+          </span>
+          <span
+            className={`rounded-full px-2.5 py-1 ${
+              isChecklistStep
+                ? "bg-amber-200 text-amber-800"
+                : "bg-gray-100 text-gray-500"
+            }`}
+          >
+            3 오픈 체크
+          </span>
+        </div>
+        <h2 className="font-bold text-gray-900">
+          {isChecklistStep
+            ? "시작 시재 저장이 완료되었습니다."
+            : "출근 처리가 완료되었습니다."}
+        </h2>
+        <p className="mt-1 text-sm text-gray-600">
+          {isChecklistStep
+            ? "보고서에서 오픈 체크를 모두 완료하면 전체 메뉴가 열립니다."
+            : "전날 시재와 일치하도록 오늘의 시작 시재를 저장하면 다음 단계로 진행됩니다."}
+        </p>
+      </div>
+      <Button
+        className="shrink-0"
+        onClick={() =>
+          router.push(
+            isChecklistStep
+              ? "/reports#opening-checklist"
+              : "/cash-management",
+          )
+        }
+      >
+        {isChecklistStep ? "보고서 이동하기" : "시재 입력하기"}
+      </Button>
+    </section>
+  );
+}

--- a/src/app/(auth)/_components/StampLogEditModal.tsx
+++ b/src/app/(auth)/_components/StampLogEditModal.tsx
@@ -26,10 +26,53 @@ const getStampAmountFromAction = (action: string) => {
 
 const formatAmount = (value: number) => value.toLocaleString('ko-KR');
 
+const getShipmentTypeLabel = (
+  item: NonNullable<StampLogMeta['items']>[number],
+) => {
+  if (item.inventoryAction === 'exchange_in') return '교환입고';
+  if (item.inventoryAction === 'exchange_out') return '교환출고';
+  if (typeof item.adjustedUnitPrice === 'number') return '가격조정';
+  if (item.remark?.startsWith('서비스')) return '서비스';
+  return '일반판매';
+};
+
+const getShipmentTypeClassName = (
+  item: NonNullable<StampLogMeta['items']>[number],
+) => {
+  const type = getShipmentTypeLabel(item);
+  if (type === '서비스') return 'bg-sky-50 text-sky-700';
+  if (type === '교환입고') return 'bg-emerald-50 text-emerald-700';
+  if (type === '교환출고') return 'bg-amber-50 text-amber-700';
+  if (type === '가격조정') return 'bg-violet-50 text-violet-700';
+  return 'bg-gray-100 text-gray-600';
+};
+
+const getItemDisplayMemo = (
+  item: NonNullable<StampLogMeta['items']>[number],
+) => {
+  const remark = item.remark?.trim();
+  if (!remark) return '';
+  const wrappedMemo = remark.match(
+    /^(?:서비스|교환입고|교환출고)\((.*)\)$/,
+  )?.[1];
+  if (wrappedMemo) return wrappedMemo.trim();
+  if (
+    remark === '서비스' ||
+    remark === '교환입고' ||
+    remark === '교환출고' ||
+    remark === '가격 조정' ||
+    remark === '가격조정'
+  ) {
+    return '';
+  }
+  return remark;
+};
+
 interface StampLogEditModalProps {
   target: {
     name: string;
     phone: string;
+    address?: string | null;
     note?: string | null;
   };
   initialAction: string;
@@ -67,6 +110,8 @@ const StampLogEditModal = ({
   const [formValidity, setFormValidity] = useState({
     hasPaymentType: false,
     hasItems: false,
+    hasDeliveryInfo: true,
+    hasCompletedBasicSequence: false,
   });
 
   const initialValue = useMemo(
@@ -78,9 +123,16 @@ const StampLogEditModal = ({
     }),
     [initialAction, initialLogMeta, initialPaymentType, initialStoreName],
   );
+  const hasValidSplitPaymentAmounts =
+    !stampLog?.logMeta.payments?.length ||
+    (stampLog.logMeta.payments.every((payment) => payment.amount >= 1) &&
+      stampLog.logMeta.payments.reduce(
+        (sum, payment) => sum + payment.amount,
+        0,
+      ) === stampLog.finalAmount);
 
   useEffect(() => {
-    setSize(step >= 2 ? 'max-w-5xl' : 'max-w-xl');
+    setSize(step >= 2 ? 'max-w-6xl' : 'max-w-2xl');
   }, [setSize, step]);
 
   const handleSubmit = async () => {
@@ -163,6 +215,7 @@ const StampLogEditModal = ({
       <TargetCustomerCard
         name={target.name}
         phone={target.phone}
+        address={target.address}
         note={target.note}
         className="mb-4 shrink-0"
       />
@@ -176,137 +229,305 @@ const StampLogEditModal = ({
           layout="split"
           step={step}
           customerMode={customerMode}
+          customerAddress={target.address}
           onChange={setStampLog}
           onValidityChange={setFormValidity}
         />
 
         {step === 3 && stampLog && (
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:items-start">
-            <div className="space-y-2 rounded-lg border border-brand-200 bg-brand-50 p-4">
-              <div>
-                <span className="text-sm font-medium text-gray-600">매장:</span>
-                <p className="text-base font-semibold text-gray-900">
-                  {stampLog.storeLabel}
-                </p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-gray-600">
-                  스탬프 개수:
-                </span>
-                <p className="text-base font-semibold text-gray-900">
-                  {stampLog.amount === 0 ? '미적립' : `${stampLog.amount}개`}
-                </p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-gray-600">
-                  결제 유형:
-                </span>
-                <p className="text-base font-semibold text-gray-900">
-                  {stampLog.paymentTypeName}
-                </p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-gray-600">금액:</span>
-                <p className="text-base font-semibold text-gray-900">
-                  {stampLog.finalAmountExpression || '0'} ={' '}
-                  {formatAmount(stampLog.finalAmount)}원
-                </p>
-              </div>
-              {stampLog.logMeta.discount && (
-                <div>
-                  <span className="text-sm font-medium text-gray-600">
-                    할인:
-                  </span>
-                  <p className="text-base font-semibold text-gray-900">
-                    {stampLog.logMeta.discount.name}{' '}
-                    {formatAmount(stampLog.logMeta.discount.amount)}원
+          <div className="space-y-4">
+            <div
+              className={`grid grid-cols-2 gap-2 ${
+                customerMode === 'x' ? 'md:grid-cols-4' : 'md:grid-cols-5'
+              }`}
+            >
+              {[
+                {
+                  label: '출고 방식',
+                  value: stampLog.logMeta.reservationDate
+                    ? `${stampLog.logMeta.reservationDate} 예약 출고`
+                    : '즉시 출고',
+                },
+                { label: '출고 매장', value: stampLog.storeLabel },
+                {
+                  label: '수령 방식',
+                  value:
+                    stampLog.logMeta.deliveryMethod === 'parcel'
+                      ? '택배'
+                      : stampLog.logMeta.deliveryMethod === 'delivery'
+                        ? '배달'
+                        : '매장방문',
+                },
+                ...(customerMode === 'x'
+                  ? []
+                  : [
+                      {
+                        label: '스탬프 적립',
+                        value:
+                          stampLog.amount === 0
+                            ? '미적립'
+                            : `${stampLog.amount}개`,
+                      },
+                    ]),
+                {
+                  label: '결제 정보',
+                  value: stampLog.logMeta.payments?.length
+                    ? stampLog.logMeta.payments
+                        .map((payment) => payment.paymentTypeName)
+                        .join(' · ')
+                    : stampLog.paymentTypeName,
+                },
+              ].map((summary) => (
+                <div
+                  key={summary.label}
+                  className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2.5"
+                >
+                  <p className="text-xs font-medium text-gray-500">
+                    {summary.label}
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-gray-900">
+                    {summary.value}
                   </p>
                 </div>
-              )}
-              {stampLog.logMeta.extraNote && (
-                <div>
-                  <span className="text-sm font-medium text-gray-600">
-                    출고 특이사항:
-                  </span>
-                  <p className="whitespace-pre-wrap text-sm text-gray-900">
-                    {stampLog.logMeta.extraNote}
-                  </p>
-                </div>
-              )}
+              ))}
             </div>
-            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-              <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
-                <p className="text-sm font-semibold text-gray-900">
-                  품목 목록{' '}
-                  <span className="font-normal text-gray-500">
-                    {stampLog.logMeta.items?.length ?? 0}개
-                  </span>
+
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-4">
+              {stampLog.logMeta.deliveryMethod !== 'store_visit' && (
+                <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
+                  <p className="text-xs font-medium text-gray-500">
+                    {stampLog.logMeta.deliveryMethod === 'delivery'
+                      ? '배달비'
+                      : '택배비'}
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-gray-900">
+                    {formatAmount(stampLog.logMeta.deliveryFee ?? 0)}원
+                  </p>
+                </div>
+              )}
+              {stampLog.logMeta.deliveryMethod !== 'store_visit' && (
+                <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 md:col-span-2">
+                  <p className="text-xs font-medium text-gray-500">배송 주소</p>
+                  <p className="mt-1 break-words text-sm text-gray-800">
+                    {stampLog.logMeta.deliveryAddress}
+                  </p>
+                </div>
+              )}
+              <div
+                className={`rounded-lg border border-gray-200 bg-white px-3 py-2.5 ${
+                  stampLog.logMeta.deliveryMethod === 'store_visit'
+                    ? 'md:col-span-4'
+                    : ''
+                }`}
+              >
+                <p className="text-xs font-medium text-gray-500">출고 메모</p>
+                <p className="mt-1 whitespace-pre-wrap break-words text-sm text-gray-800">
+                  {stampLog.logMeta.extraNote || '없음'}
                 </p>
               </div>
-              <div className="max-h-[360px] space-y-2 overflow-y-auto p-3">
-                {stampLog.logMeta.items?.map((item, index) => (
-                  <div
-                    key={`${item.itemId}-${index}`}
-                    className="flex items-start gap-2 rounded-lg border border-gray-200 px-3 py-2.5"
-                  >
-                    <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-500 text-xs font-semibold text-white">
-                      {index + 1}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex min-w-0 items-start gap-2">
-                        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600">
-                          {item.itemCategoryName ?? '미분류'}
-                        </span>
-                        <p className="min-w-0 break-words text-sm font-medium text-gray-900">
-                          {item.lineText}
-                        </p>
-                      </div>
-                      <p className="mt-1 text-xs text-gray-500">
-                        개별단가 {formatAmount(item.unitPrice)}원 / 총금액{' '}
-                        {formatAmount(item.amount)}원
-                      </p>
-                    </div>
-                  </div>
-                ))}
+            </div>
+
+            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+              <div className="flex items-center gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3">
+                <h3 className="text-sm font-semibold text-gray-900">
+                  품목 목록
+                </h3>
+                <span className="text-xs text-gray-500">
+                  {
+                    new Set(
+                      stampLog.logMeta.items?.map((item) => item.itemId) ?? [],
+                    ).size
+                  }
+                  종 · 총{' '}
+                  {stampLog.logMeta.items?.reduce(
+                    (sum, item) => sum + item.quantity,
+                    0,
+                  ) ?? 0}
+                  개
+                </span>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[760px] table-fixed text-sm">
+                  <thead className="bg-gray-50 text-xs font-semibold text-gray-600">
+                    <tr className="border-b border-gray-200">
+                      <th className="w-[6%] px-2 py-2 text-center">번호</th>
+                      <th className="w-[33%] px-2 py-2 text-left">품목명</th>
+                      <th className="w-[13%] px-2 py-2 text-center">품목종류</th>
+                      <th className="w-[13%] px-2 py-2 text-center">출고 유형</th>
+                      <th className="w-[8%] px-2 py-2 text-center">수량</th>
+                      <th className="w-[13%] px-2 py-2 text-right">단가</th>
+                      <th className="w-[14%] px-3 py-2 text-right">소계</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stampLog.logMeta.items?.map((item, index) => {
+                      const memo = getItemDisplayMemo(item);
+                      return (
+                        <tr
+                          key={`${item.itemId}-${index}`}
+                          className="border-b border-gray-200 last:border-b-0"
+                        >
+                          <td className="px-2 py-2">
+                            <span className="mx-auto flex h-5 w-5 items-center justify-center rounded-full bg-brand-500 text-xs font-semibold leading-none text-white">
+                              {index + 1}
+                            </span>
+                          </td>
+                          <td className="px-2 py-2 font-medium text-gray-900">
+                            <div className="flex flex-wrap items-center gap-x-1.5">
+                              <span className="break-words">{item.itemName}</span>
+                              {memo && (
+                                <span className="break-words text-xs font-normal text-gray-500">
+                                  ({memo})
+                                </span>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-2 py-2 text-center text-xs font-medium text-gray-600">
+                            {item.itemCategoryName ?? '미분류'}
+                          </td>
+                          <td className="px-2 py-2 text-center">
+                            <span
+                              className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold ${getShipmentTypeClassName(item)}`}
+                            >
+                              {getShipmentTypeLabel(item)}
+                            </span>
+                          </td>
+                          <td className="px-2 py-2 text-center font-medium text-gray-800">
+                            {item.quantity}개
+                          </td>
+                          <td className="px-2 py-2 text-right text-gray-700">
+                            {formatAmount(
+                              typeof item.adjustedUnitPrice === 'number'
+                                ? item.adjustedUnitPrice
+                                : item.unitPrice,
+                            )}
+                            원
+                          </td>
+                          <td className="px-3 py-2 text-right font-medium text-gray-900">
+                            {formatAmount(item.amount)}원
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         )}
       </div>
 
-      <div className="mt-4 flex shrink-0 justify-end gap-3 border-t border-gray-200 pt-4">
-        <Button
-          variant="gray"
-          size="sm"
-          onClick={() => {
-            if (step === 1) onCancel();
-            else setStep((current) => (current === 3 ? 2 : 1));
-          }}
-          disabled={isSubmitting}
-        >
-          {step === 1 ? '취소' : '이전'}
-        </Button>
-        {step < 3 ? (
-          <Button
-            size="sm"
-            onClick={() => setStep((current) => (current === 1 ? 2 : 3))}
-            disabled={
-              step === 1
-                ? !formValidity.hasPaymentType
-                : !formValidity.hasItems
-            }
-          >
-            다음
-          </Button>
+      <div className="mt-4 flex shrink-0 flex-col gap-4 border-t border-gray-200 pt-4 lg:flex-row lg:items-center lg:justify-between">
+        {(step === 2 || step === 3) && stampLog ? (
+          <div className="grid flex-1 grid-cols-2 items-center gap-x-5 gap-y-3 lg:grid-cols-[1fr_1.2fr_1fr_0.8fr_1.2fr]">
+            <div>
+              <p className="text-xs text-gray-500">품목 수량</p>
+              <p className="mt-0.5 text-sm font-semibold text-gray-900">
+                총{' '}
+                {
+                  new Set(
+                    stampLog.logMeta.items?.map((item) => item.itemId) ?? [],
+                  ).size
+                }
+                종 ·{' '}
+                {stampLog.logMeta.items?.reduce(
+                  (sum, item) => sum + item.quantity,
+                  0,
+                ) ?? 0}
+                개
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">결제방식</p>
+              <p className="mt-0.5 text-sm font-semibold text-gray-900">
+                {stampLog.logMeta.payments?.length
+                  ? stampLog.logMeta.payments
+                      .map((payment) => payment.paymentTypeName)
+                      .join(' · ')
+                  : stampLog.paymentTypeName}
+              </p>
+              {stampLog.logMeta.payments?.length ? (
+                <p className="mt-0.5 break-words text-xs text-gray-500">
+                  {stampLog.logMeta.payments
+                    .map(
+                      (payment) =>
+                        `${payment.paymentTypeName} ${formatAmount(payment.amount)}원`,
+                    )
+                    .join(' · ')}
+                </p>
+              ) : null}
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">상품 합계</p>
+              <p className="mt-0.5 text-base font-semibold text-gray-900">
+                {formatAmount(
+                  stampLog.logMeta.items?.reduce(
+                    (sum, item) => sum + item.amount,
+                    0,
+                  ) ?? 0,
+                )}
+                원
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">할인</p>
+              <p className="mt-0.5 text-base font-semibold text-gray-900">
+                {stampLog.logMeta.discount
+                  ? `${stampLog.logMeta.discount.name} ${formatAmount(stampLog.logMeta.discount.amount)}원`
+                  : '0원'}
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs font-semibold text-brand-600">
+                최종 결제금액
+              </p>
+              <p className="mt-0.5 text-lg font-bold text-brand-600">
+                {formatAmount(stampLog.finalAmount)}원
+              </p>
+            </div>
+          </div>
         ) : (
-          <Button
-            size="sm"
-            onClick={handleSubmit}
-            disabled={isSubmitting || !stampLog}
-          >
-            {isSubmitting ? '저장 중...' : '수정'}
-          </Button>
+          <div />
         )}
+
+        <div className="flex shrink-0 justify-end gap-3">
+          <Button
+            variant="gray"
+            size="sm"
+            onClick={() => {
+              if (step === 1) onCancel();
+              else setStep((current) => (current === 3 ? 2 : 1));
+            }}
+            disabled={isSubmitting}
+          >
+            {step === 1 ? '취소' : '이전'}
+          </Button>
+          {step < 3 ? (
+            step === 1 && !formValidity.hasCompletedBasicSequence ? null : (
+              <Button
+                size="sm"
+                onClick={() =>
+                  setStep((current) => (current === 1 ? 2 : 3))
+                }
+                disabled={
+                  step === 1
+                    ? !formValidity.hasCompletedBasicSequence
+                    : !formValidity.hasItems || !hasValidSplitPaymentAmounts
+                }
+              >
+                다음
+              </Button>
+            )
+          ) : (
+            <Button
+              size="sm"
+              onClick={handleSubmit}
+              disabled={isSubmitting || !stampLog}
+            >
+              {isSubmitting ? '저장 중...' : '수정'}
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/app/(auth)/cash-management/_components/ChecklistManagement.tsx
+++ b/src/app/(auth)/cash-management/_components/ChecklistManagement.tsx
@@ -41,6 +41,7 @@ export default function ChecklistManagement() {
           label: item.label,
           sortOrder: index,
           isRequired: item.is_required,
+          isOpeningGate: item.is_opening_gate,
         })),
       ),
     onSuccess: async () => {
@@ -124,6 +125,13 @@ function ChecklistPreview({
                 필수
               </span>
             )}
+            {item.is_opening_gate && (
+              <span
+                className={`${item.is_required ? '' : 'ml-auto'} rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-bold text-emerald-700`}
+              >
+                오픈
+              </span>
+            )}
           </div>
         ))}
       </div>
@@ -162,6 +170,7 @@ function ChecklistEditor({
         label: "",
         sort_order: items.filter((item) => item.phase === phase).length,
         is_required: false,
+        is_opening_gate: false,
       },
     ]);
 
@@ -203,6 +212,21 @@ function ChecklistEditor({
                       />
                       필수
                     </label>
+                    {phase === "opening" && (
+                      <label className="flex h-10 shrink-0 cursor-pointer items-center gap-1 rounded-lg border border-emerald-200 bg-emerald-50/50 px-2 text-xs font-semibold text-emerald-700">
+                        <input
+                          type="checkbox"
+                          checked={item.is_opening_gate}
+                          onChange={(event) =>
+                            updateItem(item.id, {
+                              is_opening_gate: event.target.checked,
+                            })
+                          }
+                          className="cursor-pointer accent-emerald-600"
+                        />
+                        오픈
+                      </label>
+                    )}
                     <button
                       type="button"
                       onClick={() => removeItem(item.id)}

--- a/src/app/(auth)/cash-management/_components/DailyClosingReport.tsx
+++ b/src/app/(auth)/cash-management/_components/DailyClosingReport.tsx
@@ -10,7 +10,9 @@ import {
   cancelDailyClosingReport,
   completeDailyClosingReport,
   getDailyClosingChecklistItems,
+  getDailyOpeningChecklistProgress,
   getDailyClosingReport,
+  saveDailyOpeningChecklistProgress,
 } from "@/app/_domains/_dailyClosing/_services/dailyClosingService";
 import { cashManagementKeys } from "@/app/_domains/_cashManagement/_queryKeys/cashManagementKeys";
 import type { DailyPaymentSales } from "@/app/_domains/_cashManagement/_types/cashManagement.types";
@@ -24,15 +26,15 @@ import { useModal } from "@/app/_contexts/ModalContext";
 import ConfirmModal from "@/app/(auth)/_components/ConfirmModal";
 
 const defaultChecklistItems: DailyClosingChecklistItem[] = [
-  { id: "device_login", phase: "opening", label: "매장 기기 및 업무 계정 로그인 확인", sort_order: 0, is_required: false },
-  { id: "stock_check", phase: "opening", label: "고객 출고 전 시재·재고 확인", sort_order: 1, is_required: false },
-  { id: "device_charge", phase: "opening", label: "시연용 기기와 업무용 기기 충전 확인", sort_order: 2, is_required: false },
-  { id: "notification_check", phase: "opening", label: "업무용 휴대폰 알림 확인", sort_order: 3, is_required: false },
-  { id: "restroom", phase: "closing", label: "화장실 잠금 및 정리 확인", sort_order: 0, is_required: false },
-  { id: "sales_check", phase: "closing", label: "판매처별 매출과 종합 금액 확인", sort_order: 1, is_required: false },
-  { id: "device_off", phase: "closing", label: "에어컨·송풍·조명 전원 확인", sort_order: 2, is_required: false },
-  { id: "trash", phase: "closing", label: "매장 쓰레기 정리", sort_order: 3, is_required: false },
-  { id: "door_lock", phase: "closing", label: "출입문과 창문 잠금 확인", sort_order: 4, is_required: false },
+  { id: "device_login", phase: "opening", label: "매장 기기 및 업무 계정 로그인 확인", sort_order: 0, is_required: false, is_opening_gate: true },
+  { id: "stock_check", phase: "opening", label: "고객 출고 전 시재·재고 확인", sort_order: 1, is_required: false, is_opening_gate: true },
+  { id: "device_charge", phase: "opening", label: "시연용 기기와 업무용 기기 충전 확인", sort_order: 2, is_required: false, is_opening_gate: true },
+  { id: "notification_check", phase: "opening", label: "업무용 휴대폰 알림 확인", sort_order: 3, is_required: false, is_opening_gate: true },
+  { id: "restroom", phase: "closing", label: "화장실 잠금 및 정리 확인", sort_order: 0, is_required: false, is_opening_gate: false },
+  { id: "sales_check", phase: "closing", label: "판매처별 매출과 종합 금액 확인", sort_order: 1, is_required: false, is_opening_gate: false },
+  { id: "device_off", phase: "closing", label: "에어컨·송풍·조명 전원 확인", sort_order: 2, is_required: false, is_opening_gate: false },
+  { id: "trash", phase: "closing", label: "매장 쓰레기 정리", sort_order: 3, is_required: false, is_opening_gate: false },
+  { id: "door_lock", phase: "closing", label: "출입문과 창문 잠금 확인", sort_order: 4, is_required: false, is_opening_gate: false },
 ];
 
 const formatWon = (value: number) => `${value.toLocaleString("ko-KR")}원`;
@@ -101,6 +103,11 @@ export default function DailyClosingReport({
     queryKey: ["daily-closing-checklist-items"],
     queryFn: getDailyClosingChecklistItems,
   });
+  const openingProgressQuery = useQuery({
+    queryKey: ["daily-opening-checklist-progress", businessDate],
+    queryFn: () => getDailyOpeningChecklistProgress(businessDate),
+    enabled: !reportQuery.data,
+  });
   const savedChecklistItems = reportQuery.data?.report_snapshot
     ? [
         ...reportQuery.data.report_snapshot.openingChecklist.map(
@@ -110,6 +117,7 @@ export default function DailyClosingReport({
             label: item.label,
             sort_order: index,
             is_required: item.isRequired,
+            is_opening_gate: false,
           }),
         ),
         ...reportQuery.data.report_snapshot.closingChecklist.map(
@@ -119,6 +127,7 @@ export default function DailyClosingReport({
             label: item.label,
             sort_order: index,
             is_required: item.isRequired,
+            is_opening_gate: false,
           }),
         ),
       ]
@@ -186,6 +195,11 @@ export default function DailyClosingReport({
     setCleaningNote(reportQuery.data.cleaning_note ?? "");
     setSpecialNote(reportQuery.data.special_note ?? "");
   }, [reportQuery.data]);
+
+  useEffect(() => {
+    if (reportQuery.data || !openingProgressQuery.data) return;
+    setOpeningChecks(openingProgressQuery.data);
+  }, [openingProgressQuery.data, reportQuery.data]);
 
   const requiredItems = [...openingTasks, ...closingTasks].filter(
     (item) => item.is_required,
@@ -261,6 +275,12 @@ export default function DailyClosingReport({
           })),
           payments: paymentSales.breakdown.map((payment) => ({ ...payment })),
           itemSummary: paymentSales.itemSummary.map((item) => ({ ...item })),
+          outboundTypeSummary: paymentSales.outboundTypeSummary.map((item) => ({
+            ...item,
+          })),
+          deliverySummary: paymentSales.deliverySummary.map((item) => ({
+            ...item,
+          })),
           totalSales: paymentSales.total,
           expectedCash,
           actualCash,
@@ -411,6 +431,26 @@ export default function DailyClosingReport({
     key: string,
   ) => setter((current) => ({ ...current, [key]: !current[key] }));
 
+  const toggleOpening = (key: string) => {
+    setOpeningChecks((current) => {
+      const next = { ...current, [key]: !current[key] };
+      void saveDailyOpeningChecklistProgress(businessDate, next)
+        .then(() => {
+          queryClient.setQueryData(
+            ["daily-opening-checklist-progress", businessDate],
+            next,
+          );
+          window.dispatchEvent(new Event("staff-opening-changed"));
+        })
+        .catch((error) => {
+          console.error(error);
+          toast.error("오픈 체크 상태 저장에 실패했습니다.");
+          void openingProgressQuery.refetch();
+        });
+      return next;
+    });
+  };
+
   if (reportQuery.isError) {
     return (
       <div className="rounded-xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-800">
@@ -551,7 +591,13 @@ export default function DailyClosingReport({
                     className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
                   >
                     <span className="text-gray-600">{item.categoryName}</span>
-                    <strong className="text-gray-900">{item.quantity}개</strong>
+                    <strong className="text-gray-900">
+                      {item.quantity}
+                      {item.categoryName === "택배" ||
+                      item.categoryName === "배달"
+                        ? "건"
+                        : "개"}
+                    </strong>
                   </div>
                 ))
               ) : (
@@ -562,13 +608,13 @@ export default function DailyClosingReport({
         </div>
       </section>
 
-      <div className="grid gap-4 lg:grid-cols-2">
+      <div id="opening-checklist" className="grid scroll-mt-24 gap-4 lg:grid-cols-2">
         <Checklist
           title="출근·교대 확인"
           tasks={openingTasks}
           values={openingChecks}
           disabled={isClosed}
-          onToggle={(key) => toggle(setOpeningChecks, key)}
+          onToggle={toggleOpening}
         />
         <Checklist
           title="마감 확인"
@@ -684,6 +730,13 @@ function Checklist({
                 필수
               </span>
             )}
+            {item.is_opening_gate && (
+              <span
+                className={`${item.is_required ? '' : 'ml-auto'} shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-bold text-emerald-700`}
+              >
+                오픈
+              </span>
+            )}
           </label>
         ))}
       </div>
@@ -766,6 +819,7 @@ export function ChecklistEditor({
         label: "",
         sort_order: items.filter((item) => item.phase === phase).length,
         is_required: false,
+        is_opening_gate: false,
       },
     ]);
   const moveItem = (id: string, direction: -1 | 1) => {

--- a/src/app/(auth)/cash-management/_components/ReportSnapshotView.tsx
+++ b/src/app/(auth)/cash-management/_components/ReportSnapshotView.tsx
@@ -363,7 +363,11 @@ export default function ReportSnapshotView({
             title="판매종류 및 수량"
             rows={(snapshot.itemSummary ?? []).map((item) => ({
               label: item.categoryName,
-              value: `${item.quantity}개`,
+              value: `${item.quantity}${
+                item.categoryName === "택배" || item.categoryName === "배달"
+                  ? "건"
+                  : "개"
+              }`,
             }))}
           />
         </div>

--- a/src/app/(auth)/cash-management/page.tsx
+++ b/src/app/(auth)/cash-management/page.tsx
@@ -27,9 +27,11 @@ import { getDailyClosingReportsByRange } from '@/app/_domains/_dailyClosing/_ser
 import { useModal } from '@/app/_contexts/ModalContext';
 import ConfirmModal from '@/app/(auth)/_components/ConfirmModal';
 import { useUser } from '@/app/_contexts/UserContext';
+import { useStaffOpening } from '@/app/_contexts/StaffOpeningContext';
 import DailyClosingReport from './_components/DailyClosingReport';
 import ChecklistManagement from './_components/ChecklistManagement';
 import ReportSnapshotView from './_components/ReportSnapshotView';
+import StaffOpeningProgressBanner from '@/app/(auth)/_components/StaffOpeningProgressBanner';
 
 type CashManagementTab =
   | 'save'
@@ -69,6 +71,11 @@ export default function CashManagementPage() {
   const pathname = usePathname();
   const isReportsPage = pathname?.startsWith('/reports');
   const { isAdmin } = useUser();
+  const {
+    step: staffOpeningStep,
+    previousCash: requiredOpeningCash,
+    refresh: refreshStaffOpening,
+  } = useStaffOpening();
   const queryClient = useQueryClient();
   const { open, close } = useModal();
   const [activeTab, setActiveTab] = useState<CashManagementTab>(
@@ -237,6 +244,8 @@ export default function CashManagementPage() {
     ovapeBreakdown: [],
     eguVapeBreakdown: [],
     itemSummary: [],
+    outboundTypeSummary: [],
+    deliverySummary: [],
     total: 0,
   };
   const workJournals = dayQuery.data?.workJournals ?? [];
@@ -279,6 +288,8 @@ export default function CashManagementPage() {
           queryKey: cashManagementKeys.history(),
         }),
       ]);
+      window.dispatchEvent(new Event('staff-opening-changed'));
+      await refreshStaffOpening();
     },
     onError: (error) => {
       console.error(error);
@@ -295,12 +306,26 @@ export default function CashManagementPage() {
   });
 
   const handleSave = () => {
+    if (staffOpeningStep === 'attendance') {
+      toast.error('시재를 저장하기 전에 근무기록에서 먼저 출근 처리해 주세요.');
+      return;
+    }
     if (!hasWorkerInfo) {
       toast.error('시재를 저장하려면 해당 날짜의 근무자 정보가 필요합니다.');
       return;
     }
     if (!canModifyClosing) {
       toast.error('staff 계정은 오늘 날짜의 시재만 수정할 수 있습니다.');
+      return;
+    }
+    if (
+      staffOpeningStep === 'cash' &&
+      requiredOpeningCash !== null &&
+      actualCash !== requiredOpeningCash
+    ) {
+      toast.error(
+        `영업 시작 시재는 전날 시재 ${requiredOpeningCash.toLocaleString('ko-KR')}원과 일치해야 합니다.`,
+      );
       return;
     }
     if (!isEditing && difference === 0) {
@@ -360,6 +385,7 @@ export default function CashManagementPage() {
 
   return (
     <main className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6 lg:px-8">
+      <StaffOpeningProgressBanner />
       <div className="flex items-end justify-between border-b border-gray-200">
         <div className="flex min-w-0 overflow-x-auto" role="tablist" aria-label="시재 관리 메뉴">
           {tabOrder.map((tab, index) => {

--- a/src/app/(auth)/customers/[id]/_components/CustomerEditModal.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomerEditModal.tsx
@@ -339,10 +339,10 @@ export default function CustomerEditModal({
 
         <div>
           <label className="block text-sm font-medium mb-1">주소지</label>
-          <input
-            type="text"
-            className="w-full rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
-            placeholder="주소지를 입력하세요. (선택)"
+          <textarea
+            rows={3}
+            className="w-full min-h-20 resize-y rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
+            placeholder={"주소지를 입력하세요. (선택)\nex) OO구 도로명주소 OO건물 OO동 OO호 (공동현관 : 비밀번호 or X)"}
             aria-invalid={!!errors.address || undefined}
             {...register('address')}
           />

--- a/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
@@ -42,6 +42,7 @@ const CustomersDetailStampsHistories = ({
     phone: string;
     name: string;
     gender?: 'male' | 'female' | null;
+    address?: string | null;
     note?: string | null;
   };
   isLoading: boolean;
@@ -207,6 +208,7 @@ const CustomersDetailStampsHistories = ({
             target={{
               name: targetUser.name,
               phone: targetUser.phone,
+              address: targetUser.address,
               note: targetUser.note,
             }}
             initialAction={log.action}
@@ -232,6 +234,7 @@ const CustomersDetailStampsHistories = ({
       onUpdateLog,
       isReservation,
       targetUser.name,
+      targetUser.address,
       targetUser.note,
       targetUser.phone,
     ],
@@ -280,7 +283,10 @@ const CustomersDetailStampsHistories = ({
                   className="flex items-center justify-between p-3 rounded border border-brand-50 hover:bg-brand-50/30 transition-colors whitespace-nowrap"
                 >
                   <div className="flex items-center gap-4 sm:gap-6">
-                    <ActionInfoLabel action={log.action} />
+                    {!(
+                      targetUser.name.trim() === 'X' &&
+                      targetUser.phone.trim() === 'X'
+                    ) && <ActionInfoLabel action={log.action} />}
 
                     {log.users && (
                       <div className="text-left">
@@ -308,7 +314,7 @@ const CustomersDetailStampsHistories = ({
                       )}
                   </div>
                   <div className="flex-1 pl-4 ml-4 border-l border-brand-100">
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-start gap-2">
                       <Button
                         variant="secondary"
                         size="xs"
@@ -316,16 +322,28 @@ const CustomersDetailStampsHistories = ({
                       >
                         ✏️
                       </Button>
-                      <span className="flex-1 min-w-[240px] text-xs sm:text-sm text-gray-600 break-words whitespace-pre-line">
-                        {log.note || <span className="text-gray-400"> - </span>}
+                      <div className="min-w-[240px] flex-1 break-words whitespace-normal text-xs text-gray-600 sm:text-sm">
+                        <p className="whitespace-pre-line">
+                          {log.note || (
+                            <span className="text-gray-400"> - </span>
+                          )}
+                        </p>
                         {typeof log.jsonb?.extraNote === 'string' &&
                           log.jsonb.extraNote.trim() && (
-                            <span className="ml-2 italic text-gray-400">
+                            <p className="mt-1 italic text-gray-400">
                               출고 특이사항: &quot;{log.jsonb.extraNote.trim()}
                               &quot;
-                            </span>
+                            </p>
                           )}
-                      </span>
+                        {(log.jsonb?.deliveryMethod === 'parcel' ||
+                          log.jsonb?.deliveryMethod === 'delivery') &&
+                          typeof log.jsonb?.deliveryAddress === 'string' &&
+                          log.jsonb.deliveryAddress.trim() && (
+                            <p className="mt-1 break-words italic text-gray-400">
+                              주소: {log.jsonb.deliveryAddress.trim()}
+                            </p>
+                          )}
+                      </div>
                     </div>
                   </div>
                   <div className="ml-3 flex-shrink-0 flex items-center gap-2">

--- a/src/app/(auth)/customers/[id]/_components/StampCards.tsx
+++ b/src/app/(auth)/customers/[id]/_components/StampCards.tsx
@@ -1,14 +1,54 @@
 interface StampCardsProps {
   count: number;
+  compact?: boolean;
+  pendingAmount?: number;
 }
 
-const StampCards = ({ count }: StampCardsProps) => {
+const StampCards = ({
+  count,
+  compact = false,
+  pendingAmount = 0,
+}: StampCardsProps) => {
   const completedCards = Math.floor(count / 10); // 완성된 카드 수
   const currentStamps = count % 10; // 현재 카드의 스탬프 수
   const hasCurrentCard = count > 0; // 현재 진행 중인 카드가 있는지
 
   // 5x2 그리드 (총 10칸)
   const stampSlots = Array.from({ length: 10 }, (_, i) => i);
+
+  if (compact) {
+    const projectedStamps = currentStamps + pendingAmount;
+    const hasRolledOver = projectedStamps >= 10;
+    const previewCount = hasRolledOver
+      ? projectedStamps % 10
+      : projectedStamps;
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white px-4 py-4 shadow-sm">
+        <div className="grid grid-cols-10 gap-2">
+          {stampSlots.map((slot) => {
+            const isCurrent = !hasRolledOver && slot < currentStamps;
+            const isPending = hasRolledOver
+              ? slot < previewCount
+              : slot >= currentStamps && slot < previewCount;
+            return (
+              <div
+                key={slot}
+                className={`flex aspect-square min-w-0 items-center justify-center rounded-lg border-2 text-xl transition-all duration-300 ${
+                  isCurrent
+                    ? "border-brand-500 bg-gradient-to-br from-brand-400 to-brand-500 text-white shadow-md"
+                    : isPending
+                      ? "border-brand-400 bg-gradient-to-br from-brand-100 to-brand-200 text-white"
+                      : "border-dashed border-gray-200 bg-gray-50 text-gray-300"
+                }`}
+              >
+                {isCurrent || isPending ? "🍩" : ""}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/app/(auth)/customers/[id]/_components/StampSection.tsx
+++ b/src/app/(auth)/customers/[id]/_components/StampSection.tsx
@@ -24,6 +24,7 @@ interface StampSectionProps {
     id: string;
     name: string;
     phone: string;
+    address?: string | null;
     gender?: "male" | "female" | null;
     note?: string | null;
   };
@@ -80,8 +81,10 @@ const StampSection = ({
           target={{
             name: target.name,
             phone: target.phone,
+            address: target.address,
             note: target.note,
           }}
+          stampCount={stampCount}
           mode="add"
           onCancel={close}
           onConfirm={async (
@@ -120,13 +123,20 @@ const StampSection = ({
   ) => {
     try {
       setIsLoading(true);
-      await addStamp(target.id, amount, memo ?? "", paymentType, logMeta);
+      const effectiveAmount = customerMode === "x" ? 0 : amount;
+      await addStamp(
+        target.id,
+        effectiveAmount,
+        memo ?? "",
+        paymentType,
+        logMeta,
+      );
       onUpdate();
       invalidateLogLists();
       toast.success(
-        amount === 0
+        effectiveAmount === 0
           ? "미적립으로 기록되었습니다."
-          : `스탬프 ${amount}개 적립 완료!`,
+          : `스탬프 ${effectiveAmount}개 적립 완료!`,
       );
     } catch (error) {
       const errorMessage = getRequestErrorMessage(error);
@@ -145,9 +155,10 @@ const StampSection = ({
   ) => {
     try {
       setIsLoading(true);
+      const effectiveAmount = customerMode === "x" ? 0 : amount;
       await addReservationStamp(
         target.id,
-        amount,
+        effectiveAmount,
         memo ?? "",
         paymentType,
         logMeta,
@@ -271,6 +282,7 @@ const StampSection = ({
                         target={{
                           name: target.name,
                           phone: target.phone,
+                          address: target.address,
                           note: target.note,
                         }}
                         mode="use10"
@@ -299,6 +311,7 @@ const StampSection = ({
                         target={{
                           name: target.name,
                           phone: target.phone,
+                          address: target.address,
                           note: target.note,
                         }}
                         mode="adjust"

--- a/src/app/(auth)/customers/[id]/page.tsx
+++ b/src/app/(auth)/customers/[id]/page.tsx
@@ -162,7 +162,10 @@ export default function CustomerDetailPage() {
     return <NotFoundView full={false} />;
   }
 
-  const stampCount = customer.stamps?.[0]?.count || 0;
+  const stampCount =
+    customer.name.trim() === "X" && customer.phone.trim() === "X"
+      ? 0
+      : customer.stamps?.[0]?.count || 0;
   const isSpecialCustomer = checkSpecialCustomer(
     customer.name,
     customer.phone,
@@ -214,6 +217,7 @@ export default function CustomerDetailPage() {
               id: customerId,
               name: customer.name,
               phone: customer.phone,
+              address: customer.address,
               gender: customer.gender,
               note: customer.note,
             }}
@@ -292,6 +296,7 @@ export default function CustomerDetailPage() {
                   phone: customer.phone,
                   name: customer.name,
                   gender: customer.gender,
+                  address: customer.address,
                   note: customer.note,
                 }}
                 logs={logs}

--- a/src/app/(auth)/customers/_components/CustomerCreateModal.tsx
+++ b/src/app/(auth)/customers/_components/CustomerCreateModal.tsx
@@ -301,10 +301,10 @@ export default function CustomerCreateModal({
 
           <div>
             <label className="block text-sm font-medium mb-1">주소지</label>
-            <input
-              type="text"
-              className="w-full rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
-              placeholder="주소지를 입력하세요. (선택)"
+            <textarea
+              rows={3}
+              className="w-full min-h-20 resize-y rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
+              placeholder={"주소지를 입력하세요. (선택)\nex) OO구 도로명주소 OO건물 OO동 OO호 (공동현관 : 비밀번호 or X)"}
               aria-invalid={!!errors.address || undefined}
               {...register("address")}
             />

--- a/src/app/(auth)/customers/_components/CustomerList/index.tsx
+++ b/src/app/(auth)/customers/_components/CustomerList/index.tsx
@@ -130,7 +130,12 @@ const CustomerList = ({
               </tr>
             ) : (
               customers.map((customer, index) => {
-                const stampCount = customer.stamps?.[0]?.count || 0;
+                const isNoStampCustomer =
+                  customer.name.trim() === "X" &&
+                  customer.phone.trim() === "X";
+                const stampCount = isNoStampCustomer
+                  ? 0
+                  : customer.stamps?.[0]?.count || 0;
 
                 return (
                   <tr

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/app/_enums/enums";
 import type { StampLogMeta } from "@/app/_domains/_stamp/_services/stampService";
 import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
 import { useModal } from "@/app/_contexts/ModalContext";
 import StampLogForm, { StampLogValue } from "./StampLogForm";
 import TargetCustomerCard from "./TargetCustomerCard";
@@ -15,18 +16,69 @@ import { getCustomerMode } from "@/app/_domains/_customer/_utils/specialCustomer
 
 const formatAmount = (value: number) => value.toLocaleString("ko-KR");
 
+const getShipmentTypeLabel = (item: NonNullable<StampLogMeta["items"]>[number]) => {
+  if (item.inventoryAction === "exchange_in") return "교환입고";
+  if (item.inventoryAction === "exchange_out") return "교환출고";
+  if (typeof item.adjustedUnitPrice === "number") return "가격조정";
+  if (item.remark?.startsWith("서비스")) return "서비스";
+  return "일반판매";
+};
+
+const getShipmentTypeClassName = (
+  item: NonNullable<StampLogMeta["items"]>[number],
+) => {
+  const type = getShipmentTypeLabel(item);
+
+  if (type === "서비스") return "bg-sky-50 text-sky-700";
+  if (type === "교환입고") return "bg-emerald-50 text-emerald-700";
+  if (type === "교환출고") return "bg-amber-50 text-amber-700";
+  if (type === "가격조정") return "bg-violet-50 text-violet-700";
+  return "bg-gray-100 text-gray-600";
+};
+
+const getItemDisplayMemo = (
+  item: NonNullable<StampLogMeta["items"]>[number],
+) => {
+  const remark = item.remark?.trim();
+  if (!remark) return "";
+
+  const wrappedMemo = remark.match(
+    /^(?:서비스|교환입고|교환출고)\((.*)\)$/,
+  )?.[1];
+  if (wrappedMemo) return wrappedMemo.trim();
+
+  if (
+    remark === "서비스" ||
+    remark === "교환입고" ||
+    remark === "교환출고" ||
+    remark === "가격 조정" ||
+    remark === "가격조정"
+  ) {
+    return "";
+  }
+
+  return remark;
+};
+
 const addStepLabels = ["기본 정보", "품목 · 금액", "최종 확인"] as const;
 
 export default function StampConfirmModal({
   target,
   mode,
   amount: amountProp,
+  stampCount = 0,
   onConfirm,
   onCancel,
 }: {
-  target: { name: string; phone: string; note?: string | null };
+  target: {
+    name: string;
+    phone: string;
+    address?: string | null;
+    note?: string | null;
+  };
   mode: "add" | "adjust" | "use10";
   amount?: number;
+  stampCount?: number;
   onConfirm: (
     note?: string,
     paymentType?: PaymentTypeEnumType["value"],
@@ -53,6 +105,16 @@ export default function StampConfirmModal({
   );
   const [stampLog, setStampLog] = useState<StampLogValue | null>(null);
   const [isReservation, setIsReservation] = useState(false);
+  const [reservationDate, setReservationDate] = useState("");
+  const hasValidReservationDate =
+    !isReservation || /^\d{1,2}\/\d{1,2}$/.test(reservationDate.trim());
+  const hasValidSplitPaymentAmounts =
+    !stampLog?.logMeta.payments?.length ||
+    (stampLog.logMeta.payments.every((payment) => payment.amount >= 1) &&
+      stampLog.logMeta.payments.reduce(
+        (sum, payment) => sum + payment.amount,
+        0,
+      ) === stampLog.finalAmount);
   const customerMode = getCustomerMode(target.name, target.phone);
   const usesStandardSalesFlow =
     customerMode === "normal" || customerMode === "x";
@@ -64,6 +126,8 @@ export default function StampConfirmModal({
   const [formValidity, setFormValidity] = useState({
     hasPaymentType: false,
     hasItems: false,
+    hasDeliveryInfo: true,
+    hasCompletedBasicSequence: false,
   });
 
   // 품목·금액과 최종 확인은 좌우 2단으로 보여줘야 해서 모달을 더 넓게
@@ -73,8 +137,8 @@ export default function StampConfirmModal({
       !usesStandardSalesFlow && addStep === 3
         ? "max-w-xl"
         : addStep >= 2
-          ? "max-w-5xl"
-          : "max-w-xl",
+          ? "max-w-6xl"
+          : "max-w-2xl",
     );
   }, [mode, addStep, usesStandardSalesFlow, setSize]);
 
@@ -101,11 +165,52 @@ export default function StampConfirmModal({
       setIsSubmitting(true);
       if (mode === "add") {
         if (!stampLog) return;
+        if (!hasValidReservationDate) {
+          toast.error("예약 날짜를 7/19 형식으로 입력해 주세요.");
+          return;
+        }
+        const reservationTag =
+          isReservation && reservationDate.trim()
+            ? `${reservationDate.trim()} 예약주문`
+            : "";
+        const discountTag = stampLog.logMeta.discount
+          ? `${stampLog.logMeta.discount.name}할인${stampLog.logMeta.discount.amount}`
+          : "";
+        const deliveryFeeTag =
+          (stampLog.logMeta.deliveryFee ?? 0) > 0
+            ? `${
+                stampLog.logMeta.deliveryMethod === "delivery"
+                  ? "배달비"
+                  : "택배비"
+              }${stampLog.logMeta.deliveryFee}`
+            : "";
+        const hasSavedTransactionTags = Boolean(discountTag || deliveryFeeTag);
+        const transactionCloseIndex = hasSavedTransactionTags
+          ? stampLog.note.indexOf(")")
+          : -1;
+        const itemNote =
+          transactionCloseIndex >= 0
+            ? stampLog.note.slice(transactionCloseIndex + 1).trimStart()
+            : stampLog.note;
+        const transactionTags = [
+          discountTag,
+          reservationTag,
+          deliveryFeeTag,
+        ].filter(Boolean);
+        const nextNote =
+          transactionTags.length > 0
+            ? `${transactionTags.join(",")})${itemNote ? ` ${itemNote}` : ""}`
+            : itemNote;
         await onConfirm(
-          stampLog.note,
+          nextNote,
           stampLog.paymentType,
           stampLog.amount,
-          stampLog.logMeta,
+          {
+            ...stampLog.logMeta,
+            reservationDate: reservationTag
+              ? reservationDate.trim()
+              : undefined,
+          },
           undefined,
           isReservation,
         );
@@ -120,29 +225,51 @@ export default function StampConfirmModal({
   };
 
   const reservationToggle = (
-    <div className="flex h-full items-center justify-between gap-3 rounded-lg border border-brand-200 bg-brand-50/60 px-4 py-3">
-      <div>
-        <p className="text-sm font-medium text-gray-800">출고 예약</p>
-        <p className="mt-0.5 text-xs text-gray-500">
-          예약으로 저장하면 스탬프는 적립되지 않고, 예약 이력에서 확정 시 출고
-          이력으로 반영됩니다.
-        </p>
+    <div className="h-full rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <p className="mb-2 text-sm font-semibold text-gray-800">출고 방식</p>
+      <div className="grid grid-cols-[minmax(0,1fr)_110px] items-center gap-2">
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant={!isReservation ? "primary" : "gray"}
+            className="rounded-lg"
+            onClick={() => {
+              setIsReservation(false);
+              setReservationDate("");
+            }}
+          >
+            즉시 출고
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant={isReservation ? "primary" : "gray"}
+            className="rounded-lg"
+            onClick={() => setIsReservation(true)}
+          >
+            예약 출고
+          </Button>
+        </div>
+        {isReservation ? (
+          <input
+            type="text"
+            inputMode="numeric"
+            value={reservationDate}
+            onChange={(event) => {
+              const value = event.target.value;
+              if (/^[0-9/]*$/.test(value) && value.length <= 5) {
+                setReservationDate(value);
+              }
+            }}
+            placeholder="ex) 7/19"
+            aria-label="예약 출고 날짜"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none transition placeholder:text-gray-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+          />
+        ) : (
+          <div aria-hidden="true" className="h-11" />
+        )}
       </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={isReservation}
-        onClick={() => setIsReservation((v) => !v)}
-        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
-          isReservation ? "bg-brand-500" : "bg-gray-300"
-        }`}
-      >
-        <span
-          className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
-            isReservation ? "translate-x-5" : "translate-x-0.5"
-          }`}
-        />
-      </button>
     </div>
   );
 
@@ -223,8 +350,9 @@ export default function StampConfirmModal({
         <TargetCustomerCard
           name={target.name}
           phone={target.phone}
+          address={target.address}
           note={target.note}
-          className="shrink-0 mb-4"
+          className="mr-1 mb-4 shrink-0"
         />
       )}
 
@@ -237,165 +365,418 @@ export default function StampConfirmModal({
           reservationSlot={reservationToggle}
           customerMode={customerMode}
           isStampAmountEditable={customerMode !== "x"}
+          currentStampCount={stampCount}
+          customerAddress={target.address}
         />
 
         {addStep === 3 && (
-          <div className="space-y-3">
-            {isReservation && (
-              <div className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700">
-                예약 이력으로 저장됩니다
-              </div>
-            )}
-            <div
-              className={`grid grid-cols-1 gap-4 ${usesStandardSalesFlow ? "lg:grid-cols-2 lg:items-start" : ""}`}
-            >
-              {usesStandardSalesFlow && (
-                <div className="bg-brand-50 rounded-lg p-4 border border-brand-200 space-y-2">
-                  {stampLog && (
-                    <>
-                      <div>
-                        <span className="text-sm font-medium text-gray-600">
-                          매장:
-                        </span>
-                        <p className="text-base font-semibold text-gray-900">
-                          {stampLog.storeLabel}
-                        </p>
-                      </div>
-                      {usesStandardSalesFlow && (
-                        <div>
-                          <span className="text-sm font-medium text-gray-600">
-                            스탬프 개수:
-                          </span>
-                          <p className="text-base font-semibold text-gray-900">
-                            {stampLog.amount === 0
-                              ? "미적립"
-                              : `${stampLog.amount}개`}
-                          </p>
-                        </div>
-                      )}
-                      <div>
-                        <span className="text-sm font-medium text-gray-600">
-                          결제 유형:
-                        </span>
-                        <p className="text-base font-semibold text-gray-900">
-                          {stampLog.paymentTypeName}
-                        </p>
-                      </div>
-                      {usesStandardSalesFlow && (
-                        <div>
-                          <span className="text-sm font-medium text-gray-600">
-                            금액:
-                          </span>
-                          <p className="text-base font-semibold text-gray-900">
-                            {stampLog.finalAmountExpression || "0"} ={" "}
-                            {formatAmount(stampLog.finalAmount)}
-                          </p>
-                        </div>
-                      )}
-                      {stampLog.logMeta.discount && (
-                        <div>
-                          <span className="text-sm font-medium text-gray-600">
-                            할인:
-                          </span>
-                          <p className="text-base font-semibold text-gray-900">
-                            {stampLog.logMeta.discount.name}{" "}
-                            {formatAmount(stampLog.logMeta.discount.amount)}원
-                          </p>
-                        </div>
-                      )}
-                      {stampLog.logMeta.extraNote && (
-                        <div>
-                          <span className="text-sm font-medium text-gray-600">
-                            출고 특이사항:
-                          </span>
-                          <p className="text-sm text-gray-900 whitespace-pre-wrap">
-                            {stampLog.logMeta.extraNote}
-                          </p>
-                        </div>
-                      )}
-                    </>
-                  )}
-                </div>
-              )}
-              <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-                <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
-                  <h3 className="text-sm font-semibold text-gray-900">
-                    품목 목록{" "}
-                    <span className="font-normal text-gray-500">
-                      {stampLog?.logMeta.items?.length ?? 0}개
-                    </span>
-                  </h3>
-                </div>
-                <div className="max-h-[360px] space-y-2 overflow-y-auto p-3">
-                  {stampLog?.logMeta.items?.map((item, index) => (
+          <div className="space-y-4">
+            {stampLog && usesStandardSalesFlow && (
+              <>
+                <div
+                  className={`grid grid-cols-2 gap-2 ${
+                    customerMode === "x"
+                      ? "md:grid-cols-4"
+                      : "md:grid-cols-5"
+                  }`}
+                >
+                  {[
+                    {
+                      label: "출고 방식",
+                      value: isReservation
+                        ? `${reservationDate} 예약 출고`
+                        : "즉시 출고",
+                    },
+                    { label: "출고 매장", value: stampLog.storeLabel },
+                    {
+                      label: "수령 방식",
+                      value:
+                        stampLog.logMeta.deliveryMethod === "parcel"
+                          ? "택배"
+                          : stampLog.logMeta.deliveryMethod === "delivery"
+                            ? "배달"
+                            : "매장방문",
+                    },
+                    ...(customerMode === "x"
+                      ? []
+                      : [
+                          {
+                            label: "스탬프 적립",
+                            value:
+                              stampLog.amount === 0
+                                ? "미적립"
+                                : `${stampLog.amount}개`,
+                          },
+                        ]),
+                    {
+                      label: "결제 정보",
+                      value: stampLog.logMeta.payments?.length
+                        ? stampLog.logMeta.payments
+                            .map((payment) => payment.paymentTypeName)
+                            .join(" · ")
+                        : stampLog.paymentTypeName,
+                    },
+                  ].map((summary) => (
                     <div
-                      key={`${item.itemId}-${index}`}
-                      className="flex items-start gap-2 rounded-lg border border-gray-200 px-3 py-2.5"
+                      key={summary.label}
+                      className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2.5"
                     >
-                      <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-500 text-xs font-semibold text-white">
-                        {index + 1}
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex min-w-0 items-start gap-2">
-                          <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600">
-                            {item.itemCategoryName ?? "미분류"}
-                          </span>
-                          <p className="min-w-0 break-words text-sm font-medium text-gray-900">
-                            {item.lineText}
-                          </p>
-                        </div>
-                        {usesStandardSalesFlow && (
-                          <p className="mt-1 text-xs text-gray-500">
-                            개별단가 {formatAmount(item.unitPrice)}원 / 총금액{" "}
-                            {formatAmount(item.amount)}원
-                          </p>
-                        )}
-                      </div>
+                      <p className="text-xs font-medium text-gray-500">
+                        {summary.label}
+                      </p>
+                      <p className="mt-1 text-sm font-semibold text-gray-900">
+                        {summary.value}
+                      </p>
                     </div>
                   ))}
                 </div>
+
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-4">
+                  {stampLog.logMeta.deliveryMethod !== "store_visit" && (
+                    <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
+                      <p className="text-xs font-medium text-gray-500">
+                        {stampLog.logMeta.deliveryMethod === "delivery"
+                          ? "배달비"
+                          : "택배비"}
+                      </p>
+                      <p className="mt-1 text-sm font-semibold text-gray-900">
+                        {formatAmount(stampLog.logMeta.deliveryFee ?? 0)}원
+                      </p>
+                    </div>
+                  )}
+                  {stampLog.logMeta.deliveryMethod !== "store_visit" && (
+                    <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 md:col-span-2">
+                      <p className="text-xs font-medium text-gray-500">
+                        배송 주소
+                      </p>
+                      <p className="mt-1 break-words text-sm text-gray-800">
+                        {stampLog.logMeta.deliveryAddress}
+                      </p>
+                    </div>
+                  )}
+                  <div
+                    className={`rounded-lg border border-gray-200 bg-white px-3 py-2.5 ${
+                      stampLog.logMeta.deliveryMethod === "store_visit"
+                        ? "md:col-span-4"
+                        : ""
+                    }`}
+                  >
+                    <p className="text-xs font-medium text-gray-500">
+                      출고 메모
+                    </p>
+                    <p className="mt-1 whitespace-pre-wrap break-words text-sm text-gray-800">
+                      {stampLog.logMeta.extraNote || "없음"}
+                    </p>
+                  </div>
+                </div>
+              </>
+            )}
+
+            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+              <div className="flex items-center gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3">
+                <h3 className="text-sm font-semibold text-gray-900">
+                  품목 목록
+                </h3>
+                <span className="text-xs text-gray-500">
+                  {
+                    new Set(
+                      stampLog?.logMeta.items?.map((item) => item.itemId) ?? [],
+                    ).size
+                  }
+                  종 · 총{" "}
+                  {stampLog?.logMeta.items?.reduce(
+                    (sum, item) => sum + item.quantity,
+                    0,
+                  ) ?? 0}
+                  개
+                </span>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[760px] table-fixed text-sm">
+                  <thead className="bg-gray-50 text-xs font-semibold text-gray-600">
+                    <tr className="border-b border-gray-200">
+                      <th className="w-[6%] px-2 py-2 text-center">번호</th>
+                      <th className="w-[33%] px-2 py-2 text-left">품목명</th>
+                      <th className="w-[13%] px-2 py-2 text-center">
+                        품목종류
+                      </th>
+                      <th className="w-[13%] px-2 py-2 text-center">
+                        출고 유형
+                      </th>
+                      <th className="w-[8%] px-2 py-2 text-center">수량</th>
+                      <th className="w-[13%] px-2 py-2 text-right">단가</th>
+                      <th className="w-[14%] px-3 py-2 text-right">소계</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stampLog?.logMeta.items?.map((item, index) => {
+                      const memo = getItemDisplayMemo(item);
+                      return (
+                        <tr
+                          key={`${item.itemId}-${index}`}
+                          className="border-b border-gray-200 last:border-b-0"
+                        >
+                          <td className="px-2 py-2">
+                            <span className="mx-auto flex h-5 w-5 items-center justify-center rounded-full bg-brand-500 text-xs font-semibold leading-none text-white">
+                              {index + 1}
+                            </span>
+                          </td>
+                          <td className="px-2 py-2 font-medium text-gray-900">
+                            <div className="flex flex-wrap items-center gap-x-1.5">
+                              <span className="break-words">
+                                {item.itemName}
+                              </span>
+                              {memo && (
+                                <span className="break-words text-xs font-normal text-gray-500">
+                                  ({memo})
+                                </span>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-2 py-2 text-center text-xs font-medium text-gray-600">
+                            {item.itemCategoryName ?? "미분류"}
+                          </td>
+                          <td className="px-2 py-2 text-center">
+                            <span
+                              className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold ${getShipmentTypeClassName(item)}`}
+                            >
+                              {getShipmentTypeLabel(item)}
+                            </span>
+                          </td>
+                          <td className="px-2 py-2 text-center font-medium text-gray-800">
+                            {item.quantity}개
+                          </td>
+                          <td className="px-2 py-2 text-right text-gray-700">
+                            {formatAmount(
+                              typeof item.adjustedUnitPrice === "number"
+                                ? item.adjustedUnitPrice
+                                : item.unitPrice,
+                            )}
+                            원
+                          </td>
+                          <td className="px-3 py-2 text-right font-medium text-gray-900">
+                            {formatAmount(item.amount)}원
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
               </div>
             </div>
+
           </div>
         )}
       </div>
 
-      <div className="shrink-0 flex items-center justify-end gap-3 pt-4 mt-4 border-t border-gray-200">
-        {addStep > 1 && (
-          <Button
-            variant="gray"
-            size="sm"
-            onClick={() => {
-              if (addStep === 3) setAddStep(2);
-              else if (usesStandardSalesFlow) setAddStep(1);
-              else onCancel();
-            }}
-            disabled={isSubmitting}
-          >
-            이전
-          </Button>
-        )}
-        {addStep < 3 ? (
-          <Button
-            size="sm"
-            disabled={
-              addStep === 1
-                ? !formValidity.hasPaymentType
-                : !formValidity.hasItems
-            }
-            onClick={() => setAddStep((s) => (s === 1 ? 2 : 3))}
-          >
-            다음
-          </Button>
+      <div className="mt-4 flex shrink-0 flex-col gap-4 border-t border-gray-200 pt-4 lg:flex-row lg:items-center lg:justify-between">
+        {addStep === 2 && usesStandardSalesFlow && stampLog ? (
+          <div className="grid flex-1 grid-cols-2 items-center gap-x-5 gap-y-3 lg:grid-cols-[1fr_1.2fr_1fr_0.8fr_1.2fr]">
+            <div>
+              <p className="text-xs text-gray-500">품목 수량</p>
+              <p className="mt-0.5 text-sm font-semibold text-gray-900">
+                총{" "}
+                {
+                  new Set(
+                    stampLog.logMeta.items?.map((item) => item.itemId) ?? [],
+                  ).size
+                }
+                종 ·{" "}
+                {stampLog.logMeta.items?.reduce(
+                  (sum, item) => sum + item.quantity,
+                  0,
+                ) ?? 0}
+                개
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">결제방식</p>
+              <p className="mt-0.5 text-sm font-semibold text-gray-900">
+                {stampLog.logMeta.payments?.length
+                  ? stampLog.logMeta.payments
+                      .map((payment) => payment.paymentTypeName)
+                      .join(" · ")
+                  : stampLog.paymentTypeName}
+              </p>
+              {stampLog.logMeta.payments?.length ? (
+                <p className="mt-0.5 break-words text-xs text-gray-500">
+                  {stampLog.logMeta.payments
+                    .map(
+                      (payment) =>
+                        `${payment.paymentTypeName} ${formatAmount(payment.amount)}원`,
+                    )
+                    .join(" · ")}
+                </p>
+              ) : null}
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">상품 합계</p>
+              <p className="mt-0.5 text-base font-semibold text-gray-900">
+                {formatAmount(
+                  stampLog.logMeta.items?.reduce(
+                    (sum, item) => sum + item.amount,
+                    0,
+                  ) ?? 0,
+                )}
+                원
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">할인</p>
+              <p className="mt-0.5 text-base font-semibold text-gray-900">
+                {stampLog.logMeta.discount
+                  ? `${stampLog.logMeta.discount.name} ${formatAmount(stampLog.logMeta.discount.amount)}원`
+                  : "0원"}
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs font-semibold text-brand-600">
+                최종 결제금액
+              </p>
+              <p className="mt-0.5 text-lg font-bold text-brand-600">
+                {formatAmount(stampLog.finalAmount)}원
+              </p>
+            </div>
+          </div>
+        ) : addStep === 3 && usesStandardSalesFlow && stampLog ? (
+          <div className="grid flex-1 grid-cols-2 items-center gap-x-5 gap-y-3 lg:grid-cols-[1fr_1.2fr_1fr_0.8fr_1.2fr]">
+            <div>
+              <p className="text-xs text-gray-500">품목 수량</p>
+              <p className="mt-0.5 text-sm font-semibold text-gray-900">
+                총{" "}
+                {
+                  new Set(
+                    stampLog.logMeta.items?.map((item) => item.itemId) ?? [],
+                  ).size
+                }
+                종 ·{" "}
+                {stampLog.logMeta.items?.reduce(
+                  (sum, item) => sum + item.quantity,
+                  0,
+                ) ?? 0}
+                개
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">결제방식</p>
+              <p className="mt-0.5 text-sm font-semibold text-gray-900">
+                {stampLog.logMeta.payments?.length
+                  ? stampLog.logMeta.payments
+                      .map((payment) => payment.paymentTypeName)
+                      .join(" · ")
+                  : stampLog.paymentTypeName}
+              </p>
+              {stampLog.logMeta.payments?.length ? (
+                <p className="mt-0.5 break-words text-xs text-gray-500">
+                  {stampLog.logMeta.payments
+                    .map(
+                      (payment) =>
+                        `${payment.paymentTypeName} ${formatAmount(payment.amount)}원`,
+                    )
+                    .join(" · ")}
+                </p>
+              ) : null}
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">상품 합계</p>
+              <p className="mt-0.5 text-base font-semibold text-gray-900">
+                {formatAmount(
+                  stampLog.logMeta.items?.reduce(
+                    (sum, item) => sum + item.amount,
+                    0,
+                  ) ?? 0,
+                )}
+                원
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs text-gray-500">할인</p>
+              <p className="mt-0.5 text-base font-semibold text-gray-900">
+                {stampLog.logMeta.discount
+                  ? `${stampLog.logMeta.discount.name} ${formatAmount(stampLog.logMeta.discount.amount)}원`
+                  : "0원"}
+              </p>
+            </div>
+            <div className="border-l border-gray-200 pl-5">
+              <p className="text-xs font-semibold text-brand-600">
+                최종 결제금액
+              </p>
+              <p className="mt-0.5 text-lg font-bold text-brand-600">
+                {formatAmount(stampLog.finalAmount)}원
+              </p>
+            </div>
+          </div>
         ) : (
-          <Button
-            size="sm"
-            disabled={!stampLog || isSubmitting}
-            onClick={handleConfirm}
-          >
-            {isSubmitting ? "처리 중..." : "확인"}
-          </Button>
+          <div />
         )}
+
+        <div className="flex shrink-0 items-center justify-end gap-3">
+          {addStep > 1 && (
+            <Button
+              variant="gray"
+              size="sm"
+              onClick={() => {
+                if (addStep === 3) setAddStep(2);
+                else if (usesStandardSalesFlow) setAddStep(1);
+                else onCancel();
+              }}
+              disabled={isSubmitting}
+            >
+              이전
+            </Button>
+          )}
+          {addStep < 3 ? (
+            addStep === 1 && !formValidity.hasCompletedBasicSequence ? null : (
+              <Button
+                size="sm"
+                disabled={
+                  addStep === 1
+                    ? !formValidity.hasCompletedBasicSequence
+                    : !formValidity.hasItems || !hasValidSplitPaymentAmounts
+                }
+                onClick={() => {
+                  if (addStep === 2 && !hasValidReservationDate) {
+                    toast.error("예약 날짜를 7/19 형식으로 입력해 주세요.");
+                    return;
+                  }
+                  if (addStep === 2 && stampLog?.logMeta.payments?.length) {
+                    if (
+                      stampLog.logMeta.payments.some(
+                        (payment) => payment.amount < 1,
+                      )
+                    ) {
+                      toast.error(
+                        "선택한 모든 결제방식에 1원 이상 입력해 주세요.",
+                      );
+                      return;
+                    }
+                    const splitTotal = stampLog.logMeta.payments.reduce(
+                      (sum, payment) => sum + payment.amount,
+                      0,
+                    );
+                    if (splitTotal !== stampLog.finalAmount) {
+                      toast.error(
+                        `분할결제 합계 ${formatAmount(splitTotal)}원과 결제금액 ${formatAmount(stampLog.finalAmount)}원이 일치해야 합니다.`,
+                      );
+                      return;
+                    }
+                  }
+                  setAddStep((s) => (s === 1 ? 2 : 3));
+                }}
+              >
+                다음
+              </Button>
+            )
+          ) : (
+            <Button
+              size="sm"
+              disabled={!stampLog || isSubmitting}
+              onClick={handleConfirm}
+            >
+              {isSubmitting ? "처리 중..." : "확인"}
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -414,6 +795,7 @@ export default function StampConfirmModal({
       <TargetCustomerCard
         name={target.name}
         phone={target.phone}
+        address={target.address}
         note={target.note}
         className="shrink-0 mb-4"
       />
@@ -480,6 +862,7 @@ export default function StampConfirmModal({
           <TargetCustomerCard
             name={target.name}
             phone={target.phone}
+            address={target.address}
             note={target.note}
             className="mb-4"
           />

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -24,7 +24,6 @@ const ovapePaymentTypes = [
   PaymentTypeEnum.KAKAOTALK,
   PaymentTypeEnum.CASH_RECEIPT,
   PaymentTypeEnum.TRANSFER_CASH_RECEIPT,
-  PaymentTypeEnum.SHIPMENT_REMARK,
 ];
 
 const eguVapePaymentTypes = [
@@ -32,7 +31,6 @@ const eguVapePaymentTypes = [
   PaymentTypeEnum.EGU_TRANSFER,
   PaymentTypeEnum.EGU_CASH,
   PaymentTypeEnum.EGU_CASH_RECEIPT,
-  PaymentTypeEnum.SHIPMENT_REMARK,
 ];
 
 const paymentTypesByStore = {
@@ -45,8 +43,8 @@ const remarkOptions = [
   { value: "service", name: "서비스" },
   { value: "exchange_in", name: "교환입고" },
   { value: "exchange_out", name: "교환출고" },
-  { value: "custom", name: "메모 직접 입력" },
-  { value: "price_adjust", name: "가격 조정" },
+  { value: "custom", name: "메모입력" },
+  { value: "price_adjust", name: "가격조정" },
 ] as const;
 
 type RemarkOptionValue =
@@ -62,6 +60,7 @@ const discountOptions = [
 ] as const;
 
 type DiscountOptionValue = (typeof discountOptions)[number]["value"];
+type DeliveryMethod = "store_visit" | "parcel" | "delivery";
 
 type DraftStampLogLine = StampLogItem & {
   id: string;
@@ -106,6 +105,8 @@ export default function StampLogForm({
   onValidityChange,
   reservationSlot,
   customerMode = "normal",
+  currentStampCount = 0,
+  customerAddress,
 }: {
   onChange: (value: StampLogValue | null) => void;
   initialValue?: StampLogFormInitialValue;
@@ -129,18 +130,62 @@ export default function StampLogForm({
   onValidityChange?: (info: {
     hasPaymentType: boolean;
     hasItems: boolean;
+    hasDeliveryInfo: boolean;
+    hasCompletedBasicSequence: boolean;
   }) => void;
   /** step 모드에서 2번 스텝의 출고 특이사항 입력 오른쪽에 함께 렌더링할 요소 (예: 출고 예약 토글) */
   reservationSlot?: React.ReactNode;
   customerMode?: CustomerMode;
+  currentStampCount?: number;
+  customerAddress?: string | null;
 }) {
   const [paymentType, setPaymentType] = useState<
     PaymentTypeEnumType["value"] | ""
   >(initialValue?.paymentType ?? "");
-  const [amount, setAmount] = useState<number>(initialValue?.amount ?? 0);
+  const [amount, setAmount] = useState<number>(
+    customerMode === "x" ? 0 : (initialValue?.amount ?? 0),
+  );
+  const [paymentMode, setPaymentMode] = useState<
+    "single" | "split" | "remark"
+  >(
+    initialValue?.logMeta?.payments?.length
+      ? "split"
+      : initialValue?.paymentType === PaymentTypeEnum.SHIPMENT_REMARK.value
+        ? "remark"
+        : "single",
+  );
+  const [splitPayments, setSplitPayments] = useState<
+    Array<{
+      paymentType: PaymentTypeEnumType["value"];
+      paymentTypeName: string;
+      amount: number;
+    }>
+  >(initialValue?.logMeta?.payments ?? []);
   const [storeName, setStoreName] = useState<StoreTypeEnumType["value"]>(
     initialValue?.storeName ?? StoreTypeEnum.OVAPE.value,
   );
+  const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethod>(
+    initialValue?.logMeta?.deliveryMethod ?? "store_visit",
+  );
+  const [hasConfirmedStore, setHasConfirmedStore] = useState(true);
+  const [hasConfirmedDeliveryMethod, setHasConfirmedDeliveryMethod] = useState(
+    Boolean(initialValue),
+  );
+  const [deliveryAddressSource, setDeliveryAddressSource] = useState<
+    "registered" | "new"
+  >(
+    initialValue?.logMeta?.deliveryAddressSource ?? "new",
+  );
+  const [deliveryAddress, setDeliveryAddress] = useState(
+    initialValue?.logMeta?.deliveryAddress ?? "",
+  );
+  const [deliveryFeeInput, setDeliveryFeeInput] = useState(
+    initialValue?.logMeta?.deliveryFee === undefined
+      ? ""
+      : String(initialValue.logMeta.deliveryFee),
+  );
+  const deliveryFee =
+    deliveryFeeInput === "" ? 0 : Number(deliveryFeeInput);
   const [itemSearch, setItemSearch] = useState("");
   const [selectedItem, setSelectedItem] = useState<ItemType | null>(null);
   const [showItemResults, setShowItemResults] = useState(false);
@@ -151,6 +196,7 @@ export default function StampLogForm({
   const [priceAdjustAmount, setPriceAdjustAmount] = useState("0");
   const [priceAdjustMemo, setPriceAdjustMemo] = useState("");
   const [operationMemo, setOperationMemo] = useState("");
+  const [editingLineId, setEditingLineId] = useState<string | null>(null);
   const [draftLines, setDraftLines] = useState<DraftStampLogLine[]>(
     () =>
       initialValue?.logMeta?.items?.map((item, index) => ({
@@ -175,7 +221,7 @@ export default function StampLogForm({
     initialValue?.logMeta?.extraNote ?? "",
   );
   const itemSearchRef = useRef<HTMLDivElement>(null);
-  const lineRefs = useRef(new Map<string, HTMLDivElement>());
+  const lineRefs = useRef(new Map<string, HTMLElement>());
   const previousLineRectsRef = useRef(new Map<string, DOMRect>());
 
   const itemFilters = useMemo(
@@ -210,20 +256,62 @@ export default function StampLogForm({
     (option) => option.value === discountType,
   )?.name;
   const activeDiscountAmount = discountLabel ? discountAmount : 0;
-  const discountLine =
+  const activeDeliveryFee =
+    deliveryMethod === "store_visit" ? 0 : deliveryFee;
+  const discountTag =
     discountLabel && activeDiscountAmount > 0
-      ? `${discountLabel}할인${activeDiscountAmount})`
+      ? `${discountLabel}할인${activeDiscountAmount}`
       : "";
+  const discountLine = discountTag ? `${discountTag})` : "";
+  const deliveryFeeLabel =
+    deliveryMethod === "parcel"
+      ? "택배비"
+      : deliveryMethod === "delivery"
+        ? "배달비"
+        : "";
+  const deliveryFeeTag =
+    deliveryFeeLabel && activeDeliveryFee > 0
+      ? `${deliveryFeeLabel}${activeDeliveryFee}`
+      : "";
+  const transactionTags = [discountTag, deliveryFeeTag].filter(Boolean);
+  const transactionNote =
+    transactionTags.length > 0 ? `${transactionTags.join(",")})` : "";
   const itemNote = draftLines.map((line) => line.lineText).join(", ");
-  const generatedNote = [discountLine, itemNote].filter(Boolean).join(" ");
+  const generatedNote = [transactionNote, itemNote]
+    .filter(Boolean)
+    .join(" ");
   const finalAmount = totalAmount - activeDiscountAmount;
+  const splitPaymentTotal = splitPayments.reduce(
+    (sum, payment) => sum + payment.amount,
+    0,
+  );
+  const splitPaymentDifference = finalAmount - splitPaymentTotal;
+  const hasAmountForEverySplitPayment =
+    splitPayments.length >= 2 &&
+    splitPayments.every((payment) => payment.amount >= 1);
+  const splitPaymentMatches =
+    hasAmountForEverySplitPayment && splitPaymentDifference === 0;
   const amountExpression = draftLines
     .map((line) => formatAmount(line.amount))
     .join(" + ");
-  const finalAmountExpression =
+  const finalAmountExpression = [
+    amountExpression || "0",
     activeDiscountAmount > 0
-      ? `${amountExpression || "0"} - ${formatAmount(activeDiscountAmount)}`
-      : amountExpression;
+      ? `- ${formatAmount(activeDiscountAmount)}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const hasSelectedSplitPayments = splitPayments.length >= 2;
+  const hasValidPayment =
+    paymentMode === "remark"
+      ? true
+      : paymentMode === "split"
+        ? hasSelectedSplitPayments
+        : paymentType !== "";
+  const hasValidDeliveryInfo =
+    deliveryMethod === "store_visit" ||
+    (deliveryAddress.trim().length > 0 && deliveryFeeInput !== "");
 
   useEffect(() => {
     if (!isNonSalesSpecialCustomer) return;
@@ -232,6 +320,10 @@ export default function StampLogForm({
     setDiscountType("");
     setDiscountAmount(0);
   }, [isNonSalesSpecialCustomer]);
+
+  useEffect(() => {
+    if (customerMode === "x") setAmount(0);
+  }, [customerMode]);
 
   useEffect(() => {
     if (customerMode === "demo") setRemarkType("demo");
@@ -248,6 +340,7 @@ export default function StampLogForm({
     setPriceAdjustAmount("0");
     setPriceAdjustMemo("");
     setOperationMemo("");
+    setEditingLineId(null);
   };
 
   const getItemLabel = (item: ItemType) => {
@@ -279,7 +372,7 @@ export default function StampLogForm({
   onChangeRef.current = onChange;
 
   useEffect(() => {
-    if (paymentType === "" || draftLines.length === 0) {
+    if (!hasValidPayment || draftLines.length === 0) {
       onChangeRef.current(null);
       return;
     }
@@ -288,6 +381,19 @@ export default function StampLogForm({
       storeName,
       totalAmount: finalAmount,
       extraNote: extraNote.trim() || undefined,
+      deliveryMethod,
+      deliveryAddressSource:
+        deliveryMethod === "store_visit" ? undefined : deliveryAddressSource,
+      deliveryAddress:
+        deliveryMethod === "store_visit"
+          ? undefined
+          : deliveryAddress.trim() || undefined,
+      deliveryFee:
+        deliveryMethod === "store_visit" ? undefined : activeDeliveryFee,
+      payments:
+        paymentMode === "split" && hasSelectedSplitPayments
+          ? splitPayments
+          : undefined,
       discount:
         discountLabel && activeDiscountAmount > 0
           ? {
@@ -313,9 +419,19 @@ export default function StampLogForm({
 
     onChangeRef.current({
       note: generatedNote,
-      paymentType,
+      paymentType:
+        paymentMode === "remark"
+          ? PaymentTypeEnum.SHIPMENT_REMARK.value
+          : paymentMode === "split"
+            ? splitPayments[0].paymentType
+            : (paymentType as PaymentTypeEnumType["value"]),
       paymentTypeName:
-        paymentTypeOptions.find((o) => o.value === paymentType)?.name ?? "",
+        paymentMode === "remark"
+          ? PaymentTypeEnum.SHIPMENT_REMARK.name
+          : paymentMode === "split"
+            ? "분할결제"
+            : (paymentTypeOptions.find((o) => o.value === paymentType)?.name ??
+              ""),
       amount,
       logMeta,
       storeName,
@@ -330,6 +446,13 @@ export default function StampLogForm({
     paymentType,
     draftLines,
     storeName,
+    deliveryMethod,
+    deliveryAddressSource,
+    deliveryAddress,
+    deliveryFee,
+    activeDeliveryFee,
+    deliveryFeeTag,
+    transactionNote,
     amount,
     finalAmount,
     finalAmountExpression,
@@ -339,6 +462,10 @@ export default function StampLogForm({
     discountType,
     discountLine,
     extraNote,
+    paymentMode,
+    splitPayments,
+    hasValidPayment,
+    hasSelectedSplitPayments,
   ]);
 
   // 스텝 UI에서 "다음" 버튼 활성화 여부를 부모가 판단할 수 있도록 알림
@@ -347,10 +474,22 @@ export default function StampLogForm({
 
   useEffect(() => {
     onValidityChangeRef.current?.({
-      hasPaymentType: paymentType !== "",
+      hasPaymentType: hasValidPayment,
       hasItems: draftLines.length > 0,
+      hasDeliveryInfo: hasValidDeliveryInfo,
+      hasCompletedBasicSequence:
+        hasConfirmedStore &&
+        hasConfirmedDeliveryMethod &&
+        hasValidDeliveryInfo &&
+        hasValidPayment,
     });
-  }, [paymentType, draftLines]);
+  }, [
+    hasValidPayment,
+    hasValidDeliveryInfo,
+    hasConfirmedStore,
+    hasConfirmedDeliveryMethod,
+    draftLines,
+  ]);
 
   const handleItemSelect = (item: ItemType) => {
     setSelectedItem(item);
@@ -361,7 +500,7 @@ export default function StampLogForm({
       item.item_categories?.name.trim() === "기기"
     ) {
       setRemarkType("custom");
-      toast("메모 직접 입력에 박스보관유무를 적어주세요.", {
+      toast("메모입력에 박스보관유무를 적어주세요.", {
         icon: "📦",
       });
     }
@@ -403,14 +542,13 @@ export default function StampLogForm({
               : ""
           : isExchange
             ? `${exchangeLabel}${exchangeMemo.trim() ? `(${exchangeMemo.trim()})` : ""}`
-            : remarkType === "custom"
-              ? customRemark.trim()
-              : remarkType === "price_adjust"
-                ? priceAdjustmentMemo
-                : remarkType === ""
-                  ? ""
-                  : (remarkOptions.find((option) => option.value === remarkType)
-                      ?.name ?? "");
+            : remarkType === "service"
+              ? `서비스${customRemark.trim() ? `(${customRemark.trim()})` : ""}`
+              : remarkType === "custom"
+                ? customRemark.trim()
+                : remarkType === "price_adjust"
+                  ? priceAdjustmentMemo
+                  : "";
     const isFreeRemark =
       isNonSalesSpecialCustomer || remarkType === "service" || isExchange;
     const lineAmount = isFreeRemark
@@ -426,10 +564,8 @@ export default function StampLogForm({
       remarkText ? ` (${remarkText})` : ""
     }`;
 
-    setDraftLines((prev) => [
-      ...prev,
-      {
-        id: `${selectedItem.id}-${Date.now()}`,
+    const nextLine: DraftStampLogLine = {
+        id: editingLineId ?? `${selectedItem.id}-${Date.now()}`,
         itemId: selectedItem.id,
         itemName: selectedItem.item_name,
         itemCategoryName: selectedItem.item_categories?.name ?? null,
@@ -451,12 +587,117 @@ export default function StampLogForm({
                   : remarkType === "adjustment_out"
                     ? "adjustment_out"
                     : "out",
-      },
-    ]);
+      };
+
+    setDraftLines((prev) =>
+      editingLineId
+        ? prev.map((line) => (line.id === editingLineId ? nextLine : line))
+        : [...prev, nextLine],
+    );
     resetLineInputs();
   };
 
-  const setLineRef = (id: string) => (node: HTMLDivElement | null) => {
+  const handleEditLine = (line: DraftStampLogLine) => {
+    const item: ItemType = items.find(
+      (candidate) => candidate.id === line.itemId,
+    ) ?? {
+      id: line.itemId,
+      category_id: null,
+      item_code: "",
+      item_name: line.itemName,
+      purchase_price: null,
+      selling_price: line.unitPrice,
+      liquid_type: null,
+      liquid_flavor: null,
+      note: null,
+      is_use: true,
+      created_at: "",
+      updated_at: "",
+      item_categories: line.itemCategoryName
+        ? {
+            id: "",
+            name: line.itemCategoryName,
+            order_index: 0,
+            created_at: "",
+          }
+        : null,
+    };
+
+    setEditingLineId(line.id);
+    setSelectedItem(item);
+    setItemSearch("");
+    setShowItemResults(false);
+    setQuantity(line.quantity);
+    setCustomRemark("");
+    setExchangeMemo("");
+    setPriceAdjustAmount(
+      typeof line.adjustedUnitPrice === "number"
+        ? String(line.adjustedUnitPrice)
+        : "0",
+    );
+    setPriceAdjustMemo("");
+
+    if (line.inventoryAction === "exchange_in") {
+      setRemarkType("exchange_in");
+      setExchangeMemo(line.remark?.match(/^교환입고\((.*)\)$/)?.[1] ?? "");
+    } else if (line.inventoryAction === "exchange_out") {
+      setRemarkType("exchange_out");
+      setExchangeMemo(line.remark?.match(/^교환출고\((.*)\)$/)?.[1] ?? "");
+    } else if (typeof line.adjustedUnitPrice === "number") {
+      setRemarkType("price_adjust");
+      setPriceAdjustMemo(line.remark === "가격 조정" ? "" : (line.remark ?? ""));
+    } else if (line.remark?.startsWith("서비스")) {
+      setRemarkType("service");
+      setCustomRemark(line.remark.match(/^서비스\((.*)\)$/)?.[1] ?? "");
+    } else if (line.remark) {
+      setRemarkType("custom");
+      setCustomRemark(line.remark);
+    } else {
+      setRemarkType("");
+    }
+  };
+
+  const getShipmentTypeLabel = (line: DraftStampLogLine) => {
+    if (line.inventoryAction === "exchange_in") return "교환입고";
+    if (line.inventoryAction === "exchange_out") return "교환출고";
+    if (typeof line.adjustedUnitPrice === "number") return "가격조정";
+    if (line.remark?.startsWith("서비스")) return "서비스";
+    return "일반판매";
+  };
+
+  const getShipmentTypeClassName = (line: DraftStampLogLine) => {
+    const type = getShipmentTypeLabel(line);
+
+    if (type === "서비스") return "bg-sky-50 text-sky-700";
+    if (type === "교환입고") return "bg-emerald-50 text-emerald-700";
+    if (type === "교환출고") return "bg-amber-50 text-amber-700";
+    if (type === "가격조정") return "bg-violet-50 text-violet-700";
+    return "bg-gray-100 text-gray-600";
+  };
+
+  const getLineDisplayMemo = (line: DraftStampLogLine) => {
+    const remark = line.remark?.trim();
+    if (!remark) return "";
+
+    const wrappedMemo = remark.match(
+      /^(?:서비스|교환입고|교환출고)\((.*)\)$/,
+    )?.[1];
+    if (wrappedMemo) return wrappedMemo.trim();
+
+    if (
+      remark === "서비스" ||
+      remark === "교환입고" ||
+      remark === "교환출고" ||
+      remark === "가격 조정" ||
+      remark === "가격조정"
+    ) {
+      return "";
+    }
+
+    return remark;
+  };
+
+  const setLineRef = (id: string) => (node: HTMLElement | null) => {
     if (node) {
       lineRefs.current.set(id, node);
     } else {
@@ -566,11 +807,19 @@ export default function StampLogForm({
   );
 
   const stampCountField = (
-    <div>
-      <label className="block text-sm font-medium text-gray-700 mb-1">
-        스탬프 개수 <span className="text-rose-600">*</span>
-      </label>
-      <div className="flex items-center gap-2">
+    <div className={step === 1 ? "min-w-0 w-full" : undefined}>
+      {step !== 1 && (
+        <label className="mb-1 block text-sm font-medium text-gray-700">
+          스탬프 개수 <span className="text-rose-600">*</span>
+        </label>
+      )}
+      <div
+        className={
+          step === 1
+            ? "grid grid-cols-[minmax(42px,1fr)_32px_32px] items-center gap-1"
+            : "flex items-center gap-2"
+        }
+      >
         <input
           type="text"
           value={amount}
@@ -582,13 +831,13 @@ export default function StampLogForm({
             }
           }}
           disabled={!isStampAmountEditable}
-          className="w-16 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-center disabled:bg-gray-100 disabled:text-gray-500"
+          className={`${step === 1 ? "h-9 w-full" : "w-16 py-2"} rounded-lg border border-gray-300 px-3 text-center text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:bg-gray-100 disabled:text-gray-500`}
         />
         <button
           type="button"
           onClick={() => setAmount((v) => Math.max(0, v - 1))}
           disabled={!isStampAmountEditable}
-          className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 active:bg-gray-100 transition-colors text-lg leading-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex h-9 w-8 items-center justify-center rounded-lg border border-gray-300 bg-white text-lg leading-none text-gray-600 transition-colors hover:bg-gray-50 active:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
         >
           −
         </button>
@@ -596,38 +845,341 @@ export default function StampLogForm({
           type="button"
           onClick={() => setAmount((v) => v + 1)}
           disabled={!isStampAmountEditable}
-          className="w-8 h-8 flex items-center justify-center rounded-lg bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700 transition-colors text-lg leading-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex h-9 w-8 items-center justify-center rounded-lg bg-brand-500 text-lg leading-none text-white transition-colors hover:bg-brand-600 active:bg-brand-700 disabled:cursor-not-allowed disabled:opacity-40"
         >
           +
         </button>
       </div>
       {!isStampAmountEditable ? (
-        <p className="mt-1.5 text-xs text-gray-400">
+        <p className="mt-1.5 whitespace-nowrap text-[10px] text-gray-400">
           {customerMode === "x"
             ? "미적립 고객은 스탬프가 적립되지 않습니다."
             : "수정 시 스탬프 개수는 변경되지 않습니다."}
         </p>
       ) : (
         amount === 0 && (
-          <p className="mt-1.5 text-xs text-gray-400">
-            0개 입력 시{" "}
-            <span className="font-medium text-gray-500">미적립</span>
-            으로 기록됩니다.
+          <p className="mt-1.5 whitespace-nowrap text-[10px] text-gray-400">
+            0개 입력시{" "}
+            <span className="font-medium text-gray-500">미적립 처리됩니다.</span>
           </p>
         )
       )}
     </div>
   );
 
+  const stepOneStoreField = (
+    <div className="grid grid-cols-[140px_minmax(0,1fr)] items-center border-b border-gray-200">
+      <div className="flex h-full items-center border-r border-gray-200 px-4 py-4 text-sm font-bold text-gray-800">
+        <span className="mr-2 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-500 text-[11px] font-bold leading-none text-white">
+          {hasConfirmedStore ? "✓" : "1"}
+        </span>
+        출고 매장 <span className="ml-1 text-rose-600">*</span>
+      </div>
+      <div className="grid grid-cols-2 gap-2 p-4">
+        {Object.values(StoreTypeEnum).map((option) => (
+          <Button
+            key={option.value}
+            type="button"
+            size="sm"
+            variant={
+              hasConfirmedStore && storeName === option.value
+                ? "primary"
+                : "gray"
+            }
+            className="rounded-lg"
+            onClick={() => {
+              setStoreName(option.value);
+              setHasConfirmedStore(true);
+              setHasConfirmedDeliveryMethod(false);
+              setPaymentType("");
+              setSplitPayments([]);
+            }}
+          >
+            {option.name}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+
+  const stepOnePaymentField = (
+    <div className="grid grid-cols-[140px_minmax(0,1fr)] border-b border-gray-200">
+      <div className="flex items-start border-r border-gray-200 px-4 py-5 text-sm font-bold text-gray-800">
+        <span className="mr-2 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-500 text-[11px] font-bold leading-none text-white">
+          {hasValidPayment ? "✓" : "3"}
+        </span>
+        결제 정보 <span className="ml-1 text-rose-600">*</span>
+      </div>
+      <div className="min-w-0 p-4">
+        <div className="grid grid-cols-3 gap-2">
+          {(
+            [
+              { value: "single", label: "단일결제" },
+              { value: "split", label: "분할결제" },
+              { value: "remark", label: "특이사항" },
+            ] as const
+          ).map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              size="sm"
+              variant={paymentMode === option.value ? "primary" : "gray"}
+              className="rounded-lg"
+              onClick={() => {
+                setPaymentMode(option.value);
+                if (option.value === "remark") {
+                  setPaymentType(PaymentTypeEnum.SHIPMENT_REMARK.value);
+                  setSplitPayments([]);
+                } else if (option.value === "single") {
+                  setSplitPayments([]);
+                  if (
+                    paymentType === PaymentTypeEnum.SHIPMENT_REMARK.value
+                  )
+                    setPaymentType("");
+                } else {
+                  setPaymentType("");
+                }
+              }}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+
+        {paymentMode !== "remark" && (
+          <div className="mt-3 border-t border-gray-200 pt-3">
+            <div className="grid grid-cols-3 gap-2">
+              {paymentTypeOptions.map((option) => {
+                const splitPayment = splitPayments.find(
+                  (payment) => payment.paymentType === option.value,
+                );
+                const selected =
+                  paymentMode === "single"
+                    ? paymentType === option.value
+                    : Boolean(splitPayment);
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    size="sm"
+                    variant={selected ? "primary" : "gray"}
+                    onClick={() => {
+                      if (paymentMode === "single") {
+                        setPaymentType(option.value);
+                        return;
+                      }
+                      setSplitPayments((current) =>
+                        current.some(
+                          (payment) => payment.paymentType === option.value,
+                        )
+                          ? current.filter(
+                              (payment) =>
+                                payment.paymentType !== option.value,
+                            )
+                          : [
+                              ...current,
+                              {
+                                paymentType: option.value,
+                                paymentTypeName: option.name,
+                                amount: 0,
+                              },
+                            ],
+                      );
+                    }}
+                  >
+                    <span className="whitespace-nowrap">{option.name}</span>
+                  </Button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const stepOneDeliveryField = (
+    <div className="grid grid-cols-[140px_minmax(0,1fr)] border-b border-gray-200">
+      <div className="flex items-start border-r border-gray-200 px-4 py-5 text-sm font-bold text-gray-800">
+        <span className="mr-2 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-500 text-[11px] font-bold leading-none text-white">
+          {hasConfirmedDeliveryMethod && hasValidDeliveryInfo ? "✓" : "2"}
+        </span>
+        수령 방식 <span className="ml-1 text-rose-600">*</span>
+      </div>
+      <div className="min-w-0 p-4">
+        <div className="grid grid-cols-3 gap-2">
+          {(
+            [
+              { value: "store_visit", label: "매장방문" },
+              { value: "parcel", label: "택배" },
+              { value: "delivery", label: "배달" },
+            ] as const
+          ).map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              size="sm"
+              variant={
+                hasConfirmedDeliveryMethod &&
+                deliveryMethod === option.value
+                  ? "primary"
+                  : "gray"
+              }
+              onClick={() => {
+                setDeliveryMethod(option.value);
+                setHasConfirmedDeliveryMethod(true);
+                setPaymentType("");
+                setSplitPayments([]);
+                if (option.value === "store_visit") {
+                  setDeliveryAddress("");
+                  setDeliveryFeeInput("");
+                }
+              }}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+        {deliveryMethod !== "store_visit" && (
+          <div className="mt-3 grid grid-cols-[72px_minmax(0,1fr)_88px] items-start gap-2 pt-2">
+            <div>
+              <label className="mb-1 block h-4 text-xs font-semibold leading-4 text-gray-600">
+                {deliveryMethod === "parcel" ? "택배비" : "배달비"}
+              </label>
+              <div className="relative">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={5}
+                  value={deliveryFeeInput}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    if (
+                      value === "" ||
+                      (/^[0-9]+$/.test(value) && value.length <= 5)
+                    ) {
+                      setDeliveryFeeInput(value);
+                    }
+                  }}
+                  placeholder="금액"
+                  className="h-20 w-full rounded-lg border border-gray-300 bg-white pl-1.5 pr-6 text-right text-sm outline-none transition placeholder:text-gray-400 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                />
+                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-500">
+                  원
+                </span>
+              </div>
+            </div>
+            <div className="min-w-0">
+              <label className="mb-1 block h-4 text-xs font-semibold leading-4 text-gray-600">
+                배송 주소
+              </label>
+              <textarea
+                value={deliveryAddress}
+                onChange={(event) => setDeliveryAddress(event.target.value)}
+                placeholder={
+                  customerAddress?.trim()
+                    ? "배송 주소를 확인하세요."
+                    : "배송 주소를 입력하세요."
+                }
+                rows={3}
+                className="h-20 w-full resize-none rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm leading-5 outline-none transition placeholder:text-gray-400 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+              />
+            </div>
+            <div>
+              <div aria-hidden="true" className="mb-1 h-4" />
+              <div className="grid h-20 grid-rows-2 gap-2">
+                <Button
+                  type="button"
+                  size="xs"
+                  variant={
+                    deliveryAddressSource === "registered" ? "primary" : "gray"
+                  }
+                  disabled={!customerAddress?.trim()}
+                  onClick={() => {
+                    setDeliveryAddressSource("registered");
+                    setDeliveryAddress(customerAddress?.trim() ?? "");
+                  }}
+                  className="h-9 w-full"
+                >
+                  불러오기
+                </Button>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant={deliveryAddressSource === "new" ? "primary" : "gray"}
+                  onClick={() => {
+                    setDeliveryAddressSource("new");
+                    setDeliveryAddress("");
+                  }}
+                  className="h-9 w-full"
+                >
+                  새로작성
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const stepOneStampField = (
+    <div className="grid grid-cols-[140px_minmax(0,1fr)]">
+      <div className="flex items-start border-r border-gray-200 px-4 py-5 text-sm font-bold text-gray-800">
+        <span className="mr-2 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-500 text-[11px] font-bold leading-none text-white">
+          4
+        </span>
+        스탬프 적립
+      </div>
+      <div className="min-w-0 p-4">
+        <div className="grid grid-cols-3 items-stretch gap-2">
+          <div className="min-w-0 rounded-lg border border-gray-200 bg-gray-50 p-2">
+            {stampCountField}
+          </div>
+          <div className="flex min-w-0 flex-col items-center justify-center rounded-lg border border-gray-200 bg-gray-50 px-2 py-3 text-center">
+            <p className="whitespace-nowrap text-[10px] text-gray-500">
+              현재 스탬프 잔여량
+            </p>
+            <strong className="text-lg text-gray-900">
+              {currentStampCount}개
+            </strong>
+          </div>
+          <div className="flex min-w-0 flex-col items-center justify-center rounded-lg border border-gray-200 bg-gray-50 px-2 py-3 text-center">
+            <p className="whitespace-nowrap text-[10px] text-gray-500">
+              적립 후 잔여량
+            </p>
+            <strong className="text-lg text-brand-600">
+              {currentStampCount + amount}개
+            </strong>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
   const itemSelectionField = (
-    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 space-y-3">
-      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_150px]">
+    <div className="grid grid-cols-1 gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 lg:grid-cols-2 lg:items-stretch">
+      <div className="grid gap-2 sm:grid-cols-[minmax(0,2fr)_minmax(270px,1fr)]">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
             품목 선택 <span className="text-rose-600">*</span>
           </label>
           <div ref={itemSearchRef} className="relative">
             <div className="relative">
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                />
+              </svg>
               <input
                 type="text"
                 value={selectedItem ? getItemLabel(selectedItem) : itemSearch}
@@ -642,14 +1194,14 @@ export default function StampLogForm({
                   }
                 }}
                 disabled={!!selectedItem}
-                className={`w-full px-3 py-2 pr-9 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm ${
+                className={`h-10 w-full rounded-lg border border-gray-300 bg-white pl-9 pr-10 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100 ${
                   selectedItem
                     ? "bg-gray-100 text-gray-700 cursor-not-allowed"
                     : "bg-white"
                 }`}
                 placeholder="품목명을 입력하세요"
               />
-              {selectedItem ? (
+              {selectedItem && !editingLineId ? (
                 <button
                   type="button"
                   onClick={handleItemRemove}
@@ -658,13 +1210,13 @@ export default function StampLogForm({
                 >
                   X
                 </button>
-              ) : (
+              ) : !selectedItem ? (
                 isItemsLoading && (
                   <div className="absolute right-3 top-1/2 -translate-y-1/2">
                     <div className="w-4 h-4 border-2 border-brand-300 border-t-brand-600 rounded-full animate-spin" />
                   </div>
                 )
-              )}
+              ) : null}
             </div>
 
             {!selectedItem && showItemResults && items.length > 0 && (
@@ -717,101 +1269,127 @@ export default function StampLogForm({
                   setQuantity(v === "" ? 1 : Math.max(1, Number(v)));
                 }
               }}
-              className="w-16 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-center"
+              className="h-10 w-16 rounded-lg border border-gray-300 px-3 text-center text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
             <button
               type="button"
               onClick={() => setQuantity((v) => Math.max(1, v - 1))}
-              className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 active:bg-gray-100 transition-colors text-lg leading-none"
+              className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-300 bg-white text-lg leading-none text-gray-600 transition-colors hover:bg-gray-50 active:bg-gray-100"
             >
               −
             </button>
             <button
               type="button"
               onClick={() => setQuantity((v) => v + 1)}
-              className="w-8 h-8 flex items-center justify-center rounded-lg bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700 transition-colors text-lg leading-none"
+              className="flex h-10 w-10 items-center justify-center rounded-lg bg-brand-500 text-lg leading-none text-white transition-colors hover:bg-brand-600 active:bg-brand-700"
             >
               +
             </button>
+            {editingLineId && (
+              <Button
+                type="button"
+                size="sm"
+                variant="gray"
+                onClick={resetLineInputs}
+                className="h-10"
+              >
+                취소
+              </Button>
+            )}
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleAddLine}
+              className="h-10"
+              disabled={
+                !selectedItem ||
+                quantity < 1 ||
+                (customerMode === "adjustment" &&
+                  remarkType !== "adjustment_in" &&
+                  remarkType !== "adjustment_out")
+              }
+            >
+              {editingLineId ? "수정" : "추가"}
+            </Button>
           </div>
         </div>
       </div>
 
-      <div>
-        <span className="block text-sm font-medium text-gray-700 mb-2">
-          특이사항
-        </span>
-        <div className="flex flex-wrap gap-x-4 gap-y-2">
+      <div
+        className={`h-full space-y-3 border-gray-200 lg:col-start-2 lg:flex lg:flex-col lg:border-l lg:pl-3 ${
+          remarkType === "" ? "lg:justify-center" : "lg:justify-start"
+        }`}
+      >
+        <div className="grid grid-cols-6 gap-1.5">
           {visibleRemarkOptions.map((option) => (
-            <label
+            <Button
               key={option.value}
-              className="inline-flex items-center gap-2 text-xs whitespace-nowrap"
+              type="button"
+              size="xs"
+              variant={remarkType === option.value ? "primary" : "gray"}
+              onClick={() => setRemarkType(option.value)}
             >
-              <input
-                type="radio"
-                name="remarkType"
-                value={option.value}
-                checked={remarkType === option.value}
-                onChange={() => setRemarkType(option.value)}
-              />
               {option.name}
-            </label>
+            </Button>
           ))}
         </div>
-      </div>
 
-      {remarkType === "custom" && (
-        <div>
-          {isDeviceSelected && (
-            <p className="mb-2 rounded-lg bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700">
-              메모 직접 입력에 박스보관유무를 적어주세요.
-            </p>
-          )}
-          <textarea
-            value={customRemark}
-            onChange={(e) => setCustomRemark(e.target.value)}
-            className="w-full min-h-20 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm resize-y"
-            placeholder="ex) 박스매장보관 여부, 다른 특이사항"
-          />
-        </div>
-      )}
+        {(remarkType === "custom" || remarkType === "service") && (
+          <div>
+            {remarkType === "custom" && isDeviceSelected && (
+              <p className="mb-2 rounded-lg bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700">
+                메모입력에 박스보관유무를 적어주세요.
+              </p>
+            )}
+            <input
+              type="text"
+              value={customRemark}
+              onChange={(e) => setCustomRemark(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500"
+              placeholder={
+                remarkType === "service"
+                  ? "특이사항을 입력하세요. (선택)"
+                  : "ex) 박스매장보관 여부, 다른 특이사항"
+              }
+            />
+          </div>
+        )}
 
-      {(customerMode === "demo" || customerMode === "adjustment") && (
-        <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">
-            처리 메모
-          </label>
+        {(customerMode === "demo" || customerMode === "adjustment") && (
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">
+              처리 메모
+            </label>
+            <input
+              type="text"
+              value={operationMemo}
+              onChange={(event) => setOperationMemo(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm outline-none transition placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+              placeholder={
+                customerMode === "demo"
+                  ? "시연용 처리 메모 (선택)"
+                  : "입고·출고 처리 메모 (선택)"
+              }
+            />
+          </div>
+        )}
+
+        {(remarkType === "exchange_in" || remarkType === "exchange_out") && (
           <input
             type="text"
-            value={operationMemo}
-            onChange={(event) => setOperationMemo(event.target.value)}
-            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm outline-none transition placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
-            placeholder={
-              customerMode === "demo"
-                ? "시연용 처리 메모 (선택)"
-                : "입고·출고 처리 메모 (선택)"
-            }
+            value={exchangeMemo}
+            onChange={(event) => setExchangeMemo(event.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500"
+            placeholder="특이사항을 입력하세요. (선택)"
           />
-        </div>
-      )}
+        )}
 
-      {(remarkType === "exchange_in" || remarkType === "exchange_out") && (
-        <input
-          type="text"
-          value={exchangeMemo}
-          onChange={(event) => setExchangeMemo(event.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500"
-          placeholder="특이사항을 입력하세요. (선택)"
-        />
-      )}
-
-      {remarkType === "price_adjust" && (
-        <div className="grid gap-3 sm:grid-cols-[160px_minmax(0,1fr)]">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              조정 가격 <span className="text-rose-600">*</span>
-            </label>
-            <div className="flex items-center gap-1">
+        {remarkType === "price_adjust" && (
+          <div className="grid items-center gap-3 sm:grid-cols-[170px_minmax(0,1fr)]">
+            <div className="flex items-center gap-2">
+              <span className="shrink-0 text-sm font-medium text-gray-700">
+                가격 <span className="text-rose-600">*</span>
+              </span>
               <input
                 type="text"
                 value={priceAdjustAmount}
@@ -822,64 +1400,36 @@ export default function StampLogForm({
                   }
                 }}
                 inputMode="numeric"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-right"
+                className="min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-right text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="금액"
               />
               <span className="text-sm text-gray-600">원</span>
             </div>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              메모
-            </label>
             <input
               type="text"
               value={priceAdjustMemo}
               onChange={(e) => setPriceAdjustMemo(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500"
               placeholder="미입력 시 가격 조정"
             />
           </div>
-        </div>
-      )}
-
-      <div className="flex items-center justify-between gap-2">
-        <p className="text-xs text-gray-500">
-          {selectedItem
-            ? `${selectedItem.item_name} / ${formatAmount(
-                isNonSalesSpecialCustomer ||
-                  remarkType === "service" ||
-                  remarkType === "exchange_in" ||
-                  remarkType === "exchange_out"
-                  ? 0
-                  : remarkType === "price_adjust"
-                    ? parseSignedAmount(priceAdjustAmount) * quantity
-                    : (selectedItem.selling_price ?? 0) * quantity,
-              )}원`
-            : "품목을 선택하면 메모와 금액이 생성됩니다."}
-        </p>
-        <Button
-          type="button"
-          size="sm"
-          onClick={handleAddLine}
-          disabled={
-            !selectedItem ||
-            quantity < 1 ||
-            (customerMode === "adjustment" &&
-              remarkType !== "adjustment_in" &&
-              remarkType !== "adjustment_out")
-          }
-        >
-          추가
-        </Button>
+        )}
       </div>
     </div>
   );
 
   const itemListLabel = (
-    <span className="block text-sm font-medium text-gray-700 mb-2">
-      품목 목록 <span className="text-rose-600">*</span>
-    </span>
+    <div className="mb-2 flex items-center gap-3">
+      <span className="text-sm font-medium text-gray-700">
+        품목 목록 <span className="text-rose-600">*</span>
+      </span>
+      {draftLines.length > 0 && (
+        <span className="text-xs text-gray-500">
+          {new Set(draftLines.map((line) => line.itemId)).size}종 · 총{" "}
+          {draftLines.reduce((sum, line) => sum + line.quantity, 0)}개
+        </span>
+      )}
+    </div>
   );
 
   const itemListContent = (
@@ -887,68 +1437,113 @@ export default function StampLogForm({
       {draftLines.length === 0 ? (
         <p className="text-sm text-gray-400">추가된 품목이 없습니다.</p>
       ) : (
-        <div className="space-y-2">
-          {draftLines.map((line, index) => (
-            <div
-              ref={setLineRef(line.id)}
-              key={line.id}
-              className="relative flex items-center justify-between gap-2 rounded-md border border-gray-200 bg-white px-3 py-2"
-            >
-              <div className="flex min-w-0 items-start gap-2">
-                <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-500 text-xs font-semibold text-white">
-                  {index + 1}
-                </span>
-                <div className="min-w-0">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600">
-                      {line.itemCategoryName ?? "미분류"}
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+          <table className="w-full min-w-[820px] table-fixed text-sm">
+            <thead className="bg-gray-50 text-xs font-semibold text-gray-600">
+              <tr className="border-b border-gray-200">
+                <th className="w-[5%] px-2 py-2 text-center">번호</th>
+                <th className="w-[29%] px-2 py-2 text-left">품목명</th>
+                <th className="w-[11%] px-2 py-2 text-center">품목종류</th>
+                <th className="w-[10%] px-2 py-2 text-center">출고 유형</th>
+                <th className="w-[7%] px-2 py-2 text-center">수량</th>
+                <th className="w-[10%] px-2 py-2 text-right">단가</th>
+                <th className="w-[10%] px-2 py-2 text-right">소계</th>
+                <th className="w-[18%] px-3 py-2 text-center">작업</th>
+              </tr>
+            </thead>
+            <tbody>
+              {draftLines.map((line, index) => (
+                <tr
+                  ref={setLineRef(line.id)}
+                  key={line.id}
+                  className="border-b border-gray-200 last:border-b-0"
+                >
+                  <td className="px-2 py-2">
+                    <span className="mx-auto flex h-5 w-5 items-center justify-center rounded-full bg-brand-500 text-xs font-semibold leading-none text-white">
+                      {index + 1}
                     </span>
-                    <p className="min-w-0 text-sm text-gray-900">
-                      {line.lineText}
-                    </p>
-                  </div>
-                  <p className="mt-0.5 text-xs text-gray-500">
-                    개별단가 {formatAmount(line.unitPrice)}원
-                    {typeof line.adjustedUnitPrice === "number" &&
-                      ` / 조정단가 ${formatAmount(line.adjustedUnitPrice)}원`}
-                    {" / "}총금액 {formatAmount(line.amount)}원
-                  </p>
-                </div>
-              </div>
-              <div className="shrink-0 self-center flex items-center gap-1">
-                <button
-                  type="button"
-                  onClick={() => moveLine(index, -1)}
-                  disabled={index === 0}
-                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-gray-200 bg-white text-xs font-semibold text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-35"
-                  aria-label={`${line.lineText} 위로 이동`}
-                >
-                  ↑
-                </button>
-                <button
-                  type="button"
-                  onClick={() => moveLine(index, 1)}
-                  disabled={index === draftLines.length - 1}
-                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-gray-200 bg-white text-xs font-semibold text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-35"
-                  aria-label={`${line.lineText} 아래로 이동`}
-                >
-                  ↓
-                </button>
-                <button
-                  type="button"
-                  onClick={() =>
-                    setDraftLines((prev) =>
-                      prev.filter((item) => item.id !== line.id),
-                    )
-                  }
-                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md px-2 py-1 text-xs font-semibold text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                  aria-label={`${line.lineText} 삭제`}
-                >
-                  X
-                </button>
-              </div>
-            </div>
-          ))}
+                  </td>
+                  <td className="px-2 py-2 font-medium text-gray-900">
+                    <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                      <span className="break-words">{line.itemName}</span>
+                      {getLineDisplayMemo(line) && (
+                        <span className="break-words text-xs font-normal text-gray-500">
+                          ({getLineDisplayMemo(line)})
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-2 py-2 text-center text-xs font-medium text-gray-600">
+                    {line.itemCategoryName ?? "미분류"}
+                  </td>
+                  <td className="px-2 py-2 text-center">
+                    <span
+                      className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-semibold ${getShipmentTypeClassName(line)}`}
+                    >
+                      {getShipmentTypeLabel(line)}
+                    </span>
+                  </td>
+                  <td className="px-2 py-2 text-center font-medium text-gray-800">
+                    {line.quantity}개
+                  </td>
+                  <td className="px-2 py-2 text-right text-gray-700">
+                    {formatAmount(
+                      typeof line.adjustedUnitPrice === "number"
+                        ? line.adjustedUnitPrice
+                        : line.unitPrice,
+                    )}
+                    원
+                  </td>
+                  <td className="px-2 py-2 text-right font-medium text-gray-900">
+                    {formatAmount(line.amount)}원
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex items-center justify-center gap-1">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="xs"
+                        onClick={() => handleEditLine(line)}
+                        aria-label={`${line.lineText} 수정`}
+                      >
+                        ✏️
+                      </Button>
+                      <button
+                        type="button"
+                        onClick={() => moveLine(index, -1)}
+                        disabled={index === 0}
+                        className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-gray-200 bg-white text-xs font-semibold text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-35"
+                        aria-label={`${line.lineText} 위로 이동`}
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveLine(index, 1)}
+                        disabled={index === draftLines.length - 1}
+                        className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-gray-200 bg-white text-xs font-semibold text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-35"
+                        aria-label={`${line.lineText} 아래로 이동`}
+                      >
+                        ↓
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setDraftLines((prev) =>
+                            prev.filter((item) => item.id !== line.id),
+                          )
+                        }
+                        className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-xs font-semibold text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                        aria-label={`${line.lineText} 삭제`}
+                      >
+                        X
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
     </>
@@ -969,36 +1564,46 @@ export default function StampLogForm({
   );
 
   const discountField = (
-    <div>
-      <span className="block text-sm font-medium text-gray-700 mb-2">할인</span>
-      <div className="flex items-center gap-2">
-        <div className="grid flex-1 grid-cols-3 gap-2">
+    <div className="h-full rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <span className="mb-2 block text-sm font-semibold text-gray-800">
+        할인
+      </span>
+      <div className="grid grid-cols-[minmax(0,1fr)_110px] items-center gap-2">
+        <div className="grid grid-cols-3 gap-2">
           {discountOptions.map((option) => (
             <Button
               key={option.value}
               type="button"
               size="sm"
               variant={discountType === option.value ? "primary" : "gray"}
-              onClick={() => setDiscountType(option.value)}
+              className="rounded-lg"
+              onClick={() =>
+                setDiscountType((current) =>
+                  current === option.value ? "" : option.value,
+                )
+              }
             >
               {option.name}
             </Button>
           ))}
         </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <input
-            type="text"
-            value={discountAmount}
-            onChange={(e) => {
-              const v = e.target.value;
-              if (v === "" || /^[0-9]+$/.test(v)) {
-                setDiscountAmount(v === "" ? 0 : Number(v));
-              }
-            }}
-            className="w-24 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm text-right"
-            placeholder="금액"
-          />
-          <span className="text-sm text-gray-600">원</span>
+        <div>
+          <div className="flex items-center gap-1">
+            <input
+              type="text"
+              aria-label="할인 금액"
+              value={discountAmount}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === "" || /^[0-9]+$/.test(v)) {
+                  setDiscountAmount(v === "" ? 0 : Number(v));
+                }
+              }}
+              className="h-11 min-w-0 w-full rounded-lg border border-gray-300 bg-white px-3 text-right text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500"
+              placeholder="0"
+            />
+            <span className="text-sm text-gray-600">원</span>
+          </div>
         </div>
       </div>
     </div>
@@ -1015,21 +1620,114 @@ export default function StampLogForm({
     </div>
   );
 
+  const splitPaymentAmountField =
+    paymentMode === "split" && splitPayments.length > 0 ? (
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <span className="mb-2 block text-sm font-medium text-gray-700">
+          분할결제 금액 <span className="text-rose-600">*</span>
+        </span>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          {splitPayments.map((payment) => (
+            <div
+              key={payment.paymentType}
+              className="grid min-w-0 grid-cols-[minmax(64px,0.8fr)_minmax(90px,1.2fr)] gap-1.5"
+            >
+              <div className="flex h-11 min-w-0 items-center rounded-lg border border-gray-200 bg-white px-3">
+                <span className="truncate text-sm font-semibold text-gray-700">
+                {payment.paymentTypeName}
+                </span>
+              </div>
+              <label className="flex h-11 min-w-0 items-center gap-1 rounded-lg border border-gray-200 bg-white px-2">
+                <input
+                  type="number"
+                  min="0"
+                  value={payment.amount || ""}
+                  onChange={(event) =>
+                    setSplitPayments((current) =>
+                      current.map((item) =>
+                        item.paymentType === payment.paymentType
+                          ? {
+                              ...item,
+                              amount: Math.max(
+                                0,
+                                Number(event.target.value) || 0,
+                              ),
+                            }
+                          : item,
+                      ),
+                    )
+                  }
+                  placeholder="금액"
+                  aria-label={`${payment.paymentTypeName} 결제 금액`}
+                  className="min-w-0 flex-1 bg-transparent text-right text-sm outline-none placeholder:text-gray-400"
+                />
+                <span className="shrink-0 text-xs text-gray-500">원</span>
+              </label>
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 grid grid-cols-2 overflow-hidden rounded-lg border border-gray-200 bg-white sm:grid-cols-4">
+          <div className="border-b border-r border-gray-200 px-3 py-2 sm:border-b-0">
+            <p className="text-xs text-gray-500">최종 결제금액</p>
+            <p className="mt-0.5 text-sm font-semibold text-gray-900">
+              {formatAmount(finalAmount)}원
+            </p>
+          </div>
+          <div className="border-b border-gray-200 px-3 py-2 sm:border-b-0 sm:border-r">
+            <p className="text-xs text-gray-500">입력 합계</p>
+            <p className="mt-0.5 text-sm font-semibold text-gray-900">
+              {formatAmount(splitPaymentTotal)}원
+            </p>
+          </div>
+          <div className="border-r border-gray-200 px-3 py-2">
+            <p className="text-xs text-gray-500">
+              {splitPaymentDifference < 0 ? "초과 금액" : "남은 금액"}
+            </p>
+            <p
+              className={`mt-0.5 text-sm font-semibold ${
+                splitPaymentMatches
+                  ? "text-emerald-600"
+                  : splitPaymentDifference < 0
+                    ? "text-rose-600"
+                    : "text-gray-900"
+              }`}
+            >
+              {formatAmount(Math.abs(splitPaymentDifference))}원
+            </p>
+          </div>
+          <div
+            className={`px-3 py-2 ${
+              splitPaymentMatches ? "bg-emerald-50" : "bg-rose-50"
+            }`}
+          >
+            <p className="text-xs text-gray-500">결제금액 확인</p>
+            <p
+              className={`mt-0.5 text-sm font-bold ${
+                splitPaymentMatches ? "text-emerald-700" : "text-rose-700"
+              }`}
+            >
+              {!hasAmountForEverySplitPayment
+                ? "미입력된 결제방식을 확인하세요."
+                : splitPaymentMatches
+                  ? "일치"
+                  : "불일치"}
+            </p>
+          </div>
+        </div>
+      </div>
+    ) : null;
+
   const extraNoteField = (
-    <div>
-      <label className="block text-sm font-medium text-gray-700 mb-2">
-        출고 특이사항
+    <div className="h-full rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <label className="mb-2 block text-sm font-semibold text-gray-800">
+        출고 메모
       </label>
       <input
         type="text"
         value={extraNote}
         onChange={(e) => setExtraNote(e.target.value)}
-        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
-        placeholder={
-          isNonSalesSpecialCustomer
-            ? "특이사항을 적어주세요. (선택)"
-            : "배달지주소 , 네이버톡톡 : 아이디"
-        }
+        className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500"
+        placeholder="특이사항을 입력하세요. (선택)"
       />
     </div>
   );
@@ -1042,7 +1740,8 @@ export default function StampLogForm({
       return (
         <div className="space-y-5">
           <div className={step === 1 ? "space-y-5" : "hidden"}>
-            {storeField}
+            <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+              {stepOneStoreField}
             {isNonSalesSpecialCustomer ? (
               <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
                 <span className="text-sm font-medium text-gray-600">
@@ -1054,28 +1753,34 @@ export default function StampLogForm({
               </div>
             ) : (
               <>
-                {paymentField}
-                {stampCountField}
+                {hasConfirmedStore && stepOneDeliveryField}
+                {hasConfirmedStore &&
+                  hasConfirmedDeliveryMethod &&
+                  hasValidDeliveryInfo &&
+                  stepOnePaymentField}
+                {hasConfirmedStore &&
+                  hasConfirmedDeliveryMethod &&
+                  hasValidDeliveryInfo &&
+                  hasValidPayment &&
+                  customerMode !== "x" &&
+                  stepOneStampField}
               </>
             )}
+            </div>
           </div>
           <div className={step === 2 ? "space-y-5" : "hidden"}>
-            <div className="grid grid-cols-1 gap-x-6 gap-y-5 lg:grid-cols-2 lg:items-start">
-              <div className="min-w-0">{itemSelectionField}</div>
-              <div className="min-w-0">{itemListField}</div>
-            </div>
-            {!isNonSalesSpecialCustomer && (
-              <div className="grid grid-cols-1 gap-x-6 gap-y-5 lg:grid-cols-2 lg:items-start">
+            <div className="min-w-0">{itemSelectionField}</div>
+            <div className="min-w-0">{itemListField}</div>
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-3 lg:items-stretch">
+              {!isNonSalesSpecialCustomer && (
                 <div className="min-w-0">{discountField}</div>
-                <div className="min-w-0">{amountField}</div>
-              </div>
-            )}
-            <div className="grid grid-cols-1 gap-x-6 gap-y-5 lg:grid-cols-2 lg:items-start">
-              <div className="min-w-0 w-full">{extraNoteField}</div>
+              )}
               {!isNonSalesSpecialCustomer && (
                 <div className="min-w-0">{reservationSlot}</div>
               )}
+              <div className="min-w-0">{extraNoteField}</div>
             </div>
+            {splitPaymentAmountField}
           </div>
         </div>
       );

--- a/src/app/(auth)/customers/_components/TargetCustomerCard.tsx
+++ b/src/app/(auth)/customers/_components/TargetCustomerCard.tsx
@@ -5,30 +5,51 @@ import { formatPhoneNumber } from '@/app/_utils/utils';
 export default function TargetCustomerCard({
   name,
   phone,
+  address,
   note,
   className = '',
   label = '대상 고객',
 }: {
   name: string;
   phone: string;
+  address?: string | null;
   note?: string | null;
   className?: string;
   label?: string;
 }) {
   return (
-    <div className={`bg-gray-100 rounded-lg p-4 ${className}`}>
-      <div className="flex items-center gap-2 mb-2">
-        <div className="w-2 h-2 bg-brand-500 rounded-full" />
-        <span className="text-sm font-medium text-gray-700">{label}</span>
+    <div
+      className={`overflow-hidden rounded-xl border border-gray-200 bg-white ${className}`}
+    >
+      <div className="grid sm:grid-cols-[140px_minmax(0,1fr)] sm:items-stretch">
+        <div className="flex min-w-0 flex-col justify-center border-b border-gray-200 bg-gray-50 px-4 py-4 sm:border-b-0 sm:border-r">
+          <div className="mb-3 flex items-center gap-2">
+            <div className="h-2 w-2 rounded-full bg-brand-500" />
+            <span className="text-sm font-medium text-gray-700">{label}</span>
+          </div>
+          <p className="truncate text-lg font-semibold text-gray-900">{name}</p>
+          <p className="text-sm text-gray-600">{formatPhoneNumber(phone)}</p>
+        </div>
+
+        <div className="grid min-w-0 grid-rows-2 bg-white">
+          <div className="grid min-w-0 grid-cols-[72px_minmax(0,1fr)] border-b border-gray-200">
+            <p className="flex items-center bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600">
+              주소지
+            </p>
+            <p className="whitespace-pre-wrap break-words border-l border-gray-200 px-3 py-2 text-sm text-gray-800">
+              {address?.trim() || "등록 없음"}
+            </p>
+          </div>
+          <div className="grid min-w-0 grid-cols-[72px_minmax(0,1fr)]">
+            <p className="flex items-center bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600">
+              특이사항
+            </p>
+            <p className="whitespace-pre-wrap break-words border-l border-gray-200 px-3 py-2 text-sm text-gray-800">
+              {note?.trim() || "등록 없음"}
+            </p>
+          </div>
+        </div>
       </div>
-      <p className="text-lg font-semibold text-gray-900">{name}</p>
-      <p className="text-sm text-gray-600">{formatPhoneNumber(phone)}</p>
-      {note && (
-        <p className="mt-2 text-sm text-gray-700 whitespace-pre-wrap">
-          <span className="font-medium text-gray-600">특이사항: </span>
-          {note}
-        </p>
-      )}
     </div>
   );
 }

--- a/src/app/(auth)/histories/_components/RemarkHistories/RemarkHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/RemarkHistories/RemarkHistoryItem.tsx
@@ -116,7 +116,11 @@ const RemarkHistoryItem = ({
           onClick={() =>
             copyLogToClipboard(
               log,
-              { name: log.customers?.name, phone: log.customers?.phone, gender: log.customers?.gender },
+              {
+                name: log.customers?.name,
+                phone: log.customers?.phone,
+                gender: log.customers?.gender,
+              },
               '특이사항',
             )
           }

--- a/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
@@ -31,11 +31,14 @@ const StampHistoryItem = ({
   showCopy = true,
 }: StampHistoryItemProps) => {
   const { copyLogToClipboard } = useCopy();
+  const isNoStampCustomer =
+    log.customers?.name?.trim() === 'X' &&
+    log.customers?.phone?.trim() === 'X';
 
   return (
     <div className="flex items-center justify-between p-2.5 sm:p-4 rounded-lg border border-brand-50 hover:bg-brand-50/30 transition-colors whitespace-nowrap text-xs sm:text-sm">
       <div className="flex items-center gap-2 sm:gap-4">
-        <ActionInfoLabel action={log.action} />
+        {!isNoStampCustomer && <ActionInfoLabel action={log.action} />}
         <CustomerInfo
           name={log.customers?.name}
           phone={log.customers?.phone}
@@ -59,19 +62,29 @@ const StampHistoryItem = ({
       </div>
 
       <div className="flex-1 max-w-[600px] pl-3 ml-3 sm:pl-4 sm:ml-4 border-l border-brand-100">
-        <div className="flex items-center gap-2">
+        <div className="flex items-start gap-2">
           <Button variant="secondary" size="xs" onClick={onEdit}>
             ✏️
           </Button>
-          <span className="flex-1 min-w-[240px] text-xs sm:text-sm text-gray-600 break-words whitespace-pre-line">
-            {log.note || <span className="text-gray-400"> - </span>}
+          <div className="min-w-[240px] flex-1 break-words whitespace-normal text-xs text-gray-600 sm:text-sm">
+            <p className="whitespace-pre-line">
+              {log.note || <span className="text-gray-400"> - </span>}
+            </p>
             {typeof log.jsonb?.extraNote === 'string' &&
               log.jsonb.extraNote.trim() && (
-                <span className="ml-2 italic text-gray-400">
+                <p className="mt-1 italic text-gray-400">
                   출고 특이사항: &quot;{log.jsonb.extraNote.trim()}&quot;
-                </span>
+                </p>
               )}
-          </span>
+            {(log.jsonb?.deliveryMethod === 'parcel' ||
+              log.jsonb?.deliveryMethod === 'delivery') &&
+              typeof log.jsonb?.deliveryAddress === 'string' &&
+              log.jsonb.deliveryAddress.trim() && (
+                <p className="mt-1 break-words italic text-gray-400">
+                  주소: {log.jsonb.deliveryAddress.trim()}
+                </p>
+              )}
+          </div>
         </div>
       </div>
 

--- a/src/app/(auth)/histories/_components/StampHistories/index.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/index.tsx
@@ -171,6 +171,8 @@ const StampHistories = ({
             target={{
               name: log.customers.name,
               phone: log.customers.phone,
+              address: log.customers.address,
+              note: log.customers.note,
             }}
             initialAction={log.action}
             initialPaymentType={

--- a/src/app/(auth)/inventory/InventoryPageContent.tsx
+++ b/src/app/(auth)/inventory/InventoryPageContent.tsx
@@ -33,11 +33,19 @@ import {
   closePurchaseOrderRemainder,
   reversePurchaseReceipt,
   deletePurchaseOrderHistory,
+  deactivatePurchaseAdjustmentCategory,
+  getPurchaseAdjustmentCategories,
+  savePurchaseAdjustmentCategory,
+  savePurchaseOrderAdjustments,
+  updatePurchaseOrderDetails,
 } from "@/app/_domains/_inventory/_services/inventoryService";
 import type {
   InventoryItem,
   InventorySupplier,
+  PurchaseAdjustmentCategory,
+  PurchaseAdjustmentKind,
   PurchaseOrder,
+  PurchaseOrderAdjustment,
 } from "@/app/_domains/_inventory/_types/inventory.types";
 
 type Tab = "stock" | "untracked" | "receive" | "movements" | "initial";
@@ -2387,6 +2395,7 @@ function ReceiptManager({
 
       <PurchaseOrderList
         orders={ordersQuery.data ?? []}
+        suppliers={suppliersQuery.data ?? []}
         loading={ordersQuery.isPending}
         isAdmin={isAdmin}
         focusOrderId={focusOrderId}
@@ -2602,6 +2611,7 @@ function ReceiptManager({
       </section>
       <PurchaseOrderList
         orders={ordersQuery.data ?? []}
+        suppliers={suppliersQuery.data ?? []}
         loading={ordersQuery.isPending}
         isAdmin={isAdmin}
         onSaved={async () => {
@@ -2623,6 +2633,7 @@ function ReceiptManager({
 
 function PurchaseOrderList({
   orders,
+  suppliers,
   loading,
   isAdmin,
   onSaved,
@@ -2630,6 +2641,7 @@ function PurchaseOrderList({
   onCreate,
 }: {
   orders: PurchaseOrder[];
+  suppliers: InventorySupplier[];
   loading: boolean;
   isAdmin: boolean;
   onSaved: () => Promise<void>;
@@ -2646,6 +2658,15 @@ function PurchaseOrderList({
   const [arrivalDates, setArrivalDates] = useState<Record<string, string>>({});
   const [arrivalNotes, setArrivalNotes] = useState<Record<string, string>>({});
   const [pending, setPending] = useState(false);
+  const [adjustmentOrder, setAdjustmentOrder] =
+    useState<PurchaseOrder | null>(null);
+  const [editingOrder, setEditingOrder] = useState<PurchaseOrder | null>(null);
+  const [categoryManagerOpen, setCategoryManagerOpen] = useState(false);
+  const adjustmentCategoriesQuery = useQuery({
+    queryKey: inventoryKeys.purchaseAdjustmentCategories,
+    queryFn: () => getPurchaseAdjustmentCategories(true),
+    enabled: isAdmin,
+  });
   const [listTab, setListTab] = useState<
     "waiting" | "partial" | "completed" | "closed"
   >("waiting");
@@ -3088,6 +3109,7 @@ function PurchaseOrderList({
         );
         const showCompletedCumulativeDetails =
           sortedReceipts.filter((receipt) => !receipt.reversed_at).length > 1;
+        const adjustments = order.inventory_purchase_order_adjustments ?? [];
         return (
           <article
             id={`purchase-order-${order.id}`}
@@ -3166,6 +3188,39 @@ function PurchaseOrderList({
                 <span className="rounded-lg bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700">
                   미입고 종료 사유: {order.closed_reason}
                 </span>
+              )}
+              {isAdmin && (
+                <>
+                  {adjustments.map((adjustment) => (
+                    <span
+                      key={adjustment.id}
+                      className={`rounded-full px-2.5 py-1 text-xs font-bold ${
+                        adjustment.kind === "discount"
+                          ? "bg-blue-100 text-blue-700"
+                          : "bg-orange-100 text-orange-700"
+                      }`}
+                    >
+                      {adjustment.category_name}{" "}
+                      {adjustment.kind === "discount" ? "-" : "+"}
+                      {Number(adjustment.amount).toLocaleString("ko-KR")}원
+                    </span>
+                  ))}
+                  <Button
+                    size="xs"
+                    variant="gray"
+                    onClick={() => setEditingOrder(order)}
+                    className="ml-auto"
+                  >
+                    입고 내용 수정
+                  </Button>
+                  <Button
+                    size="xs"
+                    variant="gray"
+                    onClick={() => setAdjustmentOrder(order)}
+                  >
+                    거래 조정
+                  </Button>
+                </>
               )}
               {!open && isAdmin && (
                 <Button
@@ -3947,7 +4002,797 @@ function PurchaseOrderList({
           등록된 입고 예정이 없습니다.
         </div>
       )}
+      {adjustmentOrder && (
+        <PurchaseAdjustmentOverlay
+          order={adjustmentOrder}
+          categories={adjustmentCategoriesQuery.data ?? []}
+          categoriesError={adjustmentCategoriesQuery.isError}
+          isAdmin={isAdmin}
+          onClose={() => setAdjustmentOrder(null)}
+          onManageCategories={() => setCategoryManagerOpen(true)}
+          onSaved={async () => {
+            setAdjustmentOrder(null);
+            await onSaved();
+          }}
+        />
+      )}
+      {editingOrder && (
+        <PurchaseOrderEditOverlay
+          order={editingOrder}
+          suppliers={suppliers}
+          isAdmin={isAdmin}
+          onClose={() => setEditingOrder(null)}
+          onSaved={async () => {
+            setEditingOrder(null);
+            await onSaved();
+          }}
+        />
+      )}
+      {categoryManagerOpen && (
+        <PurchaseAdjustmentCategoryOverlay
+          categories={adjustmentCategoriesQuery.data ?? []}
+          onClose={() => setCategoryManagerOpen(false)}
+          onSaved={async () => {
+            await adjustmentCategoriesQuery.refetch();
+          }}
+        />
+      )}
     </section>
+  );
+}
+
+type AdjustmentDraft = {
+  key: string;
+  categoryId: string;
+  categoryName: string;
+  kind: PurchaseAdjustmentKind;
+  amount: string;
+  note: string;
+};
+
+const formatPurchaseAdjustmentDate = (value: string) =>
+  new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(`${value}T00:00:00`));
+
+function PurchaseOrderEditOverlay({
+  order,
+  suppliers,
+  isAdmin,
+  onClose,
+  onSaved,
+}: {
+  order: PurchaseOrder;
+  suppliers: InventorySupplier[];
+  isAdmin: boolean;
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const parsedNote = splitPurchaseOrderNote(order.note);
+  const [supplierId, setSupplierId] = useState(order.supplier_id);
+  const [orderedOn, setOrderedOn] = useState(order.ordered_on);
+  const [overallNote, setOverallNote] = useState(parsedNote.note);
+  const [lines, setLines] = useState(() =>
+    order.inventory_purchase_order_lines.map((line) => ({
+      id: line.id,
+      itemName: line.item_name,
+      orderedQuantity: String(line.ordered_quantity),
+      receivedQuantity: line.received_quantity,
+      unitPrice: line.unit_price == null ? "" : String(line.unit_price),
+      note: line.note ?? "",
+    })),
+  );
+  const [receipts, setReceipts] = useState(() =>
+    order.inventory_purchase_receipts.map((receipt) => ({
+      id: receipt.id,
+      arrivedOn: receipt.arrived_on,
+      note: receipt.note ?? "",
+      reversed: Boolean(receipt.reversed_at),
+    })),
+  );
+  const [saving, setSaving] = useState(false);
+  const selectedSupplier = suppliers.find((item) => item.id === supplierId);
+
+  const save = async () => {
+    if (!supplierId || !orderedOn) {
+      toast.error("거래처와 주문일을 확인해 주세요.");
+      return;
+    }
+    if (
+      lines.some(
+        (line) =>
+          !line.itemName.trim() ||
+          !Number.isInteger(Number(line.orderedQuantity)) ||
+          Number(line.orderedQuantity) <
+            Math.max(1, line.receivedQuantity),
+      )
+    ) {
+      toast.error("품목명과 주문수량을 확인해 주세요.");
+      return;
+    }
+    if (
+      new Set(lines.map((line) => line.itemName.trim())).size !== lines.length
+    ) {
+      toast.error("같은 품목을 중복으로 저장할 수 없습니다.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await updatePurchaseOrderDetails({
+        orderId: order.id,
+        supplierId,
+        orderedOn,
+        note: mergePurchaseOrderNote(
+          parsedNote.taxInvoiceStatus,
+          overallNote,
+        ),
+        lines: lines.map((line) => ({
+          id: line.id,
+          item_name: line.itemName.trim(),
+          ordered_quantity: Number(line.orderedQuantity),
+          unit_price:
+            isAdmin && line.unitPrice !== ""
+              ? Math.max(0, Math.floor(Number(line.unitPrice)))
+              : order.inventory_purchase_order_lines.find(
+                    (item) => item.id === line.id,
+                  )?.unit_price ?? null,
+          note: line.note.trim(),
+        })),
+        receipts: receipts.map((receipt) => ({
+          id: receipt.id,
+          arrived_on: receipt.arrivedOn,
+          note: receipt.note.trim(),
+        })),
+      });
+      toast.success("입고 내용을 수정했습니다.");
+      await onSaved();
+    } catch (error) {
+      const message = (error as Error).message;
+      if (message.includes("RECEIVED_ITEM_NAME_IMMUTABLE")) {
+        toast.error(
+          "입고 처리된 품목명은 재고 이력 보호를 위해 변경할 수 없습니다.",
+        );
+      } else if (message.includes("ORDERED_QUANTITY_BELOW_RECEIVED")) {
+        toast.error("주문수량은 이미 입고된 수량보다 작게 변경할 수 없습니다.");
+      } else {
+        toast.error(message || "입고 내용 수정에 실패했습니다.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-gray-950/50 p-4 backdrop-blur-[2px]">
+      <div className="max-h-[92vh] w-full max-w-6xl overflow-y-auto rounded-2xl bg-white shadow-2xl">
+        <div className="border-b border-gray-200 px-5 py-4">
+          <h2 className="text-lg font-bold text-gray-900">입고 내용 수정</h2>
+          <p className="mt-1 text-xs text-gray-500">
+            입고 상태와 관계없이 원본 정보를 수정할 수 있습니다. 실제 입고수량은 재고 이력과 연결되어 수정 대상에서 제외됩니다.
+          </p>
+        </div>
+        <div className="space-y-5 p-5">
+          <section className="grid gap-4 rounded-xl border border-gray-200 bg-gray-50/70 p-4 md:grid-cols-2">
+            <label className="text-xs font-semibold text-gray-600">
+              거래처
+              <div className="mt-1.5">
+                <Dropdown controlledValue={supplierId}>
+                  <Dropdown.Trigger>
+                    {selectedSupplier?.name ?? "거래처 선택"}
+                  </Dropdown.Trigger>
+                  <Dropdown.Content>
+                    {suppliers
+                      .filter(
+                        (supplier) =>
+                          supplier.is_use || supplier.id === supplierId,
+                      )
+                      .map((supplier) => (
+                        <Dropdown.Item
+                          key={supplier.id}
+                          option={{
+                            value: supplier.id,
+                            label: supplier.name,
+                          }}
+                          onSelect={(selected: DropdownOption) =>
+                            setSupplierId(String(selected.value))
+                          }
+                        />
+                      ))}
+                  </Dropdown.Content>
+                </Dropdown>
+              </div>
+            </label>
+            <label className="text-xs font-semibold text-gray-600">
+              주문일
+              <input
+                type="date"
+                value={orderedOn}
+                onChange={(event) => setOrderedOn(event.target.value)}
+                className="mt-1.5 h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+              />
+            </label>
+            <label className="text-xs font-semibold text-gray-600 md:col-span-2">
+              전체 메모
+              <textarea
+                value={overallNote}
+                onChange={(event) => setOverallNote(event.target.value)}
+                placeholder="입고 전체 메모"
+                className="mt-1.5 h-24 w-full resize-none rounded-lg border border-gray-300 bg-white p-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+              />
+            </label>
+          </section>
+
+          <section>
+            <h3 className="mb-3 font-bold text-gray-900">입고 품목</h3>
+            <div className="overflow-x-auto rounded-xl border border-gray-200">
+              <table className="min-w-[900px] w-full border-collapse text-sm">
+                <thead className="bg-gray-50 text-xs font-semibold text-gray-600">
+                  <tr>
+                    <th className="px-3 py-3 text-left">품목명</th>
+                    <th className="w-28 px-3 py-3 text-right">주문수량</th>
+                    <th className="w-28 px-3 py-3 text-right">입고수량</th>
+                    {isAdmin && (
+                      <th className="w-36 px-3 py-3 text-right">단가</th>
+                    )}
+                    <th className="w-[280px] px-3 py-3 text-left">품목 메모</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lines.map((line) => (
+                    <tr key={line.id} className="border-t border-gray-200">
+                      <td className="p-2">
+                        <input
+                          value={line.itemName}
+                          disabled={line.receivedQuantity > 0}
+                          title={
+                            line.receivedQuantity > 0
+                              ? "입고 처리된 품목명은 재고 이력 보호를 위해 변경할 수 없습니다."
+                              : undefined
+                          }
+                          onChange={(event) =>
+                            setLines((current) =>
+                              current.map((item) =>
+                                item.id === line.id
+                                  ? { ...item, itemName: event.target.value }
+                                  : item,
+                              ),
+                            )
+                          }
+                          className="h-10 w-full rounded-lg border border-gray-300 px-3 outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100 disabled:text-gray-500"
+                        />
+                      </td>
+                      <td className="p-2">
+                        <input
+                          type="number"
+                          min={Math.max(1, line.receivedQuantity)}
+                          value={line.orderedQuantity}
+                          onChange={(event) =>
+                            setLines((current) =>
+                              current.map((item) =>
+                                item.id === line.id
+                                  ? {
+                                      ...item,
+                                      orderedQuantity: event.target.value,
+                                    }
+                                  : item,
+                              ),
+                            )
+                          }
+                          className="h-10 w-full rounded-lg border border-gray-300 px-3 text-right outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                        />
+                      </td>
+                      <td className="p-2 text-right font-semibold text-gray-600">
+                        {line.receivedQuantity.toLocaleString("ko-KR")}개
+                      </td>
+                      {isAdmin && (
+                        <td className="p-2">
+                          <input
+                            type="number"
+                            min="0"
+                            value={line.unitPrice}
+                            onChange={(event) =>
+                              setLines((current) =>
+                                current.map((item) =>
+                                  item.id === line.id
+                                    ? { ...item, unitPrice: event.target.value }
+                                    : item,
+                                ),
+                              )
+                            }
+                            className="h-10 w-full rounded-lg border border-gray-300 px-3 text-right outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                          />
+                        </td>
+                      )}
+                      <td className="p-2">
+                        <input
+                          value={line.note}
+                          onChange={(event) =>
+                            setLines((current) =>
+                              current.map((item) =>
+                                item.id === line.id
+                                  ? { ...item, note: event.target.value }
+                                  : item,
+                              ),
+                            )
+                          }
+                          placeholder="품목 메모"
+                          className="h-10 w-full rounded-lg border border-gray-300 px-3 outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                        />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {receipts.length > 0 && (
+            <section>
+              <h3 className="mb-3 font-bold text-gray-900">입고 처리 이력</h3>
+              <div className="grid gap-3 md:grid-cols-2">
+                {receipts.map((receipt) => (
+                  <div
+                    key={receipt.id}
+                    className="rounded-xl border border-gray-200 bg-gray-50/70 p-3"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-bold text-emerald-700">
+                        입고일
+                      </span>
+                      {receipt.reversed && (
+                        <span className="rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-bold text-rose-600">
+                          취소됨
+                        </span>
+                      )}
+                    </div>
+                    <input
+                      type="date"
+                      value={receipt.arrivedOn}
+                      disabled={receipt.reversed}
+                      onChange={(event) =>
+                        setReceipts((current) =>
+                          current.map((item) =>
+                            item.id === receipt.id
+                              ? { ...item, arrivedOn: event.target.value }
+                              : item,
+                          ),
+                        )
+                      }
+                      className="mt-2 h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100"
+                    />
+                    <input
+                      value={receipt.note}
+                      disabled={receipt.reversed}
+                      onChange={(event) =>
+                        setReceipts((current) =>
+                          current.map((item) =>
+                            item.id === receipt.id
+                              ? { ...item, note: event.target.value }
+                              : item,
+                          ),
+                        )
+                      }
+                      placeholder="입고 처리 메모"
+                      className="mt-2 h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100"
+                    />
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-4">
+          <Button variant="gray" onClick={onClose} disabled={saving}>
+            취소
+          </Button>
+          <Button onClick={save} disabled={saving}>
+            {saving ? "저장 중..." : "입고 내용 저장"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PurchaseAdjustmentOverlay({
+  order,
+  categories,
+  categoriesError,
+  isAdmin,
+  onClose,
+  onManageCategories,
+  onSaved,
+}: {
+  order: PurchaseOrder;
+  categories: PurchaseAdjustmentCategory[];
+  categoriesError: boolean;
+  isAdmin: boolean;
+  onClose: () => void;
+  onManageCategories: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const [rows, setRows] = useState<AdjustmentDraft[]>(() =>
+    (order.inventory_purchase_order_adjustments ?? []).map((item) => ({
+      key: item.id,
+      categoryId: item.category_id ?? "",
+      categoryName: item.category_name,
+      kind: item.kind,
+      amount: String(item.amount),
+      note: item.note ?? "",
+    })),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const addRow = (kind: PurchaseAdjustmentKind) => {
+    const usedIds = new Set(rows.map((row) => row.categoryId));
+    const category = categories.find(
+      (item) => item.kind === kind && item.is_active && !usedIds.has(item.id),
+    );
+    if (!category) {
+      toast.error(
+        isAdmin
+          ? "추가할 수 있는 항목이 없습니다. 거래 항목 관리에서 항목을 등록해 주세요."
+          : "관리자에게 거래 항목 등록을 요청해 주세요.",
+      );
+      return;
+    }
+    setRows((current) => [
+      ...current,
+      {
+        key: `draft-${kind}-${Date.now()}`,
+        categoryId: category.id,
+        categoryName: category.name,
+        kind,
+        amount: "",
+        note: "",
+      },
+    ]);
+  };
+
+  const updateRow = (key: string, values: Partial<AdjustmentDraft>) =>
+    setRows((current) =>
+      current.map((row) => (row.key === key ? { ...row, ...values } : row)),
+    );
+
+  const save = async () => {
+    const normalized = rows
+      .filter((row) => row.categoryName && Number(row.amount) > 0)
+      .map((row) => ({
+        category_id: row.categoryId || null,
+        category_name: row.categoryName,
+        kind: row.kind,
+        amount: Math.floor(Number(row.amount)),
+        note: row.note.trim() || null,
+      })) satisfies Array<
+      Pick<
+        PurchaseOrderAdjustment,
+        "category_id" | "category_name" | "kind" | "amount" | "note"
+      >
+    >;
+    setSaving(true);
+    try {
+      await savePurchaseOrderAdjustments(order.id, normalized);
+      toast.success("입고 거래 조정 내역을 저장했습니다.");
+      await onSaved();
+    } catch (error) {
+      toast.error((error as Error).message || "거래 조정 저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const totals = {
+    discount: rows
+      .filter((row) => row.kind === "discount")
+      .reduce((sum, row) => sum + (Number(row.amount) || 0), 0),
+    payment: rows
+      .filter((row) => row.kind === "payment")
+      .reduce((sum, row) => sum + (Number(row.amount) || 0), 0),
+  };
+
+  return (
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-gray-950/50 p-4 backdrop-blur-[2px]">
+      <div className="max-h-[92vh] w-full max-w-5xl overflow-y-auto rounded-2xl bg-white shadow-2xl">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-5 py-4">
+          <div>
+            <h2 className="text-lg font-bold text-gray-900">입고 거래 조정</h2>
+            <p className="mt-1 text-xs text-gray-500">
+              {order.inventory_suppliers?.name ?? "거래처 정보 없음"} ·{" "}
+              {formatPurchaseAdjustmentDate(order.ordered_on)}
+            </p>
+          </div>
+          {isAdmin && (
+            <Button size="sm" variant="gray" onClick={onManageCategories}>
+              거래 항목 관리
+            </Button>
+          )}
+        </div>
+        <div className="p-5">
+          {categoriesError && (
+            <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+              거래 조정 SQL이 필요합니다.{" "}
+              <code className="font-semibold">
+                docs/inventory_purchase_adjustments.sql
+              </code>
+              을 실행해 주세요.
+            </div>
+          )}
+          <p className="mb-4 rounded-lg bg-gray-50 px-3 py-2 text-xs text-gray-500">
+            참고 기록이며 현재 입고금액이나 정산에는 자동 반영되지 않습니다.
+          </p>
+          <div className="grid gap-5 lg:grid-cols-2">
+            {(["discount", "payment"] as const).map((kind) => (
+              <section
+                key={kind}
+                className="rounded-xl border border-gray-200 bg-gray-50/70 p-4"
+              >
+                <div className="flex items-center justify-between">
+                  <h3
+                    className={`font-bold ${
+                      kind === "discount" ? "text-blue-700" : "text-orange-700"
+                    }`}
+                  >
+                    {kind === "discount" ? "할인된 항목" : "지불한 항목"}
+                  </h3>
+                  <strong className="text-sm text-gray-800">
+                    {kind === "discount" ? "-" : "+"}
+                    {totals[kind].toLocaleString("ko-KR")}원
+                  </strong>
+                </div>
+                <div className="mt-3 space-y-3">
+                  {rows
+                    .filter((row) => row.kind === kind)
+                    .map((row) => {
+                      const options = categories.filter(
+                        (item) =>
+                          item.kind === kind &&
+                          (item.is_active || item.id === row.categoryId) &&
+                          (item.id === row.categoryId ||
+                            !rows.some(
+                              (candidate) =>
+                                candidate.key !== row.key &&
+                                candidate.categoryId === item.id,
+                            )),
+                      );
+                      return (
+                        <div
+                          key={row.key}
+                          className="space-y-2 rounded-xl border border-gray-200 bg-white p-3"
+                        >
+                          <div className="grid gap-2 sm:grid-cols-[minmax(140px,1fr)_140px_auto]">
+                            <Dropdown controlledValue={row.categoryId}>
+                              <Dropdown.Trigger>
+                                {row.categoryName || "항목 선택"}
+                              </Dropdown.Trigger>
+                              <Dropdown.Content>
+                                {options.map((option) => (
+                                  <Dropdown.Item
+                                    key={option.id}
+                                    option={{
+                                      value: option.id,
+                                      label: option.name,
+                                    }}
+                                    onSelect={(selected: DropdownOption) => {
+                                      const category = categories.find(
+                                        (item) => item.id === selected.value,
+                                      );
+                                      if (category)
+                                        updateRow(row.key, {
+                                          categoryId: category.id,
+                                          categoryName: category.name,
+                                        });
+                                    }}
+                                  />
+                                ))}
+                              </Dropdown.Content>
+                            </Dropdown>
+                            <div className="relative">
+                              <input
+                                type="number"
+                                min="0"
+                                value={row.amount}
+                                onChange={(event) =>
+                                  updateRow(row.key, {
+                                    amount: event.target.value,
+                                  })
+                                }
+                                placeholder="0"
+                                className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 pr-8 text-right text-sm font-semibold outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                              />
+                              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400">
+                                원
+                              </span>
+                            </div>
+                            <Button
+                              size="sm"
+                              variant="danger"
+                              onClick={() =>
+                                setRows((current) =>
+                                  current.filter(
+                                    (item) => item.key !== row.key,
+                                  ),
+                                )
+                              }
+                            >
+                              삭제
+                            </Button>
+                          </div>
+                          <input
+                            value={row.note}
+                            onChange={(event) =>
+                              updateRow(row.key, { note: event.target.value })
+                            }
+                            placeholder="항목 메모"
+                            className="h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                          />
+                        </div>
+                      );
+                    })}
+                  <Button
+                    variant="gray"
+                    className="w-full"
+                    onClick={() => addRow(kind)}
+                  >
+                    {kind === "discount"
+                      ? "할인 항목 추가"
+                      : "지불 항목 추가"}
+                  </Button>
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-4">
+          <Button variant="gray" onClick={onClose} disabled={saving}>
+            취소
+          </Button>
+          <Button onClick={save} disabled={saving || categoriesError}>
+            {saving ? "저장 중..." : "조정 내역 저장"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PurchaseAdjustmentCategoryOverlay({
+  categories,
+  onClose,
+  onSaved,
+}: {
+  categories: PurchaseAdjustmentCategory[];
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const [names, setNames] = useState<Record<string, string>>(() =>
+    Object.fromEntries(categories.map((item) => [item.id, item.name])),
+  );
+  const [newNames, setNewNames] = useState<
+    Record<PurchaseAdjustmentKind, string>
+  >({ discount: "", payment: "" });
+  const [pending, setPending] = useState(false);
+
+  const run = async (task: () => Promise<void>, message: string) => {
+    setPending(true);
+    try {
+      await task();
+      toast.success(message);
+      await onSaved();
+    } catch (error) {
+      toast.error((error as Error).message);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-950/60 p-4 backdrop-blur-[2px]">
+      <div className="max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-2xl bg-white shadow-2xl">
+        <div className="border-b border-gray-200 px-5 py-4">
+          <h2 className="text-lg font-bold text-gray-900">거래 항목 관리</h2>
+          <p className="mt-1 text-xs text-gray-500">
+            삭제한 항목은 새 입고에서 숨겨지고 기존 입고 기록에는 유지됩니다.
+          </p>
+        </div>
+        <div className="grid gap-5 p-5 md:grid-cols-2">
+          {(["discount", "payment"] as const).map((kind) => (
+            <section
+              key={kind}
+              className="rounded-xl border border-gray-200 bg-gray-50/70 p-4"
+            >
+              <h3 className="font-bold text-gray-900">
+                {kind === "discount" ? "할인 항목" : "지불 항목"}
+              </h3>
+              <div className="mt-3 space-y-2">
+                {categories
+                  .filter((item) => item.kind === kind && item.is_active)
+                  .map((item) => (
+                    <div key={item.id} className="flex gap-2">
+                      <input
+                        value={names[item.id] ?? item.name}
+                        onChange={(event) =>
+                          setNames((current) => ({
+                            ...current,
+                            [item.id]: event.target.value,
+                          }))
+                        }
+                        className="h-10 min-w-0 flex-1 rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                      />
+                      <Button
+                        size="sm"
+                        variant="gray"
+                        disabled={pending}
+                        onClick={() =>
+                          void run(
+                            () =>
+                              savePurchaseAdjustmentCategory({
+                                id: item.id,
+                                name: names[item.id] ?? item.name,
+                                kind,
+                              }),
+                            "항목 이름을 수정했습니다.",
+                          )
+                        }
+                      >
+                        저장
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        disabled={pending}
+                        onClick={() => {
+                          if (window.confirm(`‘${item.name}’ 항목을 삭제할까요?`))
+                            void run(
+                              () =>
+                                deactivatePurchaseAdjustmentCategory(item.id),
+                              "항목을 삭제했습니다.",
+                            );
+                        }}
+                      >
+                        삭제
+                      </Button>
+                    </div>
+                  ))}
+                <div className="flex gap-2 border-t border-gray-200 pt-3">
+                  <input
+                    value={newNames[kind]}
+                    onChange={(event) =>
+                      setNewNames((current) => ({
+                        ...current,
+                        [kind]: event.target.value,
+                      }))
+                    }
+                    placeholder="새 항목 이름"
+                    className="h-10 min-w-0 flex-1 rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                  />
+                  <Button
+                    size="sm"
+                    disabled={pending || !newNames[kind].trim()}
+                    onClick={() =>
+                      void run(async () => {
+                        await savePurchaseAdjustmentCategory({
+                          name: newNames[kind],
+                          kind,
+                        });
+                        setNewNames((current) => ({ ...current, [kind]: "" }));
+                      }, "새 항목을 등록했습니다.")
+                    }
+                  >
+                    항목 등록
+                  </Button>
+                </div>
+              </div>
+            </section>
+          ))}
+        </div>
+        <div className="flex justify-end border-t border-gray-200 bg-gray-50 px-5 py-4">
+          <Button onClick={onClose}>완료</Button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,6 +1,7 @@
 import Header from './_components/Header';
 import SideMenu from './_components/SideMenu';
 import { UserProvider } from '@/app/_contexts/UserContext';
+import { StaffOpeningProvider } from '@/app/_contexts/StaffOpeningContext';
 
 export default function CustomersLayout({
   children,
@@ -9,10 +10,12 @@ export default function CustomersLayout({
 }) {
   return (
     <UserProvider requireAuth>
-      <div className="hidden header:block">
-        <Header />
-      </div>
-      <SideMenu>{children}</SideMenu>
+      <StaffOpeningProvider>
+        <div className="hidden header:block">
+          <Header />
+        </div>
+        <SideMenu>{children}</SideMenu>
+      </StaffOpeningProvider>
     </UserProvider>
   );
 }

--- a/src/app/(auth)/liqud-stand/page.tsx
+++ b/src/app/(auth)/liqud-stand/page.tsx
@@ -47,6 +47,7 @@ export default function LiqudStandPage() {
   const [filter, setFilter] = useState<StatusFilter>('all');
   const [sectionFilters, setSectionFilters] = useState<Record<string, StatusFilter>>({});
   const [selectedDate, setSelectedDate] = useState('');
+  const [itemNameSearch, setItemNameSearch] = useState('');
   const [selectedSectionIds, setSelectedSectionIds] = useState<string[]>([]);
   const [allowMultipleSections, setAllowMultipleSections] = useState(false);
   const [editing, setEditing] = useState<{ section: LiqudStandSection; row: number; column: number; cell?: LiqudStandCell } | null>(null);
@@ -160,9 +161,24 @@ export default function LiqudStandPage() {
   const visibleSections = selectedSectionIds.length
     ? sections.filter((section) => selectedSectionIds.includes(section.id))
     : sections;
+  const normalizedItemNameSearch = itemNameSearch
+    .trim()
+    .toLocaleLowerCase('ko-KR');
+  const matchesItemNameSearch = (cell?: LiqudStandCell) => {
+    if (!normalizedItemNameSearch) return true;
+    return [cell?.items?.item_name, cell?.item_name, cell?.secondary_item?.item_name, cell?.secondary_item_name]
+      .some((name) =>
+        name?.toLocaleLowerCase('ko-KR').includes(normalizedItemNameSearch),
+      );
+  };
   const dateConsumableCounts = visibleSections
     .flatMap((section) => section.liqud_stand_cells)
-    .filter((cell) => selectedDate && cell.item_name && cell.installed_on === selectedDate)
+    .filter((cell) =>
+      selectedDate &&
+      cell.item_name &&
+      cell.installed_on === selectedDate &&
+      matchesItemNameSearch(cell),
+    )
     .reduce<Record<string, number>>((result, cell) => {
       const name = cell.consumable_type || '미지정';
       result[name] = (result[name] ?? 0) + 1;
@@ -173,12 +189,51 @@ export default function LiqudStandPage() {
     <main className="mx-auto max-w-[1600px] space-y-5 px-4 py-6 sm:px-6 lg:px-8">
       <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
         <div className="grid gap-4 lg:grid-cols-3 lg:items-start">
-          <div className="w-full text-left">
-            <p className="mb-2 flex min-h-6 items-center text-xs font-semibold text-gray-500">날짜</p>
-            <div className="flex items-center gap-2">
-              <div className="min-w-0 flex-1"><KoreanDatePicker value={selectedDate} onChange={setSelectedDate} selectedLabel="선택한 교체 날짜" /></div>
-              {selectedDate && <Button size="xs" variant="gray" onClick={() => setSelectedDate('')}>날짜 해제</Button>}
+          <div className="grid w-full gap-4 text-left sm:grid-cols-2">
+            <div className="min-w-0">
+              <p className="mb-2 flex min-h-6 items-center text-xs font-semibold text-gray-500">날짜</p>
+              <div className="flex items-center gap-2">
+                <div className="min-w-0 flex-1"><KoreanDatePicker value={selectedDate} onChange={setSelectedDate} selectedLabel="선택한 교체 날짜" /></div>
+                {selectedDate && <Button size="xs" variant="gray" onClick={() => setSelectedDate('')}>해제</Button>}
+              </div>
             </div>
+            <label className="block min-w-0 sm:border-l sm:border-gray-200 sm:pl-4">
+              <span className="mb-2 flex min-h-6 items-center text-xs font-semibold text-gray-500">
+                품목명
+              </span>
+              <span className="relative block">
+                <svg
+                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                  />
+                </svg>
+                <input
+                  value={itemNameSearch}
+                  onChange={(event) => setItemNameSearch(event.target.value)}
+                  className="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-10 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                  placeholder="품목명 입력"
+                />
+                {itemNameSearch && (
+                  <button
+                    type="button"
+                    onClick={() => setItemNameSearch('')}
+                    aria-label="품목명 검색어 지우기"
+                    className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-gray-100 text-base font-medium text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 active:bg-gray-300"
+                  >
+                    ×
+                  </button>
+                )}
+              </span>
+            </label>
           </div>
           <div className="text-left lg:border-l lg:border-gray-200 lg:pl-4">
             <div className="mb-2 flex min-h-6 items-center gap-2">
@@ -270,6 +325,7 @@ export default function LiqudStandPage() {
                   .filter((cell) =>
                     cell.item_name &&
                     (!selectedDate || cell.installed_on === selectedDate) &&
+                    matchesItemNameSearch(cell) &&
                     (activeFilter === 'all' || getCellStatus(cell) === activeFilter),
                   )
                   .reduce<Record<string, number>>((result, cell) => {
@@ -307,7 +363,8 @@ export default function LiqudStandPage() {
                 const activeFilter = sectionFilters[section.id] ?? filter;
                 const matchesStatus = activeFilter === 'all' || (Boolean(cell?.item_name) && activeFilter === status);
                 const matchesDate = !selectedDate || (Boolean(cell?.item_name) && cell?.installed_on === selectedDate);
-                const visible = matchesStatus && matchesDate;
+                const matchesSearch = matchesItemNameSearch(cell);
+                const visible = matchesStatus && matchesDate && matchesSearch;
                 const bg = consumables.find((c) => c.name === cell?.consumable_type)?.color ?? '#ffffff';
                 const position = cell ? { sectionId: section.id, row, column, cell } : null;
                 const isMovingSource = moveSource?.sectionId === section.id && moveSource.row === row && moveSource.column === column;

--- a/src/app/(auth)/product-search/page.tsx
+++ b/src/app/(auth)/product-search/page.tsx
@@ -121,6 +121,10 @@ export default function ProductSearchPage() {
   const { isAdmin } = useUser();
   const [mode, setMode] = useState<SearchMode>('liquid');
   const [usageFilter, setUsageFilter] = useState<UsageFilter>('used');
+  const [showSoldOut, setShowSoldOut] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem('product-search-show-sold-out') === 'true';
+  });
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [columnEditing, setColumnEditing] = useState(false);
   const [columnWidthSnapshot, setColumnWidthSnapshot] = useState<
@@ -177,6 +181,12 @@ export default function ProductSearchPage() {
         if ((mode === 'liquid') !== isLiquid) return false;
         if (usageFilter === 'used' && !item.is_use) return false;
         if (usageFilter === 'unused' && item.is_use) return false;
+        if (
+          !showSoldOut &&
+          item.current_quantity != null &&
+          item.current_quantity <= 0
+        )
+          return false;
         return true;
       }),
     [
@@ -184,6 +194,7 @@ export default function ProductSearchPage() {
       liquidCategoryQuery.isError,
       mode,
       query.data,
+      showSoldOut,
       usageFilter,
     ],
   );
@@ -386,9 +397,47 @@ export default function ProductSearchPage() {
             </Dropdown>
           </div>
 
+          <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
+            <p className="mb-1 text-xs font-semibold text-gray-600">
+              품절 상품
+            </p>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showSoldOut}
+              onClick={() => {
+                const next = !showSoldOut;
+                setShowSoldOut(next);
+                window.localStorage.setItem(
+                  'product-search-show-sold-out',
+                  String(next),
+                );
+              }}
+              className={`flex h-11 w-full items-center justify-between gap-1.5 rounded-lg border bg-white px-2.5 text-xs font-semibold shadow-sm transition ${
+                showSoldOut
+                  ? 'border-brand-300 text-brand-700'
+                  : 'border-gray-300 text-gray-600 hover:border-brand-300'
+              }`}
+            >
+              <span>{showSoldOut ? '표시' : '미표시'}</span>
+              <span
+                aria-hidden="true"
+                className={`relative inline-flex h-5 w-9 shrink-0 overflow-hidden rounded-full transition ${
+                  showSoldOut ? 'bg-brand-500' : 'bg-gray-300'
+                }`}
+              >
+                <span
+                  className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                    showSoldOut ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
+              </span>
+            </button>
+          </div>
+
           <div className="h-px w-full bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
 
-          <div className="w-full rounded-xl border border-gray-200 bg-gray-50/70 p-3 lg:w-[740px] lg:shrink-0">
+          <div className="w-full min-w-0 rounded-xl border border-gray-200 bg-gray-50/70 p-3 lg:flex-1">
             <div className="grid gap-3 sm:grid-cols-3">
               {(
                 [
@@ -646,7 +695,7 @@ export default function ProductSearchPage() {
                     >
                       {item.current_quantity == null
                         ? '-'
-                        : item.current_quantity === 0
+                        : item.current_quantity <= 0
                           ? '품절'
                           : `${item.current_quantity.toLocaleString()}개`}
                     </td>

--- a/src/app/(auth)/work-journal/page.tsx
+++ b/src/app/(auth)/work-journal/page.tsx
@@ -26,6 +26,7 @@ import { workJournalKeys } from "@/app/_domains/_workJournal/_queryKeys/workJour
 import WorkerCreateModal from "./_components/WorkerCreateModal";
 import AttendanceRecordModal from "./_components/AttendanceRecordModal";
 import { useUser } from "@/app/_contexts/UserContext";
+import StaffOpeningProgressBanner from "@/app/(auth)/_components/StaffOpeningProgressBanner";
 import {
   WorkJournalType,
   WorkPaymentStatus,
@@ -212,7 +213,9 @@ export default function WorkJournalPage() {
   const createMutation = useMutation({
     mutationFn: createWorkJournal,
     onSuccess: async () => {
-      toast.success("근무 기록이 저장되었습니다.");
+      toast.success(
+        "출근 처리가 완료되었습니다. 다음으로 시작 시재를 확인해 주세요.",
+      );
       setSelectedMonth(workDate.slice(0, 7));
       resetWorkForm();
       setShowWorkForm(false);
@@ -454,6 +457,7 @@ export default function WorkJournalPage() {
 
   return (
     <main className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6 lg:px-8">
+      <StaffOpeningProgressBanner />
       <div className="flex items-end justify-between border-b border-gray-200">
         <div className="flex min-w-0 overflow-x-auto" role="tablist" aria-label="근무기록 메뉴">
           {tabOrder.map((tab, index) => {

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
-import supabase from '@/libs/supabaseClient';
+import supabase, {
+  clearLocalSupabaseSession,
+  isInvalidRefreshTokenError,
+} from '@/libs/supabaseClient';
 import { useRouter } from 'next/navigation';
 import Loading from '@/app/_components/Loading';
 
@@ -16,10 +19,22 @@ export default function LoginPage() {
 
   useEffect(() => {
     const checkSession = async () => {
-      const { data } = await supabase.auth.getSession();
-      if (data.session) {
-        router.push('/customers');
-      } else {
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (error && isInvalidRefreshTokenError(error)) {
+          await clearLocalSupabaseSession();
+        }
+        if (data.session && !error) {
+          router.push('/customers');
+          return;
+        }
+      } catch (error) {
+        if (isInvalidRefreshTokenError(error)) {
+          await clearLocalSupabaseSession();
+        } else {
+          console.error('Session check failed:', error);
+        }
+      } finally {
         setIsChecking(false);
       }
     };

--- a/src/app/_contexts/StaffOpeningContext.tsx
+++ b/src/app/_contexts/StaffOpeningContext.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { usePathname, useRouter } from "next/navigation";
+import Loading from "@/app/_components/Loading";
+import { useUser } from "@/app/_contexts/UserContext";
+import { getCurrentWorker } from "@/app/_domains/_workJournal/_utils/currentWorker";
+import supabase from "@/libs/supabaseClient";
+
+type StaffOpeningStep = "unlocked" | "attendance" | "cash" | "checklist";
+
+type StaffOpeningContextValue = {
+  step: StaffOpeningStep;
+  isLocked: boolean;
+  isLoading: boolean;
+  previousCash: number | null;
+  refresh: () => Promise<void>;
+};
+
+const StaffOpeningContext = createContext<StaffOpeningContextValue | undefined>(
+  undefined,
+);
+
+const getTodayInKorea = () =>
+  new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date());
+
+const isAllowedPathForStep = (
+  pathname: string,
+  step: StaffOpeningStep,
+) =>
+  pathname.startsWith("/work-journal") ||
+  pathname.startsWith("/cash-management") ||
+  (step === "checklist" && pathname.startsWith("/reports"));
+
+export const StaffOpeningProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { user, isAdmin, isLoading: isUserLoading } = useUser();
+  const pathname = usePathname();
+  const router = useRouter();
+  const [step, setStep] = useState<StaffOpeningStep>("unlocked");
+  const [previousCash, setPreviousCash] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    if (isUserLoading) return;
+    if (!user || isAdmin) {
+      setStep("unlocked");
+      setPreviousCash(null);
+      setIsLoading(false);
+      return;
+    }
+
+    const today = getTodayInKorea();
+
+    try {
+      const { data: latestReport, error: reportError } = await supabase
+        .from("daily_closing_reports")
+        .select("business_date")
+        .lt("business_date", today)
+        .order("business_date", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (reportError) throw reportError;
+
+      // 마감 기능을 아직 사용하지 않은 매장은 기존처럼 모든 메뉴를 사용한다.
+      if (!latestReport) {
+        setStep("unlocked");
+        setPreviousCash(null);
+        return;
+      }
+
+      const { data: previousClosing, error: previousError } = await supabase
+        .from("cash_register_closings")
+        .select("actual_cash")
+        .lte("business_date", latestReport.business_date)
+        .order("business_date", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (previousError) throw previousError;
+
+      const requiredPreviousCash = previousClosing
+        ? Number(previousClosing.actual_cash)
+        : null;
+      setPreviousCash(requiredPreviousCash);
+
+      const { data: todayClosing, error: todayClosingError } = await supabase
+        .from("cash_register_closings")
+        .select("opening_cash")
+        .eq("business_date", today)
+        .maybeSingle();
+
+      if (todayClosingError) throw todayClosingError;
+
+      const openingMatches =
+        requiredPreviousCash !== null &&
+        todayClosing !== null &&
+        Number(todayClosing.opening_cash) === requiredPreviousCash;
+
+      // 당일 시작 시재가 한 번 확인되면 이후 근무자에게도 열린 상태를 유지한다.
+      if (openingMatches) {
+        const { data: gateItems, error: gateItemsError } = await supabase
+          .from("daily_closing_checklist_items")
+          .select("id")
+          .eq("phase", "opening")
+          .eq("is_opening_gate", true);
+        if (gateItemsError) throw gateItemsError;
+
+        if (!gateItems?.length) {
+          setStep("unlocked");
+          return;
+        }
+
+        const { data: progress, error: progressError } = await supabase
+          .from("daily_opening_checklist_progress")
+          .select("checks")
+          .eq("business_date", today)
+          .maybeSingle();
+        if (progressError) throw progressError;
+
+        const checks = (progress?.checks ?? {}) as Record<string, boolean>;
+        setStep(
+          gateItems.every((item) => checks[item.id])
+            ? "unlocked"
+            : "checklist",
+        );
+        return;
+      }
+
+      const currentWorker = getCurrentWorker();
+      if (!currentWorker) {
+        setStep("attendance");
+        return;
+      }
+
+      const { data: journal, error: journalError } = await supabase
+        .from("work_journals")
+        .select("id")
+        .eq("work_date", today)
+        .eq("worker_name", currentWorker.name)
+        .eq("status", "working")
+        .maybeSingle();
+
+      if (journalError) throw journalError;
+      if (!journal) {
+        setStep("attendance");
+        return;
+      }
+
+      setStep("cash");
+    } catch (error) {
+      console.error("Staff opening status check failed:", error);
+      // 상태 확인 실패 시 스태프 권한을 넓히지 않는다.
+      setStep("attendance");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isAdmin, isUserLoading, user]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const handleAccessChanged = () => void refresh();
+    window.addEventListener("staff-opening-changed", handleAccessChanged);
+    window.addEventListener("focus", handleAccessChanged);
+    return () => {
+      window.removeEventListener("staff-opening-changed", handleAccessChanged);
+      window.removeEventListener("focus", handleAccessChanged);
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (isLoading || step === "unlocked" || !pathname) return;
+    if (isAllowedPathForStep(pathname, step)) return;
+    router.replace(step === "attendance" ? "/work-journal" : "/cash-management");
+  }, [isLoading, pathname, router, step]);
+
+  const value = useMemo(
+    () => ({
+      step,
+      isLocked: step !== "unlocked",
+      isLoading,
+      previousCash,
+      refresh,
+    }),
+    [isLoading, previousCash, refresh, step],
+  );
+
+  if (isUserLoading || isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loading size="lg" text="스태프 영업 시작 상태를 확인하는 중..." />
+      </div>
+    );
+  }
+
+  const isAllowedPath =
+    !pathname ||
+    step === "unlocked" ||
+    isAllowedPathForStep(pathname, step);
+
+  if (!isAllowedPath) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loading
+          size="lg"
+          text={
+            step === "attendance"
+              ? "출근 처리를 위해 근무일지로 이동하는 중..."
+              : "영업 시작 확인으로 이동하는 중..."
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <StaffOpeningContext.Provider value={value}>
+      {children}
+    </StaffOpeningContext.Provider>
+  );
+};
+
+export const useStaffOpening = () => {
+  const context = useContext(StaffOpeningContext);
+  if (!context) {
+    throw new Error(
+      "useStaffOpening must be used within a StaffOpeningProvider",
+    );
+  }
+  return context;
+};

--- a/src/app/_contexts/UserContext.tsx
+++ b/src/app/_contexts/UserContext.tsx
@@ -9,7 +9,10 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
-import supabase from "@/libs/supabaseClient";
+import supabase, {
+  clearLocalSupabaseSession,
+  isInvalidRefreshTokenError,
+} from "@/libs/supabaseClient";
 import Loading from "@/app/_components/Loading";
 import { UserType } from "@/app/_domains/_user/_types/user.types";
 
@@ -41,8 +44,17 @@ export const UserProvider = ({
       const { data: sessionData, error: sessionError } =
         await supabase.auth.getSession();
 
+      if (sessionError) {
+        if (isInvalidRefreshTokenError(sessionError)) {
+          await clearLocalSupabaseSession();
+        } else {
+          console.error("Session fetch error:", sessionError);
+        }
+      }
+
       if (sessionError || !sessionData.session) {
         setUser(null);
+        setIsAdmin(false);
         // requireAuth가 true면 로그인 페이지로 리다이렉트
         if (requireAuth) {
           router.push("/login");
@@ -71,8 +83,13 @@ export const UserProvider = ({
       setUser(userData);
       setIsAdmin(userData.oss_role === "admin");
     } catch (error) {
-      console.error("Error fetching user:", error);
+      if (isInvalidRefreshTokenError(error)) {
+        await clearLocalSupabaseSession();
+      } else {
+        console.error("Error fetching user:", error);
+      }
       setUser(null);
+      setIsAdmin(false);
       if (requireAuth) {
         router.push("/login");
       }

--- a/src/app/_domains/_cashManagement/_services/cashManagementService.ts
+++ b/src/app/_domains/_cashManagement/_services/cashManagementService.ts
@@ -54,6 +54,26 @@ export const getDailyCashSales = async (
 
   for (const log of data ?? []) {
     const jsonb = (log.jsonb ?? {}) as Record<string, unknown>;
+    const splitPayments = Array.isArray(jsonb.payments)
+      ? (jsonb.payments as Array<{
+          paymentType?: unknown;
+          amount?: unknown;
+        }>)
+      : [];
+    if (splitPayments.length) {
+      for (const payment of splitPayments) {
+        const splitType = String(payment.paymentType ?? '');
+        const splitAmount = Number(payment.amount ?? 0);
+        if (
+          !CASH_PAYMENT_TYPES.has(splitType) ||
+          !Number.isFinite(splitAmount)
+        )
+          continue;
+        if (splitType.startsWith('egu_')) eguVape += splitAmount;
+        else ovape += splitAmount;
+      }
+      continue;
+    }
     const paymentType = String(jsonb.paymentType ?? '');
     if (!CASH_PAYMENT_TYPES.has(paymentType)) continue;
 
@@ -73,6 +93,7 @@ export const getDailyCashSales = async (
 export const getDailyPaymentSales = async (
   date: string,
 ): Promise<DailyPaymentSales> => {
+  const usesSeparatedDeliveryCounts = date >= '2026-07-31';
   const { start, end } = getKoreaDateRange(date);
   const { data, error } = await supabase
     .from('logs')
@@ -85,40 +106,99 @@ export const getDailyPaymentSales = async (
 
   const amountByPaymentType = new Map<string, number>();
   const quantityByCategory = new Map<string, number>();
+  const deliveryByMethod = new Map<
+    'store_visit' | 'parcel' | 'delivery',
+    { orderCount: number; quantity: number; fee: number }
+  >();
 
   for (const log of data ?? []) {
     const jsonb = (log.jsonb ?? {}) as Record<string, unknown>;
+    const splitPayments = Array.isArray(jsonb.payments)
+      ? (jsonb.payments as Array<{
+          paymentType?: unknown;
+          amount?: unknown;
+        }>)
+      : [];
+    if (splitPayments.length) {
+      for (const payment of splitPayments) {
+        const splitType = String(payment.paymentType ?? '').trim();
+        const splitAmount = Number(payment.amount ?? 0);
+        if (
+          !splitType ||
+          NON_PAYMENT_TYPES.has(splitType) ||
+          !Number.isFinite(splitAmount)
+        )
+          continue;
+        amountByPaymentType.set(
+          splitType,
+          (amountByPaymentType.get(splitType) ?? 0) + splitAmount,
+        );
+      }
+    }
     const paymentType = String(jsonb.paymentType ?? '').trim();
     const amount = Number(jsonb.totalAmount ?? 0);
-    if (
-      !paymentType ||
-      NON_PAYMENT_TYPES.has(paymentType) ||
-      !Number.isFinite(amount)
-    ) {
-      continue;
+    if (!splitPayments.length) {
+      if (
+        paymentType &&
+        !NON_PAYMENT_TYPES.has(paymentType) &&
+        Number.isFinite(amount)
+      ) {
+        amountByPaymentType.set(
+          paymentType,
+          (amountByPaymentType.get(paymentType) ?? 0) + amount,
+        );
+      }
     }
 
-    amountByPaymentType.set(
-      paymentType,
-      (amountByPaymentType.get(paymentType) ?? 0) + amount,
-    );
-
+    const deliveryMethod =
+      jsonb.deliveryMethod === 'store_visit' ||
+      jsonb.deliveryMethod === 'parcel' ||
+      jsonb.deliveryMethod === 'delivery'
+        ? jsonb.deliveryMethod
+        : null;
     const items = Array.isArray(jsonb.items)
       ? (jsonb.items as Array<{
           itemCategoryName?: unknown;
           quantity?: unknown;
         }>)
       : [];
+    let deliveryItemQuantity = 0;
     for (const item of items) {
-      const categoryName =
-        String(item.itemCategoryName ?? "").trim() || "기타";
       const quantity = Number(item.quantity ?? 0);
       if (!Number.isFinite(quantity) || quantity <= 0) continue;
+
+      const categoryName =
+        String(item.itemCategoryName ?? '').trim() || '기타';
       quantityByCategory.set(
         categoryName,
         (quantityByCategory.get(categoryName) ?? 0) + quantity,
       );
+      deliveryItemQuantity += quantity;
     }
+
+    if (deliveryMethod) {
+      const current = deliveryByMethod.get(deliveryMethod) ?? {
+        orderCount: 0,
+        quantity: 0,
+        fee: 0,
+      };
+      deliveryByMethod.set(deliveryMethod, {
+        orderCount: current.orderCount + 1,
+        quantity: current.quantity + deliveryItemQuantity,
+        fee:
+          current.fee +
+          (deliveryMethod === 'store_visit'
+            ? 0
+            : Number(jsonb.deliveryFee ?? 0) || 0),
+      });
+    }
+  }
+
+  if (usesSeparatedDeliveryCounts) {
+    const parcelCount = deliveryByMethod.get('parcel')?.orderCount ?? 0;
+    const deliveryCount = deliveryByMethod.get('delivery')?.orderCount ?? 0;
+    if (parcelCount > 0) quantityByCategory.set('택배', parcelCount);
+    if (deliveryCount > 0) quantityByCategory.set('배달', deliveryCount);
   }
 
   const ovapeBreakdown = OVAPE_PAYMENT_TYPES.map((item) => ({
@@ -138,6 +218,25 @@ export const getDailyPaymentSales = async (
     itemSummary: [...quantityByCategory.entries()]
       .map(([categoryName, quantity]) => ({ categoryName, quantity }))
       .sort((a, b) => b.quantity - a.quantity),
+    outboundTypeSummary: [],
+    deliverySummary: [
+      ['store_visit', '매장방문'],
+      ['parcel', '택배'],
+      ['delivery', '배달'],
+    ].flatMap(([method, label]) => {
+      const summary = deliveryByMethod.get(
+        method as 'store_visit' | 'parcel' | 'delivery',
+      );
+      return summary
+        ? [
+            {
+              method: method as 'store_visit' | 'parcel' | 'delivery',
+              label,
+              ...summary,
+            },
+          ]
+        : [];
+    }),
     total: breakdown.reduce((sum, item) => sum + item.amount, 0),
   };
 };

--- a/src/app/_domains/_cashManagement/_types/cashManagement.types.ts
+++ b/src/app/_domains/_cashManagement/_types/cashManagement.types.ts
@@ -54,5 +54,17 @@ export type DailyPaymentSales = {
     categoryName: string;
     quantity: number;
   }[];
+  outboundTypeSummary: {
+    type: string;
+    label: string;
+    quantity: number;
+  }[];
+  deliverySummary: {
+    method: 'store_visit' | 'parcel' | 'delivery';
+    label: string;
+    orderCount: number;
+    quantity: number;
+    fee: number;
+  }[];
   total: number;
 };

--- a/src/app/_domains/_dailyClosing/_services/dailyClosingService.ts
+++ b/src/app/_domains/_dailyClosing/_services/dailyClosingService.ts
@@ -103,7 +103,7 @@ export const getDailyClosingChecklistItems = async (): Promise<
 > => {
   const { data, error } = await supabase
     .from('daily_closing_checklist_items')
-    .select('id, phase, label, sort_order, is_required')
+    .select('id, phase, label, sort_order, is_required, is_opening_gate')
     .order('phase', { ascending: true })
     .order('sort_order', { ascending: true });
 
@@ -118,6 +118,7 @@ export const saveDailyClosingChecklistItems = async (
     label: string;
     sortOrder: number;
     isRequired: boolean;
+    isOpeningGate: boolean;
   }[],
 ): Promise<void> => {
   const { error: deleteError } = await supabase
@@ -134,12 +135,51 @@ export const saveDailyClosingChecklistItems = async (
       label: item.label.trim(),
       sort_order: item.sortOrder,
       is_required: item.isRequired,
+      is_opening_gate: item.phase === 'opening' && item.isOpeningGate,
     }));
 
   if (!normalized.length) return;
   const { error } = await supabase
     .from('daily_closing_checklist_items')
     .insert(normalized);
+
+  if (error) throw error;
+};
+
+export const getDailyOpeningChecklistProgress = async (
+  businessDate: string,
+): Promise<DailyClosingChecklist> => {
+  const { data, error } = await supabase
+    .from('daily_opening_checklist_progress')
+    .select('checks')
+    .eq('business_date', businessDate)
+    .maybeSingle();
+
+  if (error) throw error;
+  return (data?.checks ?? {}) as DailyClosingChecklist;
+};
+
+export const saveDailyOpeningChecklistProgress = async (
+  businessDate: string,
+  checks: DailyClosingChecklist,
+): Promise<void> => {
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+  if (sessionError || !session) throw new Error('세션을 찾을 수 없습니다.');
+
+  const { error } = await supabase
+    .from('daily_opening_checklist_progress')
+    .upsert(
+      {
+        business_date: businessDate,
+        checks,
+        updated_by: session.user.id,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'business_date' },
+    );
 
   if (error) throw error;
 };

--- a/src/app/_domains/_dailyClosing/_types/dailyClosing.types.ts
+++ b/src/app/_domains/_dailyClosing/_types/dailyClosing.types.ts
@@ -8,6 +8,7 @@ export type DailyClosingChecklistItem = {
   label: string;
   sort_order: number;
   is_required: boolean;
+  is_opening_gate: boolean;
 };
 
 export type DailyClosingReportSnapshot = {
@@ -29,6 +30,18 @@ export type DailyClosingReportSnapshot = {
   itemSummary: Array<{
     categoryName: string;
     quantity: number;
+  }>;
+  outboundTypeSummary?: Array<{
+    type: string;
+    label: string;
+    quantity: number;
+  }>;
+  deliverySummary?: Array<{
+    method: 'store_visit' | 'parcel' | 'delivery';
+    label: string;
+    orderCount: number;
+    quantity: number;
+    fee: number;
   }>;
   totalSales: number;
   expectedCash: number;

--- a/src/app/_domains/_inventory/_services/inventoryService.ts
+++ b/src/app/_domains/_inventory/_services/inventoryService.ts
@@ -5,6 +5,8 @@ import type {
   InventoryMovement,
   InventoryTrackingSettings,
   InventorySupplier,
+  PurchaseAdjustmentCategory,
+  PurchaseOrderAdjustment,
   PurchaseOrder,
 } from "../_types/inventory.types";
 
@@ -14,6 +16,10 @@ export const inventoryKeys = {
   movements: ["inventory", "movements"] as const,
   suppliers: ["inventory", "suppliers"] as const,
   purchaseOrders: ["inventory", "purchase-orders"] as const,
+  purchaseAdjustmentCategories: [
+    "inventory",
+    "purchase-adjustment-categories",
+  ] as const,
 };
 
 export const normalizeInventoryItemName = (value: string) =>
@@ -322,7 +328,7 @@ export const getPurchaseOrders = async (
   const { data, error } = await supabase
     .from("inventory_purchase_orders")
     .select(
-      `*, inventory_suppliers(name), inventory_purchase_order_lines(${lineColumns}), inventory_purchase_receipts(id, arrived_on, note, created_at, reversed_at, inventory_purchase_receipt_lines(id, order_line_id, item_name, quantity, note, quantity_check_note))`,
+      `*, inventory_suppliers(name), inventory_purchase_order_lines(${lineColumns}), inventory_purchase_receipts(id, arrived_on, note, created_at, reversed_at, inventory_purchase_receipt_lines(id, order_line_id, item_name, quantity, note, quantity_check_note)), inventory_purchase_order_adjustments(id, category_id, category_name, kind, amount, note)`,
     )
     .order("created_at", { ascending: false });
   if (!error) return (data ?? []) as unknown as PurchaseOrder[];
@@ -340,6 +346,7 @@ export const getPurchaseOrders = async (
   if (legacyError) throw legacyError;
   return (legacyData ?? []).map((order) => ({
     ...order,
+    inventory_purchase_order_adjustments: [],
     inventory_purchase_order_lines: order.inventory_purchase_order_lines.map(
       (line: Record<string, unknown>) => ({
         ...line,
@@ -363,6 +370,95 @@ export const getPurchaseOrders = async (
       }),
     ),
   })) as unknown as PurchaseOrder[];
+};
+
+export const getPurchaseAdjustmentCategories = async (
+  includeInactive = false,
+): Promise<PurchaseAdjustmentCategory[]> => {
+  let query = supabase
+    .from("inventory_purchase_adjustment_categories")
+    .select("id, name, kind, sort_order, is_active")
+    .order("kind")
+    .order("sort_order")
+    .order("name");
+  if (!includeInactive) query = query.eq("is_active", true);
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data ?? []) as PurchaseAdjustmentCategory[];
+};
+
+export const savePurchaseAdjustmentCategory = async (values: {
+  id?: string;
+  name: string;
+  kind: PurchaseAdjustmentCategory["kind"];
+}): Promise<void> => {
+  const { error } = await supabase.rpc(
+    "save_inventory_purchase_adjustment_category",
+    {
+      p_id: values.id ?? null,
+      p_name: values.name.trim(),
+      p_kind: values.kind,
+    },
+  );
+  if (error) throw error;
+};
+
+export const deactivatePurchaseAdjustmentCategory = async (
+  id: string,
+): Promise<void> => {
+  const { error } = await supabase.rpc(
+    "deactivate_inventory_purchase_adjustment_category",
+    { p_id: id },
+  );
+  if (error) throw error;
+};
+
+export const savePurchaseOrderAdjustments = async (
+  orderId: string,
+  adjustments: Array<
+    Pick<
+      PurchaseOrderAdjustment,
+      "category_id" | "category_name" | "kind" | "amount" | "note"
+    >
+  >,
+): Promise<void> => {
+  const { error } = await supabase.rpc(
+    "save_inventory_purchase_order_adjustments",
+    {
+      p_order_id: orderId,
+      p_adjustments: adjustments,
+    },
+  );
+  if (error) throw error;
+};
+
+export const updatePurchaseOrderDetails = async (values: {
+  orderId: string;
+  supplierId: string;
+  orderedOn: string;
+  note: string;
+  lines: Array<{
+    id: string;
+    item_name: string;
+    ordered_quantity: number;
+    unit_price: number | null;
+    note: string;
+  }>;
+  receipts: Array<{
+    id: string;
+    arrived_on: string;
+    note: string;
+  }>;
+}): Promise<void> => {
+  const { error } = await supabase.rpc("update_inventory_purchase_order_details", {
+    p_order_id: values.orderId,
+    p_supplier_id: values.supplierId,
+    p_ordered_on: values.orderedOn,
+    p_note: values.note || null,
+    p_lines: values.lines,
+    p_receipts: values.receipts,
+  });
+  if (error) throw error;
 };
 export const createPurchaseOrder = async (
   supplierId: string,

--- a/src/app/_domains/_inventory/_types/inventory.types.ts
+++ b/src/app/_domains/_inventory/_types/inventory.types.ts
@@ -84,6 +84,22 @@ export type PurchaseReceipt = {
     quantity_check_note: string | null;
   }[];
 };
+export type PurchaseAdjustmentKind = "discount" | "payment";
+export type PurchaseAdjustmentCategory = {
+  id: string;
+  name: string;
+  kind: PurchaseAdjustmentKind;
+  sort_order: number;
+  is_active: boolean;
+};
+export type PurchaseOrderAdjustment = {
+  id: string;
+  category_id: string | null;
+  category_name: string;
+  kind: PurchaseAdjustmentKind;
+  amount: number;
+  note: string | null;
+};
 export type PurchaseOrder = {
   id: string;
   supplier_id: string;
@@ -95,4 +111,5 @@ export type PurchaseOrder = {
   inventory_suppliers: { name: string } | null;
   inventory_purchase_order_lines: PurchaseOrderLine[];
   inventory_purchase_receipts: PurchaseReceipt[];
+  inventory_purchase_order_adjustments: PurchaseOrderAdjustment[];
 };

--- a/src/app/_domains/_log/_hooks/useCopy.ts
+++ b/src/app/_domains/_log/_hooks/useCopy.ts
@@ -143,10 +143,15 @@ const useCopy = () => {
     const formattedDate = `${createdAt.getFullYear()}. ${String(
       createdAt.getMonth() + 1,
     ).padStart(2, '0')}. ${createdAt.getDate()}`;
+    const deliveryAddress =
+      typeof log.jsonb?.deliveryAddress === 'string'
+        ? log.jsonb.deliveryAddress.trim()
+        : '';
+    const address = deliveryAddress.replace(/\s+/g, ' ');
 
     const textToCopy = `${storeName}\t${formattedDate}\t${log.note}\t\t${amountFormula}\t${
       paymentTypeName ?? ''
-    }\t${name}\t${phone}\t${gender}`;
+    }\t${name}\t${phone}\t${gender}\t${address}`;
 
     try {
       await navigator.clipboard.writeText(textToCopy);

--- a/src/app/_domains/_log/_services/logService.ts
+++ b/src/app/_domains/_log/_services/logService.ts
@@ -43,10 +43,43 @@ const withCreatedWorker = async (jsonb: Record<string, unknown> | null) => {
 
 const withModifiedWorker = async (jsonb: Record<string, unknown>) => {
   const workerName = await resolveCurrentWorkerName();
+  const modifiedAt = new Date().toISOString();
+  const storedHistory = Array.isArray(jsonb.modificationHistory)
+    ? jsonb.modificationHistory.filter(
+        (
+          item,
+        ): item is {
+          workerName: string;
+          modifiedAt: string;
+        } =>
+          typeof item === 'object' &&
+          item !== null &&
+          typeof (item as Record<string, unknown>).workerName === 'string' &&
+          typeof (item as Record<string, unknown>).modifiedAt === 'string',
+      )
+    : [];
+  const legacyHistory =
+    storedHistory.length === 0 &&
+    typeof jsonb.modifiedWorkerName === 'string' &&
+    typeof jsonb.modifiedAt === 'string'
+      ? [
+          {
+            workerName: jsonb.modifiedWorkerName,
+            modifiedAt: jsonb.modifiedAt,
+          },
+        ]
+      : [];
+  const nextWorkerName = workerName || '알 수 없음';
+
   return {
     ...jsonb,
-    ...(workerName ? { modifiedWorkerName: workerName } : {}),
-    modifiedAt: new Date().toISOString(),
+    modifiedWorkerName: nextWorkerName,
+    modifiedAt,
+    modificationHistory: [
+      ...storedHistory,
+      ...legacyHistory,
+      { workerName: nextWorkerName, modifiedAt },
+    ],
   };
 };
 
@@ -201,7 +234,7 @@ export const getLogs = async (
       `
       *,
       users!admin_id(name, email),
-      customers(name, phone, gender)
+      customers(name, phone, address, note, gender)
     `,
     )
     .eq('category', category);
@@ -280,6 +313,27 @@ export const updateLogNote = async (
       nextJsonb.extraNote = logMeta.extraNote;
     } else {
       delete nextJsonb.extraNote;
+    }
+    nextJsonb.deliveryMethod = logMeta.deliveryMethod ?? 'store_visit';
+    if (logMeta.deliveryAddressSource) {
+      nextJsonb.deliveryAddressSource = logMeta.deliveryAddressSource;
+    } else {
+      delete nextJsonb.deliveryAddressSource;
+    }
+    if (logMeta.deliveryAddress) {
+      nextJsonb.deliveryAddress = logMeta.deliveryAddress;
+    } else {
+      delete nextJsonb.deliveryAddress;
+    }
+    if (logMeta.deliveryFee !== undefined) {
+      nextJsonb.deliveryFee = logMeta.deliveryFee;
+    } else {
+      delete nextJsonb.deliveryFee;
+    }
+    if (logMeta.payments?.length) {
+      nextJsonb.payments = logMeta.payments;
+    } else {
+      delete nextJsonb.payments;
     }
   }
 

--- a/src/app/_domains/_log/_types/log.types.ts
+++ b/src/app/_domains/_log/_types/log.types.ts
@@ -22,6 +22,10 @@ export type LogWorkerSnapshot = {
   createdWorkerName?: string;
   modifiedWorkerName?: string;
   modifiedAt?: string;
+  modificationHistory?: Array<{
+    workerName: string;
+    modifiedAt: string;
+  }>;
 };
 
 export type AfterServiceLogType = LogBaseType & {
@@ -31,6 +35,8 @@ export type AfterServiceLogType = LogBaseType & {
 export type LogCustomerInfo = {
   name: string;
   phone: string;
+  address?: string | null;
+  note?: string | null;
   gender?: 'male' | 'female' | null;
 };
 

--- a/src/app/_domains/_stamp/_services/stampService.ts
+++ b/src/app/_domains/_stamp/_services/stampService.ts
@@ -32,6 +32,17 @@ export type StampLogMeta = {
   storeName?: StoreTypeEnumType['value'];
   totalAmount?: number;
   extraNote?: string;
+  reservationDate?: string;
+  deliveryMethod?: 'store_visit' | 'parcel' | 'delivery';
+  deliveryAddressSource?: 'registered' | 'new';
+  deliveryAddress?: string;
+  deliveryMemo?: string;
+  deliveryFee?: number;
+  payments?: Array<{
+    paymentType: PaymentTypeEnumType['value'];
+    paymentTypeName: string;
+    amount: number;
+  }>;
   discount?: {
     type: string;
     name: string;

--- a/src/app/_domains/_workJournal/_services/workJournalService.ts
+++ b/src/app/_domains/_workJournal/_services/workJournalService.ts
@@ -280,6 +280,7 @@ export const createWorkJournal = async (values: {
     'current-work-worker',
     JSON.stringify({ name: normalizedWorkerName, workDate: values.workDate }),
   );
+  window.dispatchEvent(new Event('staff-opening-changed'));
 };
 
 export const completeWorkJournal = async (values: {

--- a/src/libs/supabaseClient.ts
+++ b/src/libs/supabaseClient.ts
@@ -9,4 +9,22 @@ if (!supabaseUrl || !supabaseKey) {
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 
+export const isInvalidRefreshTokenError = (error: unknown) => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' && error !== null && 'message' in error
+        ? String(error.message)
+        : '';
+
+  return (
+    message.includes('Invalid Refresh Token') ||
+    message.includes('Refresh Token Not Found')
+  );
+};
+
+export const clearLocalSupabaseSession = async () => {
+  await supabase.auth.signOut({ scope: 'local' }).catch(() => undefined);
+};
+
 export default supabase;


### PR DESCRIPTION
1. 스태프 오픈 절차
- 마감 이후 출근한 스태프의 메뉴 접근 제한
- 출근 처리 후 시작 시재 저장 안내 추가
- 전날 시재와 일치해야 전체 메뉴가 열리도록 처리
- 출근·교대 체크리스트의 ‘오픈’ 지정 항목 완료 시 메뉴 개방
- 오픈 진행 상태 배너 및 보고서 이동 기능 추가
- 잘못된 Supabase Refresh Token 자동 정리

2. 출고 이력 추가·수정
- 기본정보, 품목·금액, 최종확인 화면 전반 개편
- 출고 매장, 수령 방식, 결제 정보, 스탬프 적립 순차 입력
- 매장방문·택배·배달 수령 방식 추가
- 택배·배달 선택 시 배송비와 배송 주소 필수 입력
- 등록 주소 불러오기 및 새로작성 기능 추가
- 단일결제·분할결제·특이사항 결제 지원
- 분할결제 수단별 금액과 최종금액 일치 여부 검증
- 할인 유형, 예약 출고, 출고 메모 기능 개선
- 품목별 서비스·교환입고·교환출고·메모입력·가격조정 지원
- 품목 목록을 표 형태로 개편하고 수정·순서변경·삭제 기능 추가
- 추가 화면과 수정 화면의 폼 통일
- 출고 이력 수정 시 기존 고객 주소지·특이사항 조회 오류 수정
- 대상 고객의 주소지·특이사항이 없으면 ‘등록 없음’으로 표시
- X 남자·X 여자 특수고객은 스탬프를 항상 0개로 처리
- X 특수고객 출고 화면과 이력에서 스탬프 적립 표시 제거

3. 출고 이력 표시 및 복사
- 거래 정보, 품목, 출고 특이사항, 배송 주소를 구분해 표시
- 배송 주소 명칭을 ‘주소’로 변경
- 최초 작업자와 모든 수정 작업자·수정 시간을 순서대로 표시
- 전체 출고 이력, 예약 이력, 고객 상세 이력에 동일하게 적용
- 복사·붙여넣기 마지막 열에 실제 출고 시 입력한 배송 주소 추가
- 고객정보에 등록된 주소는 복사하지 않도록 처리

4. 마감보고서
- 기존 ‘판매종류 및 수량’ 형식 유지
- 2026년 7월 31일 마감부터 택배와 배달을 각각 건수로 집계
- 택배비·배달비는 매출에 포함하지 않고 출고 이력에만 저장
- 분할결제 금액을 결제수단별 매출 및 현금 시재에 반영
- 특이사항 결제 출고도 택배·배달 건수에서 누락되지 않도록 수정

5. 입고 관리
- 할인된 금액과 지불한 금액의 거래조정 기능 추가
- 거래조정 카테고리 이름 추가·수정·비활성화 지원
- 입고 대기부터 미입고 종료 및 입고 완료 건까지 전체 내용 수정
- 거래조정, 입고내용 수정, 거래조정 내역은 관리자만 사용 가능

6. 고객 관리
- 고객 등록 및 고객정보 수정의 주소지 입력칸을 3줄로 확장
- 주소지 입력 예시 문구 추가
- 고객 상세 대상 고객 표의 주소지·특이사항 레이아웃 개선

7. 상품검색·시연대
- 상품검색에 품절 상품 표시·미표시 토글 추가
- 재고가 0 이하인 상품을 품절로 처리
- 시연대 날짜 영역을 분할해 품목명 검색창 추가
- 주 품목과 보조 품목 검색 지원
- 검색 시 기존 시연대 위치를 유지하면서 일치하는 칸만 표시