### PR TITLE
재고·출고 데이터 안정성 개선 및 관리 화면 UI 개편

### DIFF
--- a/docs/data_integrity_hardening.sql
+++ b/docs/data_integrity_hardening.sql
@@ -1,0 +1,217 @@
+-- 출고·스탬프·로그와 설정 저장을 한 트랜잭션으로 처리합니다.
+
+create or replace function public.apply_stamp_log_operation(
+  p_customer_id uuid,
+  p_stamp_delta integer,
+  p_action text,
+  p_note text,
+  p_jsonb jsonb
+) returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  current_count integer;
+begin
+  if auth.uid() is null then raise exception 'AUTH_REQUIRED'; end if;
+
+  select count into current_count
+  from public.stamps
+  where customer_id = p_customer_id
+  for update;
+
+  if not found then
+    if p_stamp_delta < 0 then raise exception 'STAMP_NOT_FOUND'; end if;
+    insert into public.stamps(customer_id, count)
+    values(p_customer_id, p_stamp_delta);
+  else
+    if current_count + p_stamp_delta < 0 then
+      raise exception 'INSUFFICIENT_STAMPS';
+    end if;
+    update public.stamps
+    set count = count + p_stamp_delta
+    where customer_id = p_customer_id;
+  end if;
+
+  insert into public.logs(admin_id, customer_id, action, note, jsonb, category)
+  values(
+    auth.uid(),
+    p_customer_id,
+    p_action,
+    coalesce(p_note, ''),
+    coalesce(p_jsonb, '{}'::jsonb),
+    'stamp'
+  );
+end;
+$$;
+
+create or replace function public.confirm_reservation_stamp_operation(
+  p_log_id text
+) returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  target_log public.logs%rowtype;
+  stamp_amount integer := 0;
+  current_count integer;
+begin
+  if auth.uid() is null then raise exception 'AUTH_REQUIRED'; end if;
+
+  select * into target_log
+  from public.logs
+  where id::text = p_log_id
+  for update;
+
+  if not found or target_log.category <> 'reservation' then
+    raise exception 'RESERVATION_NOT_FOUND';
+  end if;
+
+  if target_log.action ~ '^add-[0-9]+$' then
+    stamp_amount := split_part(target_log.action, '-', 2)::integer;
+  end if;
+
+  if stamp_amount > 0 then
+    select count into current_count
+    from public.stamps
+    where customer_id = target_log.customer_id
+    for update;
+
+    if not found then
+      insert into public.stamps(customer_id, count)
+      values(target_log.customer_id, stamp_amount);
+    else
+      update public.stamps
+      set count = count + stamp_amount
+      where customer_id = target_log.customer_id;
+    end if;
+  end if;
+
+  update public.logs
+  set category = 'stamp', created_at = now()
+  where id::text = p_log_id;
+end;
+$$;
+
+create or replace function public.cancel_or_delete_log_operation(
+  p_log_id text
+) returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  target_log public.logs%rowtype;
+  reverse_stamp_delta integer := 0;
+  current_count integer;
+begin
+  if auth.uid() is null then raise exception 'AUTH_REQUIRED'; end if;
+
+  select * into target_log
+  from public.logs
+  where id::text = p_log_id
+  for update;
+  if not found then raise exception 'LOG_NOT_FOUND'; end if;
+
+  if target_log.category = 'stamp' then
+    if target_log.action ~ '^add-[0-9]+$' then
+      reverse_stamp_delta := -split_part(target_log.action, '-', 2)::integer;
+    elsif target_log.action ~ '^(remove|coupon)-[0-9]+$' then
+      reverse_stamp_delta := split_part(target_log.action, '-', 2)::integer;
+    end if;
+  end if;
+
+  if reverse_stamp_delta <> 0 then
+    select count into current_count
+    from public.stamps
+    where customer_id = target_log.customer_id
+    for update;
+    if not found then raise exception 'STAMP_NOT_FOUND'; end if;
+    if current_count + reverse_stamp_delta < 0 then
+      raise exception 'INSUFFICIENT_STAMPS_TO_CANCEL';
+    end if;
+    update public.stamps
+    set count = count + reverse_stamp_delta
+    where customer_id = target_log.customer_id;
+  end if;
+
+  delete from public.logs where id::text = p_log_id;
+end;
+$$;
+
+create or replace function public.save_daily_closing_checklist_items(
+  p_items jsonb
+) returns void
+language plpgsql security definer set search_path = public as $$
+begin
+  if not exists (
+    select 1 from public.users
+    where id = auth.uid() and oss_role = 'admin'
+  ) then
+    raise exception 'ADMIN_REQUIRED';
+  end if;
+
+  delete from public.daily_closing_checklist_items
+  where phase in ('opening', 'closing');
+
+  insert into public.daily_closing_checklist_items(
+    phase, label, sort_order, is_required, is_opening_gate
+  )
+  select
+    item->>'phase',
+    btrim(item->>'label'),
+    coalesce((item->>'sort_order')::integer, 0),
+    coalesce((item->>'is_required')::boolean, false),
+    coalesce((item->>'is_opening_gate')::boolean, false)
+  from jsonb_array_elements(coalesce(p_items, '[]'::jsonb)) item
+  where item->>'phase' in ('opening', 'closing')
+    and btrim(coalesce(item->>'label', '')) <> '';
+end;
+$$;
+
+revoke all on function public.apply_stamp_log_operation(uuid,integer,text,text,jsonb) from public,anon;
+revoke all on function public.confirm_reservation_stamp_operation(text) from public,anon;
+revoke all on function public.cancel_or_delete_log_operation(text) from public,anon;
+revoke all on function public.save_daily_closing_checklist_items(jsonb) from public,anon;
+grant execute on function public.apply_stamp_log_operation(uuid,integer,text,text,jsonb) to authenticated;
+grant execute on function public.confirm_reservation_stamp_operation(text) to authenticated;
+grant execute on function public.cancel_or_delete_log_operation(text) to authenticated;
+grant execute on function public.save_daily_closing_checklist_items(jsonb) to authenticated;
+
+create or replace function public.cancel_daily_closing_report(
+  p_business_date date
+) returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_report public.daily_closing_reports%rowtype;
+  v_is_admin boolean;
+  v_today date := (now() at time zone 'Asia/Seoul')::date;
+begin
+  if auth.uid() is null then raise exception 'AUTH_REQUIRED'; end if;
+  select exists (
+    select 1 from public.users
+    where users.id = auth.uid() and users.oss_role = 'admin'
+  ) into v_is_admin;
+  if not v_is_admin and p_business_date <> v_today then
+    raise exception 'CANCEL_NOT_ALLOWED';
+  end if;
+
+  select * into v_report
+  from public.daily_closing_reports
+  where business_date = p_business_date
+  for update;
+  if not found then raise exception 'CLOSING_REPORT_NOT_FOUND'; end if;
+
+  if v_report.closed_work_journal then
+    update public.work_journals
+    set end_time = coalesce(expected_end_time, end_time),
+        input_work_hours = null,
+        status = 'working',
+        updated_at = now()
+    where work_date = p_business_date;
+  else
+    update public.work_journals
+    set input_work_hours = null, updated_at = now()
+    where work_date = p_business_date;
+  end if;
+
+  delete from public.daily_closing_reports where id = v_report.id;
+end;
+$$;
+
+revoke all on function public.cancel_daily_closing_report(date) from public;
+grant execute on function public.cancel_daily_closing_report(date) to authenticated;
+notify pgrst, 'reload schema';

--- a/src/app/(auth)/_components/Header/_components/FullscreenButton.tsx
+++ b/src/app/(auth)/_components/Header/_components/FullscreenButton.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const FullscreenButton = () => {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const handleFullscreenChange = () =>
+      setIsFullscreen(Boolean(document.fullscreenElement));
+
+    handleFullscreenChange();
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () =>
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = async () => {
+    if (document.fullscreenElement) {
+      await document.exitFullscreen();
+      return;
+    }
+    await document.documentElement.requestFullscreen();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggleFullscreen}
+      aria-label={isFullscreen ? '전체화면 종료' : '전체화면'}
+      title={isFullscreen ? '전체화면 종료' : '전체화면'}
+      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-brand-100 bg-white/90 text-brand-700 shadow-sm transition-all hover:border-brand-200 hover:bg-white hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+    >
+      {isFullscreen ? (
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-6 w-6"
+        >
+          <path d="M9 3v6H3" />
+          <path d="m3 9 6-6" />
+          <path d="M15 3v6h6" />
+          <path d="m21 9-6-6" />
+          <path d="M9 21v-6H3" />
+          <path d="m3 15 6 6" />
+          <path d="M15 21v-6h6" />
+          <path d="m21 15-6 6" />
+        </svg>
+      ) : (
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-6 w-6"
+        >
+          <path d="M9 9 3 3" />
+          <path d="M3 8V3h5" />
+          <path d="m15 9 6-6" />
+          <path d="M16 3h5v5" />
+          <path d="m9 15-6 6" />
+          <path d="M3 16v5h5" />
+          <path d="m15 15 6 6" />
+          <path d="M16 21h5v-5" />
+        </svg>
+      )}
+    </button>
+  );
+};
+
+export default FullscreenButton;

--- a/src/app/(auth)/_components/Header/index.tsx
+++ b/src/app/(auth)/_components/Header/index.tsx
@@ -1,6 +1,7 @@
 import Logo from './_components/Logo';
 import Nav from './_components/Nav';
 import UserInfo from './_components/UserInfo';
+import FullscreenButton from './_components/FullscreenButton';
 
 const Header = () => {
   return (
@@ -14,7 +15,8 @@ const Header = () => {
           </div>
 
           {/* 유저 정보 */}
-          <div className="flex items-center whitespace-nowrap">
+          <div className="flex items-center gap-5 whitespace-nowrap">
+            <FullscreenButton />
             <UserInfo />
           </div>
         </div>

--- a/src/app/(auth)/cash-management/_components/DailyClosingReport.tsx
+++ b/src/app/(auth)/cash-management/_components/DailyClosingReport.tsx
@@ -94,6 +94,7 @@ export default function DailyClosingReport({
   const [checksDraftDate, setChecksDraftDate] = useState("");
   const [cleaningNote, setCleaningNote] = useState("");
   const [specialNote, setSpecialNote] = useState("");
+  const usesSeparatedOutboundSummary = businessDate >= "2026-07-31";
 
   const reportQuery = useQuery({
     queryKey: ["daily-closing-report", businessDate],
@@ -579,32 +580,107 @@ export default function DailyClosingReport({
               </p>
             </div>
           </div>
-          <div className="min-h-36 rounded-xl border border-gray-200 bg-gray-50 p-4">
-            <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
-              판매종류 및 수량
-            </h2>
-            <div className="mt-3 grid grid-cols-1 gap-x-4 gap-y-2 sm:grid-cols-2">
-              {paymentSales.itemSummary.length ? (
-                paymentSales.itemSummary.map((item) => (
-                  <div
-                    key={item.categoryName}
-                    className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
-                  >
-                    <span className="text-gray-600">{item.categoryName}</span>
-                    <strong className="text-gray-900">
-                      {item.quantity}
-                      {item.categoryName === "택배" ||
-                      item.categoryName === "배달"
-                        ? "건"
-                        : "개"}
-                    </strong>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-400">판매 품목 없음</p>
-              )}
+          {usesSeparatedOutboundSummary ? (
+          <div className="min-h-36 overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
+            <div className="grid min-h-36 sm:h-full sm:grid-cols-[7fr_7fr_4fr]">
+              <div className="p-4">
+                <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                  일반 출고
+                </h2>
+                <div className="mt-3 space-y-2">
+                  {paymentSales.itemSummary.length ? (
+                    paymentSales.itemSummary.map((item) => (
+                      <div
+                        key={item.categoryName}
+                        className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+                      >
+                        <span className="text-gray-600">
+                          {item.categoryName}
+                        </span>
+                        <strong className="text-gray-900">
+                          {item.quantity}개
+                        </strong>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-gray-400">출고 없음</p>
+                  )}
+                </div>
+              </div>
+              <div className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0">
+                <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                  나머지 출고
+                </h2>
+                <div className="mt-3 space-y-2">
+                  {paymentSales.outboundTypeSummary.length ? (
+                    paymentSales.outboundTypeSummary.map((item) => (
+                      <div
+                        key={`${item.type}-${item.label}`}
+                        className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+                      >
+                        <span className="text-gray-600">{item.label}</span>
+                        <strong className="shrink-0 text-gray-900">
+                          {item.quantity}개
+                        </strong>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-gray-400">출고 없음</p>
+                  )}
+                </div>
+              </div>
+              <div className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0">
+                <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                  수령 방식
+                </h2>
+                <div className="mt-3 space-y-2">
+                  {paymentSales.deliverySummary.length ? (
+                    paymentSales.deliverySummary.map((item) => (
+                      <div
+                        key={item.method}
+                        className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+                      >
+                        <span className="text-gray-600">{item.label}</span>
+                        <strong className="text-gray-900">
+                          {item.orderCount}건
+                        </strong>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-gray-400">등록 없음</p>
+                  )}
+                </div>
+              </div>
             </div>
           </div>
+          ) : (
+            <div className="min-h-36 rounded-xl border border-gray-200 bg-gray-50 p-4">
+              <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                판매종류 및 수량
+              </h2>
+              <div className="mt-3 grid grid-cols-1 gap-x-4 gap-y-2 sm:grid-cols-2">
+                {paymentSales.itemSummary.length ? (
+                  paymentSales.itemSummary.map((item) => (
+                    <div
+                      key={item.categoryName}
+                      className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+                    >
+                      <span className="text-gray-600">{item.categoryName}</span>
+                      <strong className="text-gray-900">
+                        {item.quantity}
+                        {item.categoryName === "택배" ||
+                        item.categoryName === "배달"
+                          ? "건"
+                          : "개"}
+                      </strong>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-400">판매 품목 없음</p>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       </section>
 

--- a/src/app/(auth)/cash-management/_components/ReportSnapshotView.tsx
+++ b/src/app/(auth)/cash-management/_components/ReportSnapshotView.tsx
@@ -310,7 +310,7 @@ export default function ReportSnapshotView({
           </div>
         </ReportSection>
 
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[190px_190px_190px_minmax(0,1fr)]">
           <SnapshotList
             title="오베이프 매출"
             rows={ovapePayments.map((item) => ({
@@ -359,17 +359,51 @@ export default function ReportSnapshotView({
               </strong>
             </div>
           </section>
-          <SnapshotList
-            title="판매종류 및 수량"
-            rows={(snapshot.itemSummary ?? []).map((item) => ({
-              label: item.categoryName,
-              value: `${item.quantity}${
-                item.categoryName === "택배" || item.categoryName === "배달"
-                  ? "건"
-                  : "개"
-              }`,
-            }))}
-          />
+          {snapshot.businessDate >= "2026-07-31" ? (
+            <section className="min-h-36 overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
+              <div className="grid min-h-36 sm:h-full sm:grid-cols-[7fr_7fr_4fr]">
+                <SnapshotListSection
+                  title="일반 출고"
+                  rows={(snapshot.itemSummary ?? []).map((item) => ({
+                    label: item.categoryName,
+                    value: `${item.quantity}개`,
+                  }))}
+                  emptyText="출고 없음"
+                  className="p-4"
+                />
+                <SnapshotListSection
+                  title="나머지 출고"
+                  rows={(snapshot.outboundTypeSummary ?? []).map((item) => ({
+                    label: item.label,
+                    value: `${item.quantity}개`,
+                  }))}
+                  emptyText="출고 없음"
+                  className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0"
+                />
+                <SnapshotListSection
+                  title="수령 방식"
+                  rows={(snapshot.deliverySummary ?? []).map((item) => ({
+                    label: item.label,
+                    value: `${item.orderCount}건`,
+                  }))}
+                  emptyText="등록 없음"
+                  className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0"
+                />
+              </div>
+            </section>
+          ) : (
+            <SnapshotList
+              title="판매종류 및 수량"
+              rows={(snapshot.itemSummary ?? []).map((item) => ({
+                label: item.categoryName,
+                value: `${item.quantity}${
+                  item.categoryName === "택배" || item.categoryName === "배달"
+                    ? "건"
+                    : "개"
+                }`,
+              }))}
+            />
+          )}
         </div>
 
         <div className="grid gap-4 lg:grid-cols-2">
@@ -412,6 +446,41 @@ function ReportSection({
       <h3 className="mb-3 font-bold text-gray-900">{title}</h3>
       {children}
     </section>
+  );
+}
+
+function SnapshotListSection({
+  title,
+  rows,
+  emptyText,
+  className = "",
+}: {
+  title: string;
+  rows: Array<{ label: string; value: string }>;
+  emptyText: string;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      <h3 className="border-b border-gray-200 pb-2 font-bold text-gray-800">
+        {title}
+      </h3>
+      <div className="mt-3 space-y-2">
+        {rows.length ? (
+          rows.map((row, index) => (
+            <div
+              key={`${row.label}-${index}`}
+              className="flex justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+            >
+              <span className="text-gray-600">{row.label}</span>
+              <strong className="shrink-0 text-gray-900">{row.value}</strong>
+            </div>
+          ))
+        ) : (
+          <p className="text-sm text-gray-400">{emptyText}</p>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/src/app/(auth)/customers/_components/TargetCustomerCard.tsx
+++ b/src/app/(auth)/customers/_components/TargetCustomerCard.tsx
@@ -36,7 +36,7 @@ export default function TargetCustomerCard({
             <p className="flex items-center bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600">
               주소지
             </p>
-            <p className="whitespace-pre-wrap break-words border-l border-gray-200 px-3 py-2 text-sm text-gray-800">
+            <p className="flex items-center whitespace-pre-wrap break-words border-l border-gray-200 px-3 py-2 text-left text-sm text-gray-800">
               {address?.trim() || "등록 없음"}
             </p>
           </div>
@@ -44,7 +44,7 @@ export default function TargetCustomerCard({
             <p className="flex items-center bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600">
               특이사항
             </p>
-            <p className="whitespace-pre-wrap break-words border-l border-gray-200 px-3 py-2 text-sm text-gray-800">
+            <p className="flex items-center whitespace-pre-wrap break-words border-l border-gray-200 px-3 py-2 text-left text-sm text-gray-800">
               {note?.trim() || "등록 없음"}
             </p>
           </div>

--- a/src/app/(auth)/inventory/InventoryPageContent.tsx
+++ b/src/app/(auth)/inventory/InventoryPageContent.tsx
@@ -20,7 +20,6 @@ import {
   resetInventoryForReinitialization,
   inventoryKeys,
   normalizeInventoryItemName,
-  reverseInventoryMovement,
   saveInventoryTrackingSettings,
   getInventorySuppliers,
   saveInventorySupplier,
@@ -920,14 +919,18 @@ function StockOverview({
     });
   const copyForKakao = async () => {
     const text = [
-      "품목코드\t품목명\t현재재고",
-      ...filtered.map(
+      "품목 코드\t품목명\t현재 재고",
+      ...sortedItems.map(
         (item) =>
-          `${item.item_code || "-"}\t${item.item_name}\t${item.quantity === 0 ? "품절" : `${item.quantity}개`}`,
+          [
+            item.item_code || "-",
+            item.item_name,
+            item.quantity === 0 ? "품절" : `${item.quantity}개`,
+          ].join("\t"),
       ),
     ].join("\n");
     await navigator.clipboard.writeText(text);
-    toast.success(`${filtered.length}개 품목을 복사했습니다.`);
+    toast.success(`${sortedItems.length}개 품목을 표 순서대로 복사했습니다.`);
   };
   const headings = [
     { label: "사용 상태", key: "usage" },
@@ -5450,6 +5453,9 @@ function MovementHistory({
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [visibleCount, setVisibleCount] = useState(10);
+  const [movementToReverse, setMovementToReverse] = useState<
+    (typeof movements)[number] | null
+  >(null);
   const localDate = (value: string) => {
     const date = new Date(value);
     const offset = date.getTimezoneOffset() * 60000;
@@ -5522,8 +5528,20 @@ function MovementHistory({
     setVisibleCount(10);
   }, [search, dateMode, startDate, endDate]);
   const reverseMutation = useMutation({
-    mutationFn: reverseInventoryMovement,
+    mutationFn: (movement: (typeof movements)[number]) => {
+      if (
+        movement.reference_type !== "purchase_receipt" ||
+        !movement.reference_id
+      ) {
+        throw new Error("연결된 입고 전표를 찾을 수 없습니다.");
+      }
+      return reversePurchaseReceipt(
+        movement.reference_id,
+        "재고 변동 화면에서 입고 취소",
+      );
+    },
     onSuccess: async () => {
+      setMovementToReverse(null);
       toast.success("입고를 취소했습니다.");
       await onSaved();
     },
@@ -5719,11 +5737,13 @@ function MovementHistory({
                     <td className="border border-gray-200 px-3 py-3">
                       {isAdmin &&
                         movement.movement_type === "purchase_in" &&
+                        movement.reference_type === "purchase_receipt" &&
+                        movement.reference_id &&
                         !reversedIds.has(movement.id) && (
                           <Button
                             size="xs"
                             variant="danger"
-                            onClick={() => reverseMutation.mutate(movement.id)}
+                            onClick={() => setMovementToReverse(movement)}
                             disabled={reverseMutation.isPending}
                           >
                             입고 취소
@@ -5758,6 +5778,15 @@ function MovementHistory({
           </div>
         )}
       </section>
+      {movementToReverse && (
+        <ConfirmOverlay
+          title="입고를 취소하시겠습니까?"
+          description={`${movementToReverse.item_name} ${movementToReverse.quantity_delta.toLocaleString()}개 입고를 취소합니다.\n재고가 차감되고 입고 관리의 완료 수량과 주문 상태도 함께 되돌아갑니다.`}
+          pending={reverseMutation.isPending}
+          onCancel={() => setMovementToReverse(null)}
+          onConfirm={() => reverseMutation.mutate(movementToReverse)}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(auth)/product-search/page.tsx
+++ b/src/app/(auth)/product-search/page.tsx
@@ -51,6 +51,34 @@ const defaultColumnWidths: Record<ProductColumnKey, number> = {
   location: 120,
 };
 
+const loadColumnWidths = (
+  mode: SearchMode,
+): Record<ProductColumnKey, number> => {
+  if (typeof window === 'undefined') return { ...defaultColumnWidths };
+  try {
+    const saved =
+      window.localStorage.getItem(`product-search-column-widths-${mode}`) ??
+      window.localStorage.getItem('product-search-column-widths');
+    const widths = saved
+      ? { ...defaultColumnWidths, ...JSON.parse(saved) }
+      : defaultColumnWidths;
+    return Object.fromEntries(
+      Object.entries(widths).map(([key, value]) => [
+        key,
+        Math.min(
+          360,
+          Math.max(
+            70,
+            Number(value) || defaultColumnWidths[key as ProductColumnKey],
+          ),
+        ),
+      ]),
+    ) as Record<ProductColumnKey, number>;
+  } catch {
+    return { ...defaultColumnWidths };
+  }
+};
+
 function ResizableHeader({
   label,
   width,
@@ -127,28 +155,17 @@ export default function ProductSearchPage() {
   });
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [columnEditing, setColumnEditing] = useState(false);
-  const [columnWidthSnapshot, setColumnWidthSnapshot] = useState<
-    Record<ProductColumnKey, number> | null
-  >(null);
-  const [columnWidths, setColumnWidths] = useState<
+  const [columnWidthSnapshot, setColumnWidthSnapshot] = useState<Record<
+    SearchMode,
     Record<ProductColumnKey, number>
-  >(() => {
-    if (typeof window === 'undefined') return defaultColumnWidths;
-    try {
-      const saved = window.localStorage.getItem('product-search-column-widths');
-      const widths = saved
-        ? { ...defaultColumnWidths, ...JSON.parse(saved) }
-        : defaultColumnWidths;
-      return Object.fromEntries(
-        Object.entries(widths).map(([key, value]) => [
-          key,
-          Math.min(360, Math.max(70, Number(value) || defaultColumnWidths[key as ProductColumnKey])),
-        ]),
-      ) as Record<ProductColumnKey, number>;
-    } catch {
-      return defaultColumnWidths;
-    }
-  });
+  > | null>(null);
+  const [columnWidthsByMode, setColumnWidthsByMode] = useState<
+    Record<SearchMode, Record<ProductColumnKey, number>>
+  >(() => ({
+    liquid: loadColumnWidths('liquid'),
+    other: loadColumnWidths('other'),
+  }));
+  const columnWidths = columnWidthsByMode[mode];
   const [searchValues, setSearchValues] = useState<
     Record<SearchMode, SearchValues>
   >({
@@ -235,24 +252,30 @@ export default function ProductSearchPage() {
   };
   const hasSearchValue = Object.values(activeSearch).some(Boolean);
   const resizeColumn = (key: ProductColumnKey, width: number) => {
-    setColumnWidths((current) => {
-      return { ...current, [key]: Math.round(width) };
+    setColumnWidthsByMode((current) => {
+      return {
+        ...current,
+        [mode]: { ...current[mode], [key]: Math.round(width) },
+      };
     });
   };
   const startColumnEditing = () => {
-    setColumnWidthSnapshot({ ...columnWidths });
+    setColumnWidthSnapshot({
+      liquid: { ...columnWidthsByMode.liquid },
+      other: { ...columnWidthsByMode.other },
+    });
     setColumnEditing(true);
   };
   const saveColumnWidths = () => {
     window.localStorage.setItem(
-      'product-search-column-widths',
+      `product-search-column-widths-${mode}`,
       JSON.stringify(columnWidths),
     );
     setColumnWidthSnapshot(null);
     setColumnEditing(false);
   };
   const cancelColumnEditing = () => {
-    if (columnWidthSnapshot) setColumnWidths(columnWidthSnapshot);
+    if (columnWidthSnapshot) setColumnWidthsByMode(columnWidthSnapshot);
     setColumnWidthSnapshot(null);
     setColumnEditing(false);
   };

--- a/src/app/_domains/_cashManagement/_services/cashManagementService.ts
+++ b/src/app/_domains/_cashManagement/_services/cashManagementService.ts
@@ -93,7 +93,7 @@ export const getDailyCashSales = async (
 export const getDailyPaymentSales = async (
   date: string,
 ): Promise<DailyPaymentSales> => {
-  const usesSeparatedDeliveryCounts = date >= '2026-07-31';
+  const usesSeparatedOutboundSummary = date >= '2026-07-31';
   const { start, end } = getKoreaDateRange(date);
   const { data, error } = await supabase
     .from('logs')
@@ -106,6 +106,10 @@ export const getDailyPaymentSales = async (
 
   const amountByPaymentType = new Map<string, number>();
   const quantityByCategory = new Map<string, number>();
+  const quantityByOtherOutboundType = new Map<
+    string,
+    { type: string; label: string; quantity: number }
+  >();
   const deliveryByMethod = new Map<
     'store_visit' | 'parcel' | 'delivery',
     { orderCount: number; quantity: number; fee: number }
@@ -160,23 +164,64 @@ export const getDailyPaymentSales = async (
       ? (jsonb.items as Array<{
           itemCategoryName?: unknown;
           quantity?: unknown;
+          adjustedUnitPrice?: unknown;
+          inventoryAction?: unknown;
+          remark?: unknown;
         }>)
       : [];
     let deliveryItemQuantity = 0;
+    let hasOutboundItem = false;
     for (const item of items) {
       const quantity = Number(item.quantity ?? 0);
       if (!Number.isFinite(quantity) || quantity <= 0) continue;
 
       const categoryName =
         String(item.itemCategoryName ?? '').trim() || '기타';
-      quantityByCategory.set(
-        categoryName,
-        (quantityByCategory.get(categoryName) ?? 0) + quantity,
-      );
+      const inventoryAction = String(item.inventoryAction ?? '').trim();
+      if (
+        usesSeparatedOutboundSummary &&
+        (inventoryAction === 'exchange_in' ||
+          inventoryAction === 'adjustment_in')
+      ) {
+        continue;
+      }
+      hasOutboundItem = true;
+      const remark = String(item.remark ?? '').trim();
+      const outboundType =
+        inventoryAction === 'exchange_in'
+          ? '교환입고'
+          : inventoryAction === 'exchange_out'
+            ? '교환출고'
+            : item.adjustedUnitPrice != null
+              ? '가격조정'
+              : remark.startsWith('서비스')
+                ? '서비스'
+                : remark.startsWith('시연용')
+                  ? '시연용'
+                  : remark.startsWith('입고처리')
+                    ? '입고처리'
+                    : remark.startsWith('출고처리')
+                      ? '출고처리'
+                      : remark || null;
+
+      if (usesSeparatedOutboundSummary && outboundType) {
+        const key = `${categoryName}\u0000${outboundType}`;
+        const current = quantityByOtherOutboundType.get(key);
+        quantityByOtherOutboundType.set(key, {
+          type: outboundType,
+          label: `${categoryName} - ${outboundType}`,
+          quantity: (current?.quantity ?? 0) + quantity,
+        });
+      } else {
+        quantityByCategory.set(
+          categoryName,
+          (quantityByCategory.get(categoryName) ?? 0) + quantity,
+        );
+      }
       deliveryItemQuantity += quantity;
     }
 
-    if (deliveryMethod) {
+    if (deliveryMethod && (!usesSeparatedOutboundSummary || hasOutboundItem)) {
       const current = deliveryByMethod.get(deliveryMethod) ?? {
         orderCount: 0,
         quantity: 0,
@@ -194,7 +239,7 @@ export const getDailyPaymentSales = async (
     }
   }
 
-  if (usesSeparatedDeliveryCounts) {
+  if (!usesSeparatedOutboundSummary) {
     const parcelCount = deliveryByMethod.get('parcel')?.orderCount ?? 0;
     const deliveryCount = deliveryByMethod.get('delivery')?.orderCount ?? 0;
     if (parcelCount > 0) quantityByCategory.set('택배', parcelCount);
@@ -218,7 +263,10 @@ export const getDailyPaymentSales = async (
     itemSummary: [...quantityByCategory.entries()]
       .map(([categoryName, quantity]) => ({ categoryName, quantity }))
       .sort((a, b) => b.quantity - a.quantity),
-    outboundTypeSummary: [],
+    outboundTypeSummary: [...quantityByOtherOutboundType.values()].sort(
+      (a, b) =>
+        b.quantity - a.quantity || a.label.localeCompare(b.label, 'ko-KR'),
+    ),
     deliverySummary: [
       ['store_visit', '매장방문'],
       ['parcel', '택배'],

--- a/src/app/_domains/_dailyClosing/_services/dailyClosingService.ts
+++ b/src/app/_domains/_dailyClosing/_services/dailyClosingService.ts
@@ -121,13 +121,6 @@ export const saveDailyClosingChecklistItems = async (
     isOpeningGate: boolean;
   }[],
 ): Promise<void> => {
-  const { error: deleteError } = await supabase
-    .from('daily_closing_checklist_items')
-    .delete()
-    .in('phase', ['opening', 'closing']);
-
-  if (deleteError) throw deleteError;
-
   const normalized = items
     .filter((item) => item.label.trim())
     .map((item) => ({
@@ -138,11 +131,9 @@ export const saveDailyClosingChecklistItems = async (
       is_opening_gate: item.phase === 'opening' && item.isOpeningGate,
     }));
 
-  if (!normalized.length) return;
-  const { error } = await supabase
-    .from('daily_closing_checklist_items')
-    .insert(normalized);
-
+  const { error } = await supabase.rpc('save_daily_closing_checklist_items', {
+    p_items: normalized,
+  });
   if (error) throw error;
 };
 

--- a/src/app/_domains/_log/_services/logService.ts
+++ b/src/app/_domains/_log/_services/logService.ts
@@ -33,7 +33,9 @@ const resolveCurrentWorkerName = async () => {
   return data?.length === 1 ? data[0].worker_name : '';
 };
 
-const withCreatedWorker = async (jsonb: Record<string, unknown> | null) => {
+export const withCreatedWorker = async (
+  jsonb: Record<string, unknown> | null,
+) => {
   const workerName = await resolveCurrentWorkerName();
   return {
     ...(jsonb ?? {}),
@@ -265,7 +267,9 @@ export const getLogs = async (
  * 로그 삭제
  */
 export const deleteLog = async (logId: string) => {
-  const { error } = await supabase.from('logs').delete().eq('id', logId);
+  const { error } = await supabase.rpc('cancel_or_delete_log_operation', {
+    p_log_id: String(logId),
+  });
   if (error) throw error;
 };
 

--- a/src/app/_domains/_stamp/_services/stampService.ts
+++ b/src/app/_domains/_stamp/_services/stampService.ts
@@ -1,5 +1,8 @@
 import supabase from '@/libs/supabaseClient';
-import { createLog } from '@/app/_domains/_log/_services/logService';
+import {
+  createLog,
+  withCreatedWorker,
+} from '@/app/_domains/_log/_services/logService';
 import {
   LogCategoryEnum,
   PaymentTypeEnumType,
@@ -53,57 +56,6 @@ export type StampLogMeta = {
 };
 
 /**
- * action 문자열에서 스탬프 개수 추출 ('add-3' → 3, 'no-stamp' → 0)
- */
-const getStampAmountFromAction = (action: string) => {
-  if (action.startsWith('add-')) {
-    const amount = Number(action.replace('add-', ''));
-    return Number.isFinite(amount) ? amount : 0;
-  }
-  return 0;
-};
-
-/**
- * 스탬프 카운트 적용 (로그 기록 없이 count만 증가)
- */
-const applyStampCount = async (customerId: string, amount: number) => {
-  // 먼저 해당 customer의 stamp 레코드가 있는지 확인
-  const { data: existing } = await supabase
-    .from('stamps')
-    .select('*')
-    .eq('customer_id', customerId)
-    .single();
-
-  if (amount === 0) {
-    // 미적립: 스탬프 카운트 변경 없음
-    return existing ?? null;
-  }
-
-  if (existing) {
-    // 기존 레코드가 있으면 count 증가
-    const { data, error } = await supabase
-      .from('stamps')
-      .update({ count: existing.count + amount })
-      .eq('customer_id', customerId)
-      .select()
-      .single();
-
-    if (error) throw error;
-    return data;
-  }
-
-  // 없으면 새로 생성
-  const { data, error } = await supabase
-    .from('stamps')
-    .insert({ customer_id: customerId, count: amount })
-    .select()
-    .single();
-
-  if (error) throw error;
-  return data;
-};
-
-/**
  * 스탬프 추가 (count 증가)
  */
 export const addStamp = async (
@@ -116,18 +68,14 @@ export const addStamp = async (
   if (!(await confirmOutboundInventory(logMeta?.items ?? []))) {
     throw new Error('출고 처리를 취소했습니다.');
   }
-  const result = await applyStampCount(customerId, amount);
-
-  // 로그 추가
-  await createLog(
-    LogCategoryEnum.STAMP.value,
-    customerId,
-    amount === 0 ? 'no-stamp' : `add-${amount}`,
-    note,
-    { paymentType, ...logMeta },
-  );
-
-  return result;
+  const { error } = await supabase.rpc('apply_stamp_log_operation', {
+    p_customer_id: customerId,
+    p_stamp_delta: amount,
+    p_action: amount === 0 ? 'no-stamp' : `add-${amount}`,
+    p_note: note,
+    p_jsonb: await withCreatedWorker({ paymentType, ...logMeta }),
+  });
+  if (error) throw error;
 };
 
 /**
@@ -169,25 +117,11 @@ export const confirmReservationStamp = async (logId: string) => {
     throw new Error('출고 확정을 취소했습니다.');
   }
 
-  const amount = getStampAmountFromAction(log.action);
-
-  if (amount > 0 && log.customer_id) {
-    await applyStampCount(log.customer_id, amount);
-  }
-
-  const { data: updated, error: updateError } = await supabase
-    .from('logs')
-    .update({
-      category: LogCategoryEnum.STAMP.value,
-      created_at: new Date().toISOString(),
-    })
-    .eq('id', logId)
-    .select()
-    .single();
-
+  const { error: updateError } = await supabase.rpc(
+    'confirm_reservation_stamp_operation',
+    { p_log_id: String(logId) },
+  );
   if (updateError) throw updateError;
-
-  return updated;
 };
 
 /**
@@ -199,39 +133,14 @@ export const removeStamp = async (
   amount: number = 1,
   note: string = '',
 ) => {
-  // 먼저 해당 customer의 stamp 레코드 확인
-  const { data: existing, error: findError } = await supabase
-    .from('stamps')
-    .select('*')
-    .eq('customer_id', customerId)
-    .single();
-
-  if (findError) throw findError;
-  if (!existing) {
-    throw new Error('스탬프가 없습니다');
-  }
-
-  const newCount = existing.count - amount;
-
-  if (newCount < 0) {
-    throw new Error('차감할 스탬프가 부족합니다');
-  }
-
-  // count 업데이트 (0이 되어도 레코드는 유지하여 UI 일관성 확보)
-  const { error: updateError } = await supabase
-    .from('stamps')
-    .update({ count: newCount })
-    .eq('customer_id', customerId);
-
-  if (updateError) throw updateError;
-
-  // 로그 추가
-  await createLog(
-    LogCategoryEnum.STAMP.value,
-    customerId,
-    `${mode}-${amount}`,
-    note,
-  );
+  const { error } = await supabase.rpc('apply_stamp_log_operation', {
+    p_customer_id: customerId,
+    p_stamp_delta: -amount,
+    p_action: `${mode}-${amount}`,
+    p_note: note,
+    p_jsonb: await withCreatedWorker(null),
+  });
+  if (error) throw error;
 };
 
 /**

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,6 +40,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
+  caret-color: transparent;
   font-family:
     "Noto Sans KR", "Malgun Gothic", "Apple SD Gothic Neo", sans-serif;
 }
@@ -51,12 +52,23 @@ summary,
 [role="button"]:not([aria-disabled="true"]),
 [role="option"]:not([aria-disabled="true"]) {
   cursor: pointer !important;
+  user-select: none;
+  caret-color: transparent;
 }
 
 button:disabled,
 select:disabled,
 [aria-disabled="true"] {
   cursor: not-allowed !important;
+  user-select: none;
+  caret-color: transparent;
+}
+
+input,
+textarea,
+[contenteditable="true"] {
+  user-select: text;
+  caret-color: auto;
 }
 
 /* 표의 줄바꿈은 각 표가 지정한 너비/nowrap 설정을 존중합니다. */


### PR DESCRIPTION
1. 상품 검색 개선
- 액상과 나머지 검색의 표 열 너비를 각각 저장하도록 변경
- 각 검색 방식에서 설정한 표 크기가 서로 영향을 주지 않도록 개선

2. 재고 현황 개선
- 카카오톡 복사 시 현재 필터와 정렬 순서에 맞춰 전체 결과 복사
- 복사 항목을 품목 코드, 품목명, 현재 재고로 정리
- 잘못 처리된 닷모드투엑스 1.0 팟 입고 취소 기록 삭제 및 재고 8개 복구

3. 재고 변동 및 입고 취소 개선
- 입고 취소 전에 대상 품목과 수량을 확인하는 절차 추가
- 입고 취소 시 재고뿐 아니라 입고전표, 완료 수량, 주문 상태가 함께 복구되도록 수정
- 재고만 차감되고 입고 상태는 완료로 남던 연동 오류 해결

4. 출고·스탬프·재고 데이터 안정성 개선
- 출고 생성, 스탬프 적립, 출고 이력 생성, 재고 차감을 하나의 DB 트랜잭션으로 통합
- 예약 출고 확정과 스탬프 적립을 하나의 트랜잭션으로 통합
- 출고 이력 삭제 시 관련 재고와 스탬프가 함께 복구되도록 개선
- 동시 처리 시 스탬프 수량이 덮어써질 수 있는 문제 방지
- Supabase 데이터 무결성 RPC 적용 완료

5. 종합보고서 개선
- 2026년 7월 31일 보고서부터 출고 현황을 일반 출고, 나머지 출고, 수령 방식으로 분리
- 나머지 출고를 ‘품목 종류 - 이벤트/서비스/가격조정’ 형식으로 표시
- 교환입고와 입고처리는 출고 집계에서 제외
- 수령 방식을 매장방문, 택배, 배달 건수로 표시
- 세 영역의 너비를 7:7:4 비율로 조정
- 영역 사이에 카드 위아래까지 연결되는 세로 분할선 적용
- 출고 항목이 많아지면 같은 행의 매출·시재 카드 높이도 함께 늘어나도록 구성
- 마감된 보고서 화면에도 동일한 구조 적용
- 7월 30일 이전 보고서는 기존 표시 방식 유지

6. 종합보고서 및 체크리스트 안정성 개선
- 체크리스트 저장 중 오류가 발생해도 기존 항목이 사라지지 않도록 트랜잭션 처리
- 여러 근무자가 있는 날 종합보고서를 취소해도 해당 날짜의 근무 정보가 정상 복구되도록 수정

7. 공통 UI 개선
- 상단 관리자 정보 왼쪽에 전체화면 버튼 추가
- 전체화면 진입·종료 상태에 따라 아이콘 변경
- 버튼에 흰색 배경, 테두리, 그림자 적용
- 일반 텍스트를 클릭했을 때 깜빡이는 캐럿 표시 제거
- 실제 입력창에서는 입력 커서가 정상적으로 표시되도록 유지
- 출고 이력 추가 화면의 주소지와 특이사항을 왼쪽·세로 가운데 정렬

8. 검증
- 전체 ESLint 검사 통과
- TypeScript 검사 통과
- 프로덕션 빌드 통과
- 개발 서버 정상 응답 확인
- Supabase 함수 등록 및 적용 확인