### PR TITLE
0731(2) 출고 이력 UI 개선 및 분할결제 처리 오류 수정

### DIFF
--- a/docs/data_integrity_hardening.sql
+++ b/docs/data_integrity_hardening.sql
@@ -1,7 +1,9 @@
 -- 출고·스탬프·로그와 설정 저장을 한 트랜잭션으로 처리합니다.
 
+drop function if exists public.apply_stamp_log_operation(uuid,integer,text,text,jsonb);
+
 create or replace function public.apply_stamp_log_operation(
-  p_customer_id uuid,
+  p_customer_id bigint,
   p_stamp_delta integer,
   p_action text,
   p_note text,
@@ -162,11 +164,11 @@ begin
 end;
 $$;
 
-revoke all on function public.apply_stamp_log_operation(uuid,integer,text,text,jsonb) from public,anon;
+revoke all on function public.apply_stamp_log_operation(bigint,integer,text,text,jsonb) from public,anon;
 revoke all on function public.confirm_reservation_stamp_operation(text) from public,anon;
 revoke all on function public.cancel_or_delete_log_operation(text) from public,anon;
 revoke all on function public.save_daily_closing_checklist_items(jsonb) from public,anon;
-grant execute on function public.apply_stamp_log_operation(uuid,integer,text,text,jsonb) to authenticated;
+grant execute on function public.apply_stamp_log_operation(bigint,integer,text,text,jsonb) to authenticated;
 grant execute on function public.confirm_reservation_stamp_operation(text) to authenticated;
 grant execute on function public.cancel_or_delete_log_operation(text) to authenticated;
 grant execute on function public.save_daily_closing_checklist_items(jsonb) to authenticated;

--- a/src/app/(auth)/_components/Header/_components/FullscreenButton.tsx
+++ b/src/app/(auth)/_components/Header/_components/FullscreenButton.tsx
@@ -1,26 +1,72 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const FULLSCREEN_PREFERENCE_KEY = 'app-fullscreen-preferred';
 
 const FullscreenButton = () => {
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const prefersFullscreenRef = useRef(false);
+
+  const requestFullscreen = useCallback(async () => {
+    if (document.fullscreenElement || !document.fullscreenEnabled) return true;
+
+    try {
+      await document.documentElement.requestFullscreen();
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
 
   useEffect(() => {
     const handleFullscreenChange = () =>
       setIsFullscreen(Boolean(document.fullscreenElement));
+    const restoreFullscreen = () => {
+      if (
+        prefersFullscreenRef.current &&
+        document.visibilityState === 'visible' &&
+        !document.fullscreenElement
+      ) {
+        void requestFullscreen();
+      }
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') restoreFullscreen();
+    };
 
+    prefersFullscreenRef.current =
+      window.localStorage.getItem(FULLSCREEN_PREFERENCE_KEY) === 'true';
     handleFullscreenChange();
+    restoreFullscreen();
     document.addEventListener('fullscreenchange', handleFullscreenChange);
-    return () =>
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    document.addEventListener('pointerdown', restoreFullscreen, true);
+    document.addEventListener('keydown', restoreFullscreen, true);
+
+    return () => {
       document.removeEventListener('fullscreenchange', handleFullscreenChange);
-  }, []);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      document.removeEventListener('pointerdown', restoreFullscreen, true);
+      document.removeEventListener('keydown', restoreFullscreen, true);
+    };
+  }, [requestFullscreen]);
 
   const toggleFullscreen = async () => {
     if (document.fullscreenElement) {
+      prefersFullscreenRef.current = false;
+      window.localStorage.removeItem(FULLSCREEN_PREFERENCE_KEY);
       await document.exitFullscreen();
       return;
     }
-    await document.documentElement.requestFullscreen();
+
+    prefersFullscreenRef.current = true;
+    window.localStorage.setItem(FULLSCREEN_PREFERENCE_KEY, 'true');
+    const enteredFullscreen = await requestFullscreen();
+    if (!enteredFullscreen) {
+      prefersFullscreenRef.current = false;
+      window.localStorage.removeItem(FULLSCREEN_PREFERENCE_KEY);
+    }
   };
 
   return (

--- a/src/app/(auth)/_components/HistoriesComponents/PaymentTypeLabel.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/PaymentTypeLabel.tsx
@@ -9,6 +9,40 @@ const paymentTypeNameByValue = Object.values(PaymentTypeEnum).reduce(
 );
 
 const PaymentTypeLabel = ({ jsonb }: { jsonb: Record<string, unknown> }) => {
+  const splitPayments = Array.isArray(jsonb.payments)
+    ? jsonb.payments.filter(
+        (
+          payment,
+        ): payment is {
+          paymentType: PaymentTypeEnumType['value'];
+          amount: number;
+        } =>
+          typeof payment === 'object' &&
+          payment !== null &&
+          typeof payment.paymentType === 'string' &&
+          typeof payment.amount === 'number',
+      )
+    : [];
+
+  if (splitPayments.length >= 2) {
+    return (
+      <div className="flex flex-col items-start gap-1">
+        {splitPayments.map((payment, index) => (
+          <span
+            key={`${payment.paymentType}-${index}`}
+            className="inline-flex items-center rounded-full bg-gray-100 px-1.5 py-1 text-xs font-medium text-gray-500"
+          >
+            {paymentTypeNameByValue[payment.paymentType]?.replace(
+              '이구베이프',
+              '',
+            )}{' '}
+            {payment.amount.toLocaleString('ko-KR')}원
+          </span>
+        ))}
+      </div>
+    );
+  }
+
   const paymentTypeValue = jsonb?.paymentType as
     | PaymentTypeEnumType['value']
     | undefined;

--- a/src/app/(auth)/cash-management/page.tsx
+++ b/src/app/(auth)/cash-management/page.tsx
@@ -469,7 +469,7 @@ export default function CashManagementPage() {
             );
           })}
         </div>
-        <button
+        {isAdmin && <button
           type="button"
           onClick={() => setEditingTabOrder((current) => !current)}
           className={`mb-2 ml-3 flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border bg-white transition ${
@@ -483,7 +483,7 @@ export default function CashManagementPage() {
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z" />
           </svg>
-        </button>
+        </button>}
       </div>
 
       {activeTab === 'save' && (

--- a/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
@@ -10,6 +10,7 @@ import {
   StoreLabel,
 } from '@/app/(auth)/_components/HistoriesComponents';
 import useCopy from '@/app/_domains/_log/_hooks/useCopy';
+import { isSpecialCustomer } from '@/app/_domains/_customer/_utils/specialCustomer';
 
 interface StampHistoryItemProps {
   log: LogsResType;
@@ -31,14 +32,22 @@ const StampHistoryItem = ({
   showCopy = true,
 }: StampHistoryItemProps) => {
   const { copyLogToClipboard } = useCopy();
-  const isNoStampCustomer =
-    log.customers?.name?.trim() === 'X' &&
-    log.customers?.phone?.trim() === 'X';
+  const isSplitPayment =
+    Array.isArray(log.jsonb?.payments) && log.jsonb.payments.length >= 2;
+  const hasSpecialCustomer =
+    Boolean(log.customers?.name) &&
+    isSpecialCustomer(log.customers.name, log.customers.phone);
 
   return (
     <div className="flex items-center justify-between p-2.5 sm:p-4 rounded-lg border border-brand-50 hover:bg-brand-50/30 transition-colors whitespace-nowrap text-xs sm:text-sm">
       <div className="flex items-center gap-2 sm:gap-4">
-        {!isNoStampCustomer && <ActionInfoLabel action={log.action} />}
+        {hasSpecialCustomer ? (
+          <span className="whitespace-nowrap rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">
+            특수계정
+          </span>
+        ) : (
+          <ActionInfoLabel action={log.action} />
+        )}
         <CustomerInfo
           name={log.customers?.name}
           phone={log.customers?.phone}
@@ -68,7 +77,11 @@ const StampHistoryItem = ({
           </Button>
           <div className="min-w-[240px] flex-1 break-words whitespace-normal text-xs text-gray-600 sm:text-sm">
             <p className="whitespace-pre-line">
-              {log.note || <span className="text-gray-400"> - </span>}
+              {log.note ? (
+                `${isSplitPayment ? '분할결제) ' : ''}${log.note}`
+              ) : (
+                <span className="text-gray-400"> - </span>
+              )}
             </p>
             {typeof log.jsonb?.extraNote === 'string' &&
               log.jsonb.extraNote.trim() && (

--- a/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
@@ -39,15 +39,17 @@ const StampHistoryItem = ({
     isSpecialCustomer(log.customers.name, log.customers.phone);
 
   return (
-    <div className="flex items-center justify-between p-2.5 sm:p-4 rounded-lg border border-brand-50 hover:bg-brand-50/30 transition-colors whitespace-nowrap text-xs sm:text-sm">
-      <div className="flex items-center gap-2 sm:gap-4">
-        {hasSpecialCustomer ? (
-          <span className="whitespace-nowrap rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">
-            특수계정
-          </span>
-        ) : (
-          <ActionInfoLabel action={log.action} />
-        )}
+    <div className="grid grid-cols-[125px_88px_minmax(260px,1fr)_115px_auto] items-center gap-2 whitespace-nowrap rounded-lg border border-brand-50 p-2.5 text-xs transition-colors hover:bg-brand-50/30 sm:px-2 sm:py-4 sm:text-sm">
+      <div className="flex min-w-0 self-start flex-col items-center text-center">
+        <div>
+          {hasSpecialCustomer ? (
+            <span className="inline-flex whitespace-nowrap rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">
+              특수계정
+            </span>
+          ) : (
+            <ActionInfoLabel action={log.action} />
+          )}
+        </div>
         <CustomerInfo
           name={log.customers?.name}
           phone={log.customers?.phone}
@@ -55,7 +57,7 @@ const StampHistoryItem = ({
         />
       </div>
 
-      <div className="flex flex-col items-start gap-1">
+      <div className="ml-2 flex min-w-0 self-start flex-col items-start gap-1">
         {log.jsonb && 'storeName' in log.jsonb && (
           <StoreLabel jsonb={log.jsonb} />
         )}
@@ -70,12 +72,12 @@ const StampHistoryItem = ({
           )}
       </div>
 
-      <div className="flex-1 max-w-[600px] pl-3 ml-3 sm:pl-4 sm:ml-4 border-l border-brand-100">
+      <div className="min-w-0 border-l border-brand-100 pl-3 sm:pl-4">
         <div className="flex items-start gap-2">
           <Button variant="secondary" size="xs" onClick={onEdit}>
             ✏️
           </Button>
-          <div className="min-w-[240px] flex-1 break-words whitespace-normal text-xs text-gray-600 sm:text-sm">
+          <div className="min-w-0 flex-1 break-words whitespace-normal text-xs text-gray-600 sm:text-sm">
             <p className="whitespace-pre-line">
               {log.note ? (
                 `${isSplitPayment ? '분할결제) ' : ''}${log.note}`
@@ -112,7 +114,7 @@ const StampHistoryItem = ({
         )}
       </div>
 
-      <div className="ml-4 flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         {onConfirm && (
           <Button variant="primary" size="sm" onClick={onConfirm}>
             출고 확정

--- a/src/app/(auth)/histories/_components/StampHistories/index.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/index.tsx
@@ -336,7 +336,7 @@ const StampHistories = ({
         </div>
       ) : (
         <div className="overflow-x-auto">
-          <div className="w-max min-w-[1100px] space-y-4 sm:space-y-6 text-xs sm:text-sm">
+          <div className="w-full min-w-[960px] space-y-4 text-xs sm:space-y-6 sm:text-sm">
             {sortedDates.map((dateKey) => {
               const logsOfDate = itemsByDate[dateKey];
 

--- a/src/app/(auth)/inventory/InventoryPageContent.tsx
+++ b/src/app/(auth)/inventory/InventoryPageContent.tsx
@@ -257,7 +257,7 @@ export function InventoryPageContent({
             ),
           )}
         </div>
-        <button
+        {isAdmin && <button
           type="button"
           onClick={() => setEditingTabOrder((current) => !current)}
           className={`mb-2 ml-3 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-white transition ${
@@ -284,7 +284,7 @@ export function InventoryPageContent({
               d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z"
             />
           </svg>
-        </button>
+        </button>}
       </div>
       )}
       {inventorySection === "receive" && (
@@ -330,7 +330,7 @@ export function InventoryPageContent({
               </div>
             ))}
           </div>
-          <button
+          {isAdmin && <button
             type="button"
             onClick={() =>
               setEditingReceiveTabOrder((current) => !current)
@@ -354,7 +354,7 @@ export function InventoryPageContent({
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z" />
             </svg>
-          </button>
+          </button>}
         </div>
       )}
 

--- a/src/app/(auth)/work-journal/page.tsx
+++ b/src/app/(auth)/work-journal/page.tsx
@@ -509,7 +509,7 @@ export default function WorkJournalPage() {
             );
           })}
         </div>
-        <button
+        {isAdmin && <button
           type="button"
           onClick={() => setEditingTabOrder((current) => !current)}
           className={`mb-2 ml-3 flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border bg-white transition ${
@@ -523,7 +523,7 @@ export default function WorkJournalPage() {
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z" />
           </svg>
-        </button>
+        </button>}
       </div>
 
       {activeTab === "workers" && isAdmin && (

--- a/src/app/_domains/_log/_hooks/useCopy.ts
+++ b/src/app/_domains/_log/_hooks/useCopy.ts
@@ -93,6 +93,20 @@ const useCopy = () => {
     const basePaymentTypeName =
       paymentTypeLabelOverride ??
       (paymentTypeValue ? paymentTypeNameByValue[paymentTypeValue] : undefined);
+    const splitPayments = Array.isArray(log.jsonb?.payments)
+      ? log.jsonb.payments.filter(
+          (
+            payment,
+          ): payment is {
+            paymentType: PaymentTypeEnumType['value'];
+            amount: number;
+          } =>
+            typeof payment === 'object' &&
+            payment !== null &&
+            typeof payment.paymentType === 'string' &&
+            typeof payment.amount === 'number',
+        )
+      : [];
 
     const isEguPayment =
       typeof paymentTypeValue === 'string' &&
@@ -149,9 +163,29 @@ const useCopy = () => {
         : '';
     const address = deliveryAddress.replace(/\s+/g, ' ');
 
-    const textToCopy = `${storeName}\t${formattedDate}\t${log.note}\t\t${amountFormula}\t${
-      paymentTypeName ?? ''
-    }\t${name}\t${phone}\t${gender}\t${address}`;
+    const buildClipboardRow = (
+      note: string,
+      copiedAmount: string,
+      copiedPaymentType: string,
+    ) =>
+      `${storeName}\t${formattedDate}\t${note}\t\t${copiedAmount}\t${copiedPaymentType}\t${name}\t${phone}\t${gender}\t${address}`;
+
+    const textToCopy =
+      splitPayments.length >= 2
+        ? splitPayments
+            .map((payment) =>
+              buildClipboardRow(
+                `분할결제) ${log.note}`,
+                String(payment.amount),
+                paymentTypeNameByValue[payment.paymentType] ?? '',
+              ),
+            )
+            .join('\n')
+        : buildClipboardRow(
+            log.note,
+            amountFormula,
+            paymentTypeName ?? '',
+          );
 
     try {
       await navigator.clipboard.writeText(textToCopy);

--- a/src/app/_domains/_log/_services/logService.ts
+++ b/src/app/_domains/_log/_services/logService.ts
@@ -248,7 +248,12 @@ export const getLogs = async (
   }
 
   if (paymentMethod) {
-    query = query.eq('jsonb->>paymentType', paymentMethod);
+    const splitPaymentFilter = JSON.stringify([
+      { paymentType: paymentMethod },
+    ]);
+    query = query.or(
+      `jsonb->>paymentType.eq.${paymentMethod},jsonb->payments.cs.${splitPaymentFilter}`,
+    );
   }
 
   if (searchKeyword) {


### PR DESCRIPTION
내용

- staff 계정에서 재고/입고, 시재, 근무일지, 보고서의 탭 순서 변경 버튼 숨김 처리
- 태블릿 잠금 해제 후 전체화면 상태가 자동으로 복원되도록 개선
- 고객 ID 숫자형 불일치로 발생하던 UUID 오류 수정
- 분할결제 출고 이력에 카드·현금 등 결제수단별 금액 표시
- 분할결제 총 결제금액 표시 유지
- 분할결제 품목명 앞에 `분할결제)` 문구 표시
- 구글 스프레드시트 복사 시 결제수단별로 행을 분리하여 붙여넣도록 개선
- 분할결제에 포함된 보조 결제수단으로도 출고 이력을 검색할 수 있도록 수정
- X 남자, X 여자, 시연용, 재고조정 이력에 `특수계정` 표시
- 출고 이력의 고객, 결제정보, 품목, 작업자, 복사 버튼 열 정렬 개선
- 긴 품목명과 특이사항이 영역 안에서 자동 줄바꿈되도록 개선
- 좁은 화면에서도 작업자와 복사 버튼이 보이도록 표 너비와 간격 최적화
- 전체 ESLint 및 TypeScript 검사 완료
- 개발 서버와 출고 이력 화면 정상 동작 확인