### PR TITLE
feat: 재고·근무기록·마감보고서 운영 기능 개선

### DIFF
--- a/src/app/(auth)/_components/Header/_components/Logo.tsx
+++ b/src/app/(auth)/_components/Header/_components/Logo.tsx
@@ -4,13 +4,13 @@ import Image from 'next/image';
 const Logo = () => {
   return (
     <Link href="/" className="flex items-center gap-2">
-      <div className="w-15 h-15 rounded-lg flex items-center justify-center overflow-hidden">
+      <div className="relative flex h-15 w-15 items-center justify-center overflow-hidden rounded-lg">
         <Image
           src="/logo.PNG"
           alt="OSS Logo"
-          width={50}
-          height={50}
-          className="object-contain"
+          fill
+          sizes="60px"
+          className="object-contain p-[5px]"
         />
       </div>
     </Link>

--- a/src/app/(auth)/_components/Header/_components/Nav.tsx
+++ b/src/app/(auth)/_components/Header/_components/Nav.tsx
@@ -1,41 +1,84 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import toast from 'react-hot-toast';
-import Button from '@/app/_components/Button';
-import { useUser } from '@/app/_contexts/UserContext';
-import { useStaffOpening } from '@/app/_contexts/StaffOpeningContext';
-import supabase from '@/libs/supabaseClient';
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import toast from "react-hot-toast";
+import Button from "@/app/_components/Button";
+import { useUser } from "@/app/_contexts/UserContext";
+import { useStaffOpening } from "@/app/_contexts/StaffOpeningContext";
+import supabase from "@/libs/supabaseClient";
 
-type GroupKey = 'customer' | 'product' | 'store';
-type MenuItem = { href: string; label: string; group_key: GroupKey; sort_order: number };
+type GroupKey = "customer" | "product" | "store";
+type MenuItem = {
+  href: string;
+  label: string;
+  group_key: GroupKey;
+  sort_order: number;
+};
 
 const groupLabels: Record<GroupKey, string> = {
-  customer: '고객 관리',
-  product: '상품 관리',
-  store: '매장 운영',
+  customer: "고객 관리",
+  product: "상품 관리",
+  store: "매장 운영",
 };
-const groupOrder: GroupKey[] = ['customer', 'product', 'store'];
+const groupOrder: GroupKey[] = ["customer", "product", "store"];
 const defaultMenuItems: MenuItem[] = [
-  { href: '/customers', label: '고객', group_key: 'customer', sort_order: 0 },
-  { href: '/histories', label: '이력', group_key: 'customer', sort_order: 1 },
-  { href: '/after-services', label: 'AS 현황', group_key: 'customer', sort_order: 2 },
-  { href: '/product-search', label: '상품 검색', group_key: 'product', sort_order: 0 },
-  { href: '/items', label: '품목 관리', group_key: 'product', sort_order: 1 },
-  { href: '/inventory', label: '재고/입고', group_key: 'product', sort_order: 2 },
-  { href: '/comparison', label: '기기 비교', group_key: 'product', sort_order: 3 },
-  { href: '/liqud-stand', label: '시연대', group_key: 'product', sort_order: 4 },
-  { href: '/cash-management', label: '시재', group_key: 'store', sort_order: 0 },
-  { href: '/reports', label: '보고서', group_key: 'store', sort_order: 1 },
-  { href: '/work-journal', label: '근무일지', group_key: 'store', sort_order: 2 },
-  { href: '/manuals', label: '매뉴얼', group_key: 'store', sort_order: 3 },
+  { href: "/customers", label: "고객", group_key: "customer", sort_order: 0 },
+  { href: "/histories", label: "이력", group_key: "customer", sort_order: 1 },
+  {
+    href: "/after-services",
+    label: "AS 현황",
+    group_key: "customer",
+    sort_order: 2,
+  },
+  {
+    href: "/product-search",
+    label: "상품 검색",
+    group_key: "product",
+    sort_order: 0,
+  },
+  { href: "/items", label: "품목 관리", group_key: "product", sort_order: 1 },
+  {
+    href: "/inventory",
+    label: "재고/입고",
+    group_key: "product",
+    sort_order: 2,
+  },
+  {
+    href: "/comparison",
+    label: "기기 비교",
+    group_key: "product",
+    sort_order: 3,
+  },
+  {
+    href: "/liqud-stand",
+    label: "시연대",
+    group_key: "product",
+    sort_order: 4,
+  },
+  {
+    href: "/cash-management",
+    label: "시재",
+    group_key: "store",
+    sort_order: 0,
+  },
+  { href: "/reports", label: "보고서", group_key: "store", sort_order: 1 },
+  {
+    href: "/work-journal",
+    label: "근무일지",
+    group_key: "store",
+    sort_order: 2,
+  },
+  { href: "/manuals", label: "매뉴얼", group_key: "store", sort_order: 3 },
 ];
 
-type NavProps = { orientation?: 'horizontal' | 'vertical'; onNavigate?: () => void };
+type NavProps = {
+  orientation?: "horizontal" | "vertical";
+  onNavigate?: () => void;
+};
 
-const Nav = ({ orientation = 'horizontal', onNavigate }: NavProps) => {
+const Nav = ({ orientation = "horizontal", onNavigate }: NavProps) => {
   const pathname = usePathname();
   const { isAdmin } = useUser();
   const { isLocked, step: staffOpeningStep } = useStaffOpening();
@@ -49,8 +92,18 @@ const Nav = ({ orientation = 'horizontal', onNavigate }: NavProps) => {
 
   useEffect(() => {
     const loadMenu = async () => {
-      const { data, error } = await supabase.from('navigation_menu_settings').select('href, label, group_key, sort_order');
-      if (!error && data?.length) setMenuItems(defaultMenuItems.map((fallback) => (data as MenuItem[]).find((item) => item.href === fallback.href) ?? fallback));
+      const { data, error } = await supabase
+        .from("navigation_menu_settings")
+        .select("href, label, group_key, sort_order");
+      if (!error && data?.length)
+        setMenuItems(
+          defaultMenuItems.map(
+            (fallback) =>
+              (data as MenuItem[]).find(
+                (item) => item.href === fallback.href,
+              ) ?? fallback,
+          ),
+        );
     };
     loadMenu();
   }, []);
@@ -67,14 +120,14 @@ const Nav = ({ orientation = 'horizontal', onNavigate }: NavProps) => {
       if (!navRef.current?.contains(event.target as Node)) setOpenGroup(null);
     };
     const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpenGroup(null);
+      if (event.key === "Escape") setOpenGroup(null);
     };
 
-    document.addEventListener('pointerdown', closeOnOutsidePointer);
-    document.addEventListener('keydown', closeOnEscape);
+    document.addEventListener("pointerdown", closeOnOutsidePointer);
+    document.addEventListener("keydown", closeOnEscape);
     return () => {
-      document.removeEventListener('pointerdown', closeOnOutsidePointer);
-      document.removeEventListener('keydown', closeOnEscape);
+      document.removeEventListener("pointerdown", closeOnOutsidePointer);
+      document.removeEventListener("keydown", closeOnEscape);
     };
   }, [openGroup]);
 
@@ -82,11 +135,11 @@ const Nav = ({ orientation = 'horizontal', onNavigate }: NavProps) => {
     () =>
       menuItems.filter(
         (item) =>
-          (isAdmin || item.href !== '/items') &&
+          (isAdmin || item.href !== "/items") &&
           (!isLocked ||
-            item.href === '/work-journal' ||
-            item.href === '/cash-management' ||
-            (staffOpeningStep === 'checklist' && item.href === '/reports')),
+            item.href === "/work-journal" ||
+            item.href === "/cash-management" ||
+            (staffOpeningStep === "checklist" && item.href === "/reports")),
       ),
     [isAdmin, isLocked, menuItems, staffOpeningStep],
   );
@@ -103,85 +156,340 @@ const Nav = ({ orientation = 'horizontal', onNavigate }: NavProps) => {
         .filter((group) => group.links.length > 0),
     [visibleMenuItems],
   );
-  const closeAfterNavigate = () => { setOpenGroup(null); onNavigate?.(); };
+  const closeAfterNavigate = () => {
+    setOpenGroup(null);
+    onNavigate?.();
+  };
 
   const moveDraft = (href: string, direction: -1 | 1) => {
     setDraftItems((current) => {
       const target = current.find((item) => item.href === href);
       if (!target) return current;
-      const groupItems = current.filter((item) => item.group_key === target.group_key).sort((a, b) => a.sort_order - b.sort_order);
+      const groupItems = current
+        .filter((item) => item.group_key === target.group_key)
+        .sort((a, b) => a.sort_order - b.sort_order);
       const index = groupItems.findIndex((item) => item.href === href);
       const swap = groupItems[index + direction];
       if (!swap) return current;
-      return current.map((item) => item.href === target.href ? { ...item, sort_order: swap.sort_order } : item.href === swap.href ? { ...item, sort_order: target.sort_order } : item);
+      return current.map((item) =>
+        item.href === target.href
+          ? { ...item, sort_order: swap.sort_order }
+          : item.href === swap.href
+            ? { ...item, sort_order: target.sort_order }
+            : item,
+      );
     });
   };
 
   const saveMenu = async () => {
     setSaving(true);
-    const normalized = groupOrder.flatMap((key) => draftItems.filter((item) => item.group_key === key).sort((a, b) => a.sort_order - b.sort_order).map((item, index) => ({ ...item, sort_order: index })));
-    const { error } = await supabase.from('navigation_menu_settings').upsert(normalized, { onConflict: 'href' });
+    const normalized = groupOrder.flatMap((key) =>
+      draftItems
+        .filter((item) => item.group_key === key)
+        .sort((a, b) => a.sort_order - b.sort_order)
+        .map((item, index) => ({ ...item, sort_order: index })),
+    );
+    const { error } = await supabase
+      .from("navigation_menu_settings")
+      .upsert(normalized, { onConflict: "href" });
     setSaving(false);
-    if (error) { toast.error(`메뉴 설정 저장 실패: ${error.message}`); return; }
+    if (error) {
+      toast.error(`메뉴 설정 저장 실패: ${error.message}`);
+      return;
+    }
     setMenuItems(normalized);
     setEditing(false);
-    toast.success('메뉴 분류가 저장되었습니다.');
+    toast.success("메뉴 분류가 저장되었습니다.");
   };
 
-  if (orientation === 'vertical') return (
-    <nav className="flex flex-col gap-5">
-      {groupedItems.map((group) => (
-        <div key={group.key}>
-          <p className="mb-1.5 px-2 text-[11px] font-bold tracking-wide text-brand-600/70">
-            {group.label}
-          </p>
-          <div className="flex flex-col gap-1">
-            {group.links.map((link) =>
-              link.href === '/inventory' ? (
-                <div key={link.href}>
-                  <button
-                    type="button"
-                    onClick={() => setInventorySubmenuOpen((current) => !current)}
-                    className={`flex w-full items-center justify-between rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
-                      pathname?.startsWith(link.href)
-                        ? 'bg-white text-brand-700 shadow-sm'
-                        : 'text-brand-700 hover:bg-white/60'
-                    }`}
-                    aria-expanded={inventorySubmenuOpen}
+  if (orientation === "vertical")
+    return (
+      <nav className="flex flex-col gap-5">
+        {groupedItems.map((group) => (
+          <div key={group.key}>
+            <p className="mb-1.5 px-2 text-[11px] font-bold tracking-wide text-brand-600/70">
+              {group.label}
+            </p>
+            <div className="flex flex-col gap-1">
+              {group.links.map((link) =>
+                link.href === "/inventory" ? (
+                  <div key={link.href}>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setInventorySubmenuOpen((current) => !current)
+                      }
+                      className={`flex w-full items-center justify-between rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
+                        pathname?.startsWith(link.href)
+                          ? "bg-white text-brand-700 shadow-sm"
+                          : "text-brand-700 hover:bg-white/60"
+                      }`}
+                      aria-expanded={inventorySubmenuOpen}
+                    >
+                      {link.label}
+                      <span
+                        className={`transition-transform ${inventorySubmenuOpen ? "rotate-90" : ""}`}
+                      >
+                        ›
+                      </span>
+                    </button>
+                    {inventorySubmenuOpen && (
+                      <div className="ml-4 mt-1 flex flex-col gap-1 border-l border-brand-200 pl-2">
+                        <Link
+                          href="/inventory/stock"
+                          onClick={closeAfterNavigate}
+                          className="rounded-lg px-4 py-2.5 text-sm font-medium text-brand-700 hover:bg-white/60"
+                        >
+                          재고
+                        </Link>
+                        <Link
+                          href="/inventory/receive"
+                          onClick={closeAfterNavigate}
+                          className="rounded-lg px-4 py-2.5 text-sm font-medium text-brand-700 hover:bg-white/60"
+                        >
+                          입고
+                        </Link>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    onClick={closeAfterNavigate}
+                    className={`rounded-lg px-4 py-3 text-sm font-medium transition-colors ${pathname?.startsWith(link.href) ? "bg-white text-brand-700 shadow-sm" : "text-brand-700 hover:bg-white/60"}`}
                   >
                     {link.label}
-                    <span className={`transition-transform ${inventorySubmenuOpen ? 'rotate-90' : ''}`}>›</span>
-                  </button>
-                  {inventorySubmenuOpen && (
-                    <div className="ml-4 mt-1 flex flex-col gap-1 border-l border-brand-200 pl-2">
-                      <Link href="/inventory/stock" onClick={closeAfterNavigate} className="rounded-lg px-4 py-2.5 text-sm font-medium text-brand-700 hover:bg-white/60">재고</Link>
-                      <Link href="/inventory/receive" onClick={closeAfterNavigate} className="rounded-lg px-4 py-2.5 text-sm font-medium text-brand-700 hover:bg-white/60">입고</Link>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <Link key={link.href} href={link.href} onClick={closeAfterNavigate} className={`rounded-lg px-4 py-3 text-sm font-medium transition-colors ${pathname?.startsWith(link.href) ? 'bg-white text-brand-700 shadow-sm' : 'text-brand-700 hover:bg-white/60'}`}>
-                  {link.label}
-                </Link>
-              ),
-            )}
+                  </Link>
+                ),
+              )}
+            </div>
           </div>
-        </div>
-      ))}
-    </nav>
-  );
+        ))}
+      </nav>
+    );
 
   return (
     <>
-      <nav ref={navRef} className="flex items-center gap-2" onPointerLeave={(event) => { if (event.pointerType === 'mouse') setOpenGroup(null); }}>
+      <nav
+        ref={navRef}
+        className="flex items-center gap-2"
+        onPointerLeave={(event) => {
+          if (event.pointerType === "mouse") setOpenGroup(null);
+        }}
+      >
         {groupedItems.map((group) => {
-          const active = group.links.some((link) => pathname?.startsWith(link.href));
-          return <div key={group.key} className="relative" onPointerEnter={(event) => { if (event.pointerType === 'mouse') setOpenGroup(group.key); }}><button type="button" aria-haspopup="menu" aria-expanded={openGroup === group.key} onClick={() => setOpenGroup((current) => current === group.key ? null : group.key)} className={`flex min-h-12 items-center gap-1 rounded-lg px-4 py-2 text-sm font-semibold transition-colors ${active ? 'bg-white text-brand-700 shadow-sm' : 'text-brand-700 hover:bg-white/60'}`}>{group.label}<svg className={`h-3.5 w-3.5 transition-transform ${openGroup === group.key ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m6 9 6 6 6-6" /></svg></button>{openGroup === group.key && <div className="absolute left-0 top-[calc(100%-2px)] z-50 min-w-44 pt-2"><div role="menu" className="overflow-visible rounded-xl border border-gray-100 bg-white p-1.5 shadow-xl">{group.links.map((link) => link.href === '/inventory' ? <div key={link.href} className="relative" onPointerEnter={(event) => { if (event.pointerType === 'mouse') setInventorySubmenuOpen(true); }} onPointerLeave={(event) => { if (event.pointerType === 'mouse') setInventorySubmenuOpen(false); }}><button type="button" role="menuitem" aria-haspopup="menu" aria-expanded={inventorySubmenuOpen} onClick={() => setInventorySubmenuOpen((current) => !current)} className={`flex min-h-12 w-full items-center justify-between rounded-lg px-4 py-2.5 text-sm font-medium transition-colors ${pathname?.startsWith(link.href) ? 'bg-brand-50 text-brand-700' : 'text-gray-700 hover:bg-gray-50 hover:text-brand-700'}`}><span>{link.label}</span><span>›</span></button>{inventorySubmenuOpen && <div className="absolute left-full top-0 z-50 pl-2"><div role="menu" className="min-w-28 rounded-xl border border-gray-100 bg-white p-1.5 shadow-xl"><Link href="/inventory/stock" onClick={closeAfterNavigate} role="menuitem" className="flex min-h-11 items-center rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-brand-50 hover:text-brand-700">재고</Link><Link href="/inventory/receive" onClick={closeAfterNavigate} role="menuitem" className="flex min-h-11 items-center rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-brand-50 hover:text-brand-700">입고</Link></div></div>}</div> : <Link key={link.href} href={link.href} onClick={closeAfterNavigate} role="menuitem" className={`flex min-h-12 items-center rounded-lg px-4 py-2.5 text-sm font-medium transition-colors ${pathname?.startsWith(link.href) ? 'bg-brand-50 text-brand-700' : 'text-gray-700 hover:bg-gray-50 hover:text-brand-700'}`}>{link.label}</Link>)}</div></div>}</div>;
+          const active = group.links.some((link) =>
+            pathname?.startsWith(link.href),
+          );
+          return (
+            <div
+              key={group.key}
+              className="relative"
+              onPointerEnter={(event) => {
+                if (event.pointerType === "mouse") setOpenGroup(group.key);
+              }}
+            >
+              <button
+                type="button"
+                aria-haspopup="menu"
+                aria-expanded={openGroup === group.key}
+                onClick={() =>
+                  setOpenGroup((current) =>
+                    current === group.key ? null : group.key,
+                  )
+                }
+                className={`flex min-h-12 items-center gap-1 rounded-lg px-4 py-2 text-sm font-semibold transition-colors ${active ? "bg-white text-brand-700 shadow-sm" : "text-brand-700 hover:bg-white/60"}`}
+              >
+                {group.label}
+                <svg
+                  className={`h-3.5 w-3.5 transition-transform ${openGroup === group.key ? "rotate-180" : ""}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="m6 9 6 6 6-6"
+                  />
+                </svg>
+              </button>
+              {openGroup === group.key && (
+                <div className="absolute left-0 top-[calc(100%-2px)] z-50 min-w-44 pt-2">
+                  <div
+                    role="menu"
+                    className="overflow-visible rounded-xl border border-gray-100 bg-white p-1.5 shadow-xl"
+                  >
+                    {group.links.map((link) =>
+                      link.href === "/inventory" ? (
+                        <div
+                          key={link.href}
+                          className="relative"
+                          onPointerEnter={(event) => {
+                            if (event.pointerType === "mouse")
+                              setInventorySubmenuOpen(true);
+                          }}
+                          onPointerLeave={(event) => {
+                            if (event.pointerType === "mouse")
+                              setInventorySubmenuOpen(false);
+                          }}
+                        >
+                          <button
+                            type="button"
+                            role="menuitem"
+                            aria-haspopup="menu"
+                            aria-expanded={inventorySubmenuOpen}
+                            onClick={() =>
+                              setInventorySubmenuOpen((current) => !current)
+                            }
+                            className={`flex min-h-12 w-full items-center justify-between rounded-lg px-4 py-2.5 text-sm font-medium transition-colors ${pathname?.startsWith(link.href) ? "bg-brand-50 text-brand-700" : "text-gray-700 hover:bg-gray-50 hover:text-brand-700"}`}
+                          >
+                            <span>{link.label}</span>
+                            <span>›</span>
+                          </button>
+                          {inventorySubmenuOpen && (
+                            <div className="absolute left-full top-0 z-50 pl-2">
+                              <div
+                                role="menu"
+                                className="min-w-28 rounded-xl border border-gray-100 bg-white p-1.5 shadow-xl"
+                              >
+                                <Link
+                                  href="/inventory/stock"
+                                  onClick={closeAfterNavigate}
+                                  role="menuitem"
+                                  className="flex min-h-11 items-center rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-brand-50 hover:text-brand-700"
+                                >
+                                  재고
+                                </Link>
+                                <Link
+                                  href="/inventory/receive"
+                                  onClick={closeAfterNavigate}
+                                  role="menuitem"
+                                  className="flex min-h-11 items-center rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-brand-50 hover:text-brand-700"
+                                >
+                                  입고
+                                </Link>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      ) : (
+                        <Link
+                          key={link.href}
+                          href={link.href}
+                          onClick={closeAfterNavigate}
+                          role="menuitem"
+                          className={`flex min-h-12 items-center rounded-lg px-4 py-2.5 text-sm font-medium transition-colors ${pathname?.startsWith(link.href) ? "bg-brand-50 text-brand-700" : "text-gray-700 hover:bg-gray-50 hover:text-brand-700"}`}
+                        >
+                          {link.label}
+                        </Link>
+                      ),
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
         })}
-        {isAdmin && <button type="button" onClick={() => { setDraftItems(menuItems); setEditing(true); }} className="hidden whitespace-nowrap rounded-lg border border-white/60 bg-white/30 px-2.5 py-1.5 text-xs font-semibold text-brand-700 hover:bg-white/60 xl:block">메뉴 편집</button>}
+        {isAdmin && (
+          <button
+            type="button"
+            onClick={() => {
+              setDraftItems(menuItems);
+              setEditing(true);
+            }}
+            className="hidden whitespace-nowrap rounded-lg border border-white/60 bg-white/30 px-2.5 py-1.5 text-xs font-semibold text-brand-700 hover:bg-white/60 xl:block"
+          >
+            메뉴 편집
+          </button>
+        )}
       </nav>
 
-      {isAdmin && editing && <div className="fixed inset-0 z-[80] flex items-center justify-center bg-gray-950/50 p-4 backdrop-blur-[2px]"><div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white shadow-2xl"><div className="border-b border-gray-100 px-6 py-5"><h2 className="text-lg font-bold text-gray-900">메뉴 분류 편집</h2><p className="mt-1 text-xs text-gray-500">카테고리를 선택하고 화살표로 같은 카테고리 안의 순서를 변경하세요.</p></div><div className="space-y-2 p-6">{groupOrder.flatMap((key) => draftItems.filter((item) => item.group_key === key).sort((a, b) => a.sort_order - b.sort_order)).map((item) => <div key={item.href} className="grid grid-cols-[1fr_150px_auto] items-center gap-2 rounded-xl border border-gray-100 bg-gray-50 p-3"><span className="text-sm font-semibold text-gray-800">{item.label}</span><select value={item.group_key} onChange={(event) => setDraftItems((current) => current.map((draft) => draft.href === item.href ? { ...draft, group_key: event.target.value as GroupKey, sort_order: 999 } : draft))} className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm outline-none focus:border-brand-400">{groupOrder.map((groupKey) => <option key={groupKey} value={groupKey}>{groupLabels[groupKey]}</option>)}</select><div className="flex gap-1"><button type="button" onClick={() => moveDraft(item.href, -1)} className="rounded-lg border border-gray-200 bg-white px-2.5 py-2 text-sm text-gray-600 hover:bg-gray-100" aria-label={`${item.label} 위로`}>↑</button><button type="button" onClick={() => moveDraft(item.href, 1)} className="rounded-lg border border-gray-200 bg-white px-2.5 py-2 text-sm text-gray-600 hover:bg-gray-100" aria-label={`${item.label} 아래로`}>↓</button></div></div>)}</div><div className="flex justify-end gap-2 border-t border-gray-100 bg-gray-50 px-6 py-4"><Button variant="gray" onClick={() => setEditing(false)}>취소</Button><Button disabled={saving} onClick={saveMenu}>{saving ? '저장 중...' : '저장'}</Button></div></div></div>}
+      {isAdmin && editing && (
+        <div className="fixed inset-0 z-[80] flex items-center justify-center bg-gray-950/50 p-4 backdrop-blur-[2px]">
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white shadow-2xl">
+            <div className="border-b border-gray-100 px-6 py-5">
+              <h2 className="text-lg font-bold text-gray-900">
+                메뉴 분류 편집
+              </h2>
+              <p className="mt-1 text-xs text-gray-500">
+                카테고리를 선택하고 화살표로 같은 카테고리 안의 순서를
+                변경하세요.
+              </p>
+            </div>
+            <div className="space-y-2 p-6">
+              {groupOrder
+                .flatMap((key) =>
+                  draftItems
+                    .filter((item) => item.group_key === key)
+                    .sort((a, b) => a.sort_order - b.sort_order),
+                )
+                .map((item) => (
+                  <div
+                    key={item.href}
+                    className="grid grid-cols-[1fr_150px_auto] items-center gap-2 rounded-xl border border-gray-100 bg-gray-50 p-3"
+                  >
+                    <span className="text-sm font-semibold text-gray-800">
+                      {item.label}
+                    </span>
+                    <select
+                      value={item.group_key}
+                      onChange={(event) =>
+                        setDraftItems((current) =>
+                          current.map((draft) =>
+                            draft.href === item.href
+                              ? {
+                                  ...draft,
+                                  group_key: event.target.value as GroupKey,
+                                  sort_order: 999,
+                                }
+                              : draft,
+                          ),
+                        )
+                      }
+                      className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm outline-none focus:border-brand-400"
+                    >
+                      {groupOrder.map((groupKey) => (
+                        <option key={groupKey} value={groupKey}>
+                          {groupLabels[groupKey]}
+                        </option>
+                      ))}
+                    </select>
+                    <div className="flex gap-1">
+                      <button
+                        type="button"
+                        onClick={() => moveDraft(item.href, -1)}
+                        className="rounded-lg border border-gray-200 bg-white px-2.5 py-2 text-sm text-gray-600 hover:bg-gray-100"
+                        aria-label={`${item.label} 위로`}
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveDraft(item.href, 1)}
+                        className="rounded-lg border border-gray-200 bg-white px-2.5 py-2 text-sm text-gray-600 hover:bg-gray-100"
+                        aria-label={`${item.label} 아래로`}
+                      >
+                        ↓
+                      </button>
+                    </div>
+                  </div>
+                ))}
+            </div>
+            <div className="flex justify-end gap-2 border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <Button variant="gray" onClick={() => setEditing(false)}>
+                취소
+              </Button>
+              <Button disabled={saving} onClick={saveMenu}>
+                {saving ? "저장 중..." : "저장"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 };

--- a/src/app/(auth)/_components/Header/_components/UserInfo.tsx
+++ b/src/app/(auth)/_components/Header/_components/UserInfo.tsx
@@ -1,124 +1,268 @@
-'use client';
+"use client";
 
-import { useEffect, useRef, useState } from 'react';
-import { useUser } from '@/app/_contexts/UserContext';
-import Loading from '@/app/_components/Loading';
-import Button from '@/app/_components/Button';
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import toast from "react-hot-toast";
+import { useUser } from "@/app/_contexts/UserContext";
+import Loading from "@/app/_components/Loading";
+import Button from "@/app/_components/Button";
+import supabase from "@/libs/supabaseClient";
+
+type SwitchAccount = {
+  id: string;
+  name: string;
+  email: string;
+  oss_role: "staff" | "admin";
+};
+
+const hiddenSwitchAccountNames = new Set(["윤동호", "이대양"]);
 
 const UserInfo = () => {
-  const { user, isLoading, logout } = useUser();
+  const { user, isLoading, refreshUser, logout } = useUser();
+  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
+  const [accounts, setAccounts] = useState<SwitchAccount[]>([]);
+  const [isAccountsLoading, setIsAccountsLoading] = useState(false);
+  const [selectedAccount, setSelectedAccount] = useState<SwitchAccount | null>(
+    null,
+  );
+  const [password, setPassword] = useState("");
+  const [switchError, setSwitchError] = useState("");
+  const [isSwitching, setIsSwitching] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
-  // 드롭다운 외부 클릭 시 닫기 (모바일 터치 포함)
+
   useEffect(() => {
     if (!isOpen) return;
-
     const handleClickOutside = (event: MouseEvent | TouchEvent) => {
       const target = event.target as Node;
       if (containerRef.current && !containerRef.current.contains(target)) {
         setIsOpen(false);
       }
     };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('touchstart', handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('touchstart', handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
     };
   }, [isOpen]);
 
-  if (isLoading) {
-    return <Loading size="sm" />;
-  }
+  const loadAccounts = async () => {
+    if (accounts.length || isAccountsLoading) return;
+    setIsAccountsLoading(true);
+    const { data, error } = await supabase
+      .from("users")
+      .select("id, name, email, oss_role")
+      .in("oss_role", ["staff", "admin"])
+      .order("oss_role")
+      .order("name");
+    setIsAccountsLoading(false);
+    if (error) {
+      toast.error("전환할 계정을 불러오지 못했습니다.");
+      return;
+    }
+    setAccounts(
+      ((data ?? []) as SwitchAccount[]).filter(
+        (account) => !hiddenSwitchAccountNames.has(account.name.trim()),
+      ),
+    );
+  };
 
-  if (!user) {
-    return null;
-  }
+  const toggleAccounts = () => {
+    setIsOpen((current) => !current);
+    if (!isOpen) void loadAccounts();
+  };
 
-  return (
-    <div ref={containerRef} className="relative whitespace-nowrap">
-      {/* Desktop / Tablet: 전체 정보 + 로그아웃 */}
-      <div className="hidden header:flex items-center gap-4 bg-white/70 px-4 py-2.5 rounded-full border border-brand-200 shadow-sm text-sm">
-        {/* 사용자 정보 */}
-        <div className="flex items-center gap-3">
-          {/* 아바타 */}
-          <div className="w-10 h-10 rounded-full bg-gradient-to-br from-brand-400 to-brand-500 flex items-center justify-center text-white font-bold shrink-0">
-            <span className="text-xs text-white font-medium leading-tight">
-              {user.oss_role}
-            </span>
+  const openPasswordModal = (account: SwitchAccount) => {
+    if (account.id === user?.id) return;
+    setSelectedAccount(account);
+    setPassword("");
+    setSwitchError("");
+    setIsOpen(false);
+  };
+
+  const switchAccount = async () => {
+    if (!selectedAccount || !password || isSwitching) return;
+    setIsSwitching(true);
+    setSwitchError("");
+    const { error } = await supabase.auth.signInWithPassword({
+      email: selectedAccount.email,
+      password,
+    });
+    if (error) {
+      setIsSwitching(false);
+      setSwitchError("비밀번호가 올바르지 않습니다.");
+      return;
+    }
+    await refreshUser();
+    setIsSwitching(false);
+    setSelectedAccount(null);
+    setPassword("");
+    toast.success(`${selectedAccount.name} 계정으로 전환했습니다.`);
+    router.refresh();
+  };
+
+  if (isLoading) return <Loading size="sm" />;
+  if (!user) return null;
+
+  const accountList = (
+    <div className="absolute right-0 top-full z-[80] mt-2 w-72 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl">
+      <p className="border-b border-gray-100 px-4 py-2.5 text-xs font-semibold text-gray-500">
+        전환할 계정
+      </p>
+      <div className="max-h-72 overflow-y-auto p-1.5">
+        {isAccountsLoading ? (
+          <div className="flex justify-center py-5">
+            <Loading size="sm" />
           </div>
-
-          {/* 이름 & 이메일 */}
-          <div className="flex flex-col min-w-0">
-            <span className="text-sm font-semibold text-brand-700 leading-tight truncate max-w-[160px]">
-              {user.name}
-            </span>
-            <span className="text-xs text-brand-500 leading-tight truncate max-w-[200px]">
-              {user.email}
-            </span>
-          </div>
-        </div>
-
-        {/* 로그아웃 버튼 */}
-        <Button size="xs" onClick={logout} variant="secondary">
+        ) : accounts.length ? (
+          accounts.map((account) => {
+            const isCurrent = account.id === user.id;
+            return (
+              <button
+                key={account.id}
+                type="button"
+                disabled={isCurrent}
+                onClick={() => openPasswordModal(account)}
+                className="flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition hover:bg-gray-50 disabled:cursor-default disabled:bg-brand-50/60"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-semibold text-gray-900">
+                    {account.name}
+                  </span>
+                  <span className="block truncate text-xs text-gray-500">
+                    {account.email}
+                  </span>
+                </span>
+                <span className="ml-3 shrink-0 text-[11px] font-semibold uppercase text-brand-600">
+                  {isCurrent ? "현재" : account.oss_role}
+                </span>
+              </button>
+            );
+          })
+        ) : (
+          <p className="px-3 py-5 text-center text-xs text-gray-500">
+            전환할 계정이 없습니다.
+          </p>
+        )}
+      </div>
+      <div className="border-t border-gray-100 p-2 header:hidden">
+        <Button
+          size="xs"
+          variant="secondary"
+          className="w-full"
+          onClick={logout}
+        >
           로그아웃
         </Button>
       </div>
+    </div>
+  );
 
-      {/* Mobile: ADMIN 동그라미만 보이는 트리거 */}
-      <div className="flex header:hidden items-center">
-        <button
-          type="button"
-          onClick={() => setIsOpen((prev) => !prev)}
-          className="flex items-center bg-white/80 px-2 py-1.5 rounded-full border border-brand-200 shadow-sm"
-        >
-          <div className="w-8 h-8 rounded-full bg-gradient-to-br from-brand-400 to-brand-500 flex items-center justify-center text-white font-bold text-[11px] shrink-0">
-            <span className="text-[10px] text-white font-medium leading-tight">
-              {user.oss_role}
-            </span>
-          </div>
-        </button>
-      </div>
-
-      {/* Mobile Dropdown */}
-      <div
-        className={`absolute right-0 top-full mt-2 w-56 bg-white rounded-xl shadow-lg border border-brand-200 p-3 header:hidden z-50 transform origin-top-right transition-all duration-150 ease-out ${
-          isOpen
-            ? 'opacity-100 scale-100 pointer-events-auto'
-            : 'opacity-0 scale-95 pointer-events-none'
-        }`}
-      >
-        <div className="flex gap-2">
-          <div className="flex items-center gap-2 mb-2">
-            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-brand-400 to-brand-500 flex items-center justify-center text-white font-bold text-[11px] shrink-0">
-              <span className="text-[10px] text-white font-medium leading-tight">
+  return (
+    <>
+      <div ref={containerRef} className="relative whitespace-nowrap">
+        <div className="hidden items-center gap-4 rounded-full border border-brand-200 bg-white/70 px-4 py-2.5 text-sm shadow-sm header:flex">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-brand-400 to-brand-500 font-bold text-white">
+              <span className="text-xs font-medium leading-tight text-white">
                 {user.oss_role}
               </span>
             </div>
-            <div className="flex flex-col min-w-0">
-              <span className="text-xs font-semibold text-brand-700 leading-tight truncate">
+            <button
+              type="button"
+              onClick={toggleAccounts}
+              aria-expanded={isOpen}
+              className="flex min-w-0 flex-col text-left"
+              title="계정 전환"
+            >
+              <span className="max-w-[160px] truncate text-sm font-semibold leading-tight text-brand-700">
                 {user.name}
               </span>
-              <span className="text-[11px] text-brand-500 leading-tight truncate">
+              <span className="max-w-[200px] truncate text-xs leading-tight text-brand-500">
                 {user.email}
               </span>
-            </div>
+            </button>
           </div>
-
-          <div className="flex items-center justify-end mt-1">
-            <Button
-              size="xs"
-              variant="secondary"
-              className="px-2 py-1 text-[11px]"
-              onClick={logout}
-            >
-              로그아웃
-            </Button>
-          </div>
+          <Button size="xs" onClick={logout} variant="secondary">
+            로그아웃
+          </Button>
         </div>
+
+        <div className="flex items-center header:hidden">
+          <button
+            type="button"
+            onClick={toggleAccounts}
+            aria-expanded={isOpen}
+            className="flex items-center rounded-full border border-brand-200 bg-white/80 px-2 py-1.5 shadow-sm"
+          >
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-brand-400 to-brand-500 text-[11px] font-bold text-white">
+              <span className="text-[10px] font-medium leading-tight text-white">
+                {user.oss_role}
+              </span>
+            </div>
+          </button>
+        </div>
+
+        {isOpen && accountList}
       </div>
-    </div>
+
+      {selectedAccount &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div className="fixed inset-0 z-[180] flex items-center justify-center bg-gray-950/50 p-4">
+            <section className="w-full max-w-sm overflow-hidden rounded-2xl bg-white shadow-2xl">
+              <header className="border-b border-gray-100 px-5 py-4">
+                <h2 className="text-lg font-bold text-gray-950">계정 전환</h2>
+                <p className="mt-1 text-sm text-gray-500">
+                  {selectedAccount.name} · {selectedAccount.email}
+                </p>
+              </header>
+              <div className="p-5">
+                <label className="block text-sm font-semibold text-gray-700">
+                  비밀번호
+                  <input
+                    autoFocus
+                    type="password"
+                    value={password}
+                    onChange={(event) => {
+                      setPassword(event.target.value);
+                      setSwitchError("");
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") void switchAccount();
+                    }}
+                    placeholder="비밀번호를 입력하세요"
+                    className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none transition hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                  />
+                </label>
+                {switchError && (
+                  <p className="mt-2 text-sm font-medium text-rose-600">
+                    {switchError}
+                  </p>
+                )}
+              </div>
+              <footer className="flex justify-end gap-2 border-t border-gray-100 px-5 py-4">
+                <Button
+                  variant="gray"
+                  onClick={() => setSelectedAccount(null)}
+                  disabled={isSwitching}
+                >
+                  취소
+                </Button>
+                <Button
+                  onClick={() => void switchAccount()}
+                  disabled={!password || isSwitching}
+                >
+                  {isSwitching ? "전환 중..." : "전환"}
+                </Button>
+              </footer>
+            </section>
+          </div>,
+          document.body,
+        )}
+    </>
   );
 };
 

--- a/src/app/(auth)/_components/HistoriesComponents/LogActorInfo.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/LogActorInfo.tsx
@@ -1,4 +1,4 @@
-import { LogActorUserInfo } from '@/app/_domains/_log/_types/log.types';
+import { LogActorUserInfo } from "@/app/_domains/_log/_types/log.types";
 
 const LogActorInfo = ({
   users,
@@ -12,17 +12,17 @@ const LogActorInfo = ({
   jsonb?: Record<string, unknown>;
 }) => {
   const createdWorkerName =
-    typeof jsonb?.createdWorkerName === 'string'
-      ? jsonb.createdWorkerName
-      : '';
+    typeof jsonb?.createdWorkerName === "string" ? jsonb.createdWorkerName : "";
   const modifiedWorkerName =
-    typeof jsonb?.modifiedWorkerName === 'string'
+    typeof jsonb?.modifiedWorkerName === "string"
       ? jsonb.modifiedWorkerName
-      : '';
+      : "";
   const modifiedAt =
-    typeof jsonb?.modifiedAt === 'string' ? jsonb.modifiedAt : updated_at;
+    typeof jsonb?.modifiedAt === "string" ? jsonb.modifiedAt : updated_at;
   const userDisplay =
-    createdWorkerName || users?.name || users?.email || '알 수 없음';
+    users?.oss_role === "admin"
+      ? "관리자"
+      : createdWorkerName || users?.name || users?.email || "알 수 없음";
 
   const storedModificationHistory = Array.isArray(jsonb?.modificationHistory)
     ? jsonb.modificationHistory.filter(
@@ -32,10 +32,10 @@ const LogActorInfo = ({
           workerName: string;
           modifiedAt: string;
         } =>
-          typeof item === 'object' &&
+          typeof item === "object" &&
           item !== null &&
-          typeof (item as Record<string, unknown>).workerName === 'string' &&
-          typeof (item as Record<string, unknown>).modifiedAt === 'string',
+          typeof (item as Record<string, unknown>).workerName === "string" &&
+          typeof (item as Record<string, unknown>).modifiedAt === "string",
       )
     : [];
   const modificationHistory =
@@ -44,20 +44,22 @@ const LogActorInfo = ({
       : modifiedWorkerName && modifiedAt
         ? [{ workerName: modifiedWorkerName, modifiedAt }]
         : [];
-  const formatDate = (value: string) => new Date(value).toLocaleString('ko-KR', {
-    year: '2-digit',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
+  const formatDate = (value: string) =>
+    new Date(value).toLocaleString("ko-KR", {
+      year: "2-digit",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
   const createdDateText = formatDate(created_at);
 
   return (
     <div>
       <div className="text-xs text-gray-500">
-        작업자 · <span className="font-medium text-gray-700">{userDisplay}</span>
+        작업자 ·{" "}
+        <span className="font-medium text-gray-700">{userDisplay}</span>
       </div>
       <div className="mt-0.5 text-xs text-gray-400">{createdDateText}</div>
       {modificationHistory.map((history, index) => (
@@ -66,7 +68,7 @@ const LogActorInfo = ({
           className="mt-1"
         >
           <div className="text-xs text-gray-500">
-            수정{' '}
+            수정{" "}
             <span className="font-medium text-gray-700">
               {history.workerName}
             </span>

--- a/src/app/(auth)/_components/StampLogEditModal.tsx
+++ b/src/app/(auth)/_components/StampLogEditModal.tsx
@@ -29,8 +29,11 @@ const formatAmount = (value: number) => value.toLocaleString('ko-KR');
 const getShipmentTypeLabel = (
   item: NonNullable<StampLogMeta['items']>[number],
 ) => {
+  if (item.inventoryAction === 'adjustment_in') return '재고조정-입고';
+  if (item.inventoryAction === 'adjustment_out') return '재고조정-출고';
   if (item.inventoryAction === 'exchange_in') return '교환입고';
   if (item.inventoryAction === 'exchange_out') return '교환출고';
+  if (item.remark?.startsWith('시연용')) return '시연용';
   if (typeof item.adjustedUnitPrice === 'number') return '가격조정';
   if (item.remark?.startsWith('서비스')) return '서비스';
   return '일반판매';

--- a/src/app/(auth)/cash-management/_components/DailyClosingReport.tsx
+++ b/src/app/(auth)/cash-management/_components/DailyClosingReport.tsx
@@ -26,15 +26,78 @@ import { useModal } from "@/app/_contexts/ModalContext";
 import ConfirmModal from "@/app/(auth)/_components/ConfirmModal";
 
 const defaultChecklistItems: DailyClosingChecklistItem[] = [
-  { id: "device_login", phase: "opening", label: "매장 기기 및 업무 계정 로그인 확인", sort_order: 0, is_required: false, is_opening_gate: true },
-  { id: "stock_check", phase: "opening", label: "고객 출고 전 시재·재고 확인", sort_order: 1, is_required: false, is_opening_gate: true },
-  { id: "device_charge", phase: "opening", label: "시연용 기기와 업무용 기기 충전 확인", sort_order: 2, is_required: false, is_opening_gate: true },
-  { id: "notification_check", phase: "opening", label: "업무용 휴대폰 알림 확인", sort_order: 3, is_required: false, is_opening_gate: true },
-  { id: "restroom", phase: "closing", label: "화장실 잠금 및 정리 확인", sort_order: 0, is_required: false, is_opening_gate: false },
-  { id: "sales_check", phase: "closing", label: "판매처별 매출과 종합 금액 확인", sort_order: 1, is_required: false, is_opening_gate: false },
-  { id: "device_off", phase: "closing", label: "에어컨·송풍·조명 전원 확인", sort_order: 2, is_required: false, is_opening_gate: false },
-  { id: "trash", phase: "closing", label: "매장 쓰레기 정리", sort_order: 3, is_required: false, is_opening_gate: false },
-  { id: "door_lock", phase: "closing", label: "출입문과 창문 잠금 확인", sort_order: 4, is_required: false, is_opening_gate: false },
+  {
+    id: "device_login",
+    phase: "opening",
+    label: "매장 기기 및 업무 계정 로그인 확인",
+    sort_order: 0,
+    is_required: false,
+    is_opening_gate: true,
+  },
+  {
+    id: "stock_check",
+    phase: "opening",
+    label: "고객 출고 전 시재·재고 확인",
+    sort_order: 1,
+    is_required: false,
+    is_opening_gate: true,
+  },
+  {
+    id: "device_charge",
+    phase: "opening",
+    label: "시연용 기기와 업무용 기기 충전 확인",
+    sort_order: 2,
+    is_required: false,
+    is_opening_gate: true,
+  },
+  {
+    id: "notification_check",
+    phase: "opening",
+    label: "업무용 휴대폰 알림 확인",
+    sort_order: 3,
+    is_required: false,
+    is_opening_gate: true,
+  },
+  {
+    id: "restroom",
+    phase: "closing",
+    label: "화장실 잠금 및 정리 확인",
+    sort_order: 0,
+    is_required: false,
+    is_opening_gate: false,
+  },
+  {
+    id: "sales_check",
+    phase: "closing",
+    label: "판매처별 매출과 종합 금액 확인",
+    sort_order: 1,
+    is_required: false,
+    is_opening_gate: false,
+  },
+  {
+    id: "device_off",
+    phase: "closing",
+    label: "에어컨·송풍·조명 전원 확인",
+    sort_order: 2,
+    is_required: false,
+    is_opening_gate: false,
+  },
+  {
+    id: "trash",
+    phase: "closing",
+    label: "매장 쓰레기 정리",
+    sort_order: 3,
+    is_required: false,
+    is_opening_gate: false,
+  },
+  {
+    id: "door_lock",
+    phase: "closing",
+    label: "출입문과 창문 잠금 확인",
+    sort_order: 4,
+    is_required: false,
+    is_opening_gate: false,
+  },
 ];
 
 const formatWon = (value: number) => `${value.toLocaleString("ko-KR")}원`;
@@ -53,9 +116,7 @@ const formatReportDate = (date: string) => {
     month: "long",
     day: "numeric",
   }).format(parsed);
-  const weekday = ["일", "월", "화", "수", "목", "금", "토"][
-    parsed.getDay()
-  ];
+  const weekday = ["일", "월", "화", "수", "목", "금", "토"][parsed.getDay()];
   return `${dateText} (${weekday})`;
 };
 const PHOTO_SAVE_ENABLED = false;
@@ -135,9 +196,7 @@ export default function DailyClosingReport({
     : null;
   const checklistItems =
     savedChecklistItems ??
-    (checklistQuery.data?.length
-      ? checklistQuery.data
-      : defaultChecklistItems);
+    (checklistQuery.data?.length ? checklistQuery.data : defaultChecklistItems);
   const openingTasks = checklistItems.filter(
     (item) => item.phase === "opening",
   );
@@ -172,11 +231,7 @@ export default function DailyClosingReport({
   }, [businessDate]);
 
   useEffect(() => {
-    if (
-      checksDraftDate !== businessDate ||
-      reportQuery.data
-    )
-      return;
+    if (checksDraftDate !== businessDate || reportQuery.data) return;
     window.sessionStorage.setItem(
       getChecklistDraftKey(businessDate),
       JSON.stringify({ openingChecks, closingChecks }),
@@ -270,14 +325,17 @@ export default function DailyClosingReport({
               journal.end_time.slice(0, 5),
             actualEndTime: journal.end_time.slice(0, 5),
             actualWorkHours: Number(journal.work_hours),
-            inputWorkHours: Number(
-              journal.input_work_hours ?? journal.work_hours,
-            ),
+            inputWorkHours: Number(journal.input_work_hours ?? 0),
           })),
           payments: paymentSales.breakdown.map((payment) => ({ ...payment })),
           itemSummary: paymentSales.itemSummary.map((item) => ({ ...item })),
           outboundTypeSummary: paymentSales.outboundTypeSummary.map((item) => ({
             ...item,
+          })),
+          inboundSummary: paymentSales.inboundSummary.map((item) => ({
+            ...item,
+            aggregationUnit:
+              item.type === "purchase" ? "count" : "quantity",
           })),
           deliverySummary: paymentSales.deliverySummary.map((item) => ({
             ...item,
@@ -350,7 +408,9 @@ export default function DailyClosingReport({
         return;
       }
       if (message.includes("OPEN_WORK_JOURNAL_EXISTS")) {
-        toast.error("퇴근하지 않은 근무자가 있습니다. 근무기록에서 먼저 퇴근 처리해 주세요.");
+        toast.error(
+          "퇴근하지 않은 근무자가 있습니다. 근무기록에서 먼저 퇴근 처리해 주세요.",
+        );
         return;
       }
       if (message.includes("ALREADY_CLOSED")) {
@@ -496,98 +556,196 @@ export default function DailyClosingReport({
       </div>
 
       <div ref={captureRef} className="space-y-4 bg-white">
-      <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-          <div className="shrink-0">
-            <p className="text-xs font-semibold text-gray-500">마감 날짜</p>
-            <h2 className="mt-1 text-lg font-bold text-gray-900">
-              {formatReportDate(businessDate)}
-            </h2>
-          </div>
-          <div className="h-px bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
-          <div className="min-w-0 flex-1">
-            <p className="text-xs font-semibold text-gray-500">근무자 명단</p>
-            <div className="mt-2 grid gap-2 md:grid-cols-2">
-              {workJournals.length ? (
-                workJournals.map((journal) => (
-                  <div
-                    key={journal.id}
-                    className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm"
-                  >
-                    <strong className="text-gray-900">
-                      {journal.worker_name}
-                    </strong>
-                    <span className="text-gray-600">
-                      {journal.start_time.slice(0, 5)} ~{" "}
-                      {journal.status === "working"
-                        ? "근무 중"
-                        : journal.end_time.slice(0, 5)}
-                    </span>
-                    <span className="text-xs text-gray-500">
-                      실제 {Number(journal.work_hours)}시간 · 입력{" "}
-                      {Number(journal.input_work_hours ?? 0)}시간
-                    </span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-400">등록된 근무자 없음</p>
-              )}
-            </div>
-          </div>
-        </div>
-      </section>
-      <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[190px_190px_190px_minmax(0,1fr)]">
-          <SalesBreakdownCard
-            title="오베이프 매출"
-            items={paymentSales.ovapeBreakdown}
-            rowCount={Math.max(
-              paymentSales.ovapeBreakdown.length,
-              paymentSales.eguVapeBreakdown.length,
-            )}
-          />
-          <SalesBreakdownCard
-            title="이구베이프 매출"
-            items={paymentSales.eguVapeBreakdown}
-            rowCount={Math.max(
-              paymentSales.ovapeBreakdown.length,
-              paymentSales.eguVapeBreakdown.length,
-            )}
-          />
-          <div className="flex min-h-36 flex-col overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
-            <div className="flex min-h-0 flex-1 flex-col p-4">
-              <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
-                시재 현황
+        <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+          <div className="flex flex-col gap-4 lg:w-[500px] lg:flex-row lg:items-start">
+            <div className="shrink-0">
+              <p className="text-xs font-semibold text-gray-500">마감 날짜</p>
+              <h2 className="mt-1 text-lg font-bold text-gray-900">
+                {formatReportDate(businessDate)}
               </h2>
-              <div className="flex flex-1 items-center justify-center py-3">
-                <span
-                  className={`rounded-full px-4 py-2 text-sm font-bold ${
-                    difference === 0
-                      ? "bg-emerald-100 text-emerald-700"
-                      : "bg-rose-100 text-rose-700"
-                  }`}
-                >
-                  {difference === 0 ? "일치" : "불일치"}
-                </span>
+            </div>
+            <div className="h-px bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-semibold text-gray-500">근무자 명단</p>
+              <div className="mt-2 grid gap-2">
+                {workJournals.length ? (
+                  workJournals.map((journal) => (
+                    <div
+                      key={journal.id}
+                      className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm"
+                    >
+                      <strong className="text-gray-900">
+                        {journal.worker_name}
+                      </strong>
+                      <span className="text-gray-600">
+                        {journal.start_time.slice(0, 5)} ~{" "}
+                        {journal.status === "working"
+                          ? "근무 중"
+                          : journal.end_time.slice(0, 5)}
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-400">등록된 근무자 없음</p>
+                )}
               </div>
             </div>
-            <div className="flex min-h-0 flex-1 flex-col border-t border-gray-200 p-4">
-              <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
-                총 매출
-              </h2>
-              <p className="flex flex-1 items-center justify-center py-3 text-center text-2xl font-bold text-brand-700">
-                {formatWon(paymentSales.total)}
-              </p>
-            </div>
           </div>
-          {usesSeparatedOutboundSummary ? (
-          <div className="min-h-36 overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
-            <div className="grid min-h-36 sm:h-full sm:grid-cols-[7fr_7fr_4fr]">
-              <div className="p-4">
+        </section>
+        <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[170px_170px_140px_minmax(0,1fr)]">
+            <SalesBreakdownCard
+              title="오베이프 매출"
+              items={paymentSales.ovapeBreakdown}
+              rowCount={Math.max(
+                paymentSales.ovapeBreakdown.length,
+                paymentSales.eguVapeBreakdown.length,
+              )}
+            />
+            <SalesBreakdownCard
+              title="이구베이프 매출"
+              items={paymentSales.eguVapeBreakdown}
+              rowCount={Math.max(
+                paymentSales.ovapeBreakdown.length,
+                paymentSales.eguVapeBreakdown.length,
+              )}
+            />
+            <div className="flex min-h-36 flex-col overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
+              <div className="flex min-h-0 flex-1 flex-col p-4">
                 <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
-                  일반 출고
+                  시재 현황
                 </h2>
-                <div className="mt-3 space-y-2">
+                <div className="flex flex-1 items-center justify-center py-3">
+                  <span
+                    className={`rounded-full px-4 py-2 text-sm font-bold ${
+                      difference === 0
+                        ? "bg-emerald-100 text-emerald-700"
+                        : "bg-rose-100 text-rose-700"
+                    }`}
+                  >
+                    {difference === 0 ? "일치" : "불일치"}
+                  </span>
+                </div>
+              </div>
+              <div className="flex min-h-0 flex-1 flex-col border-t border-gray-200 p-4">
+                <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                  총 매출
+                </h2>
+                <p className="flex flex-1 items-center justify-center whitespace-nowrap py-3 text-center text-xl font-bold text-brand-700">
+                  {formatWon(paymentSales.total)}
+                </p>
+              </div>
+            </div>
+            {usesSeparatedOutboundSummary ? (
+              <div className="min-h-36 overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
+                <div className="grid min-h-36 sm:h-full sm:grid-cols-[180px_180px_130px_minmax(0,1fr)]">
+                  <div className="p-4">
+                    <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                      일반 출고
+                    </h2>
+                    <div className="mt-3 space-y-2">
+                      {paymentSales.itemSummary.length ? (
+                        paymentSales.itemSummary.map((item) => (
+                          <div
+                            key={item.categoryName}
+                            className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+                          >
+                            <span className="text-gray-600">
+                              {item.categoryName}
+                            </span>
+                            <strong className="text-gray-900">
+                              {item.quantity}개
+                            </strong>
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-sm text-gray-400">출고 없음</p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0">
+                    <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                      나머지 출고
+                    </h2>
+                    <div className="mt-3 space-y-2">
+                      {paymentSales.outboundTypeSummary.length ? (
+                        paymentSales.outboundTypeSummary.map((item) => (
+                          <div
+                            key={`${item.type}-${item.label}`}
+                            className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+                          >
+                            <span className="min-w-0 break-all text-gray-600">
+                              {item.label}
+                            </span>
+                            {item.type !== "purchase" && (
+                              <strong className="shrink-0 text-gray-900">
+                                {item.quantity}개
+                              </strong>
+                            )}
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-sm text-gray-400">출고 없음</p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0">
+                    <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                      수령 방식
+                    </h2>
+                    <div className="mt-3 space-y-2">
+                      {paymentSales.deliverySummary.length ? (
+                        paymentSales.deliverySummary.map((item) => (
+                          <div
+                            key={item.method}
+                            className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+                          >
+                            <span className="whitespace-nowrap text-gray-600">
+                              {item.label}
+                            </span>
+                            <strong className="shrink-0 whitespace-nowrap text-gray-900">
+                              {item.orderCount}건
+                            </strong>
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-sm text-gray-400">등록 없음</p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0">
+                    <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                      입고
+                    </h2>
+                    <div className="mt-3 space-y-2">
+                      {paymentSales.inboundSummary.length ? (
+                        paymentSales.inboundSummary.map((item) => (
+                          <div
+                            key={`${item.type}-${item.label}`}
+                            className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+                          >
+                            <span className="min-w-0 break-all text-gray-600">
+                              {item.label}
+                            </span>
+                            <strong className="shrink-0 text-gray-900">
+                              {item.quantity}
+                              {item.type === "purchase" ? "건" : "개"}
+                            </strong>
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-sm text-gray-400">입고 없음</p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="min-h-36 rounded-xl border border-gray-200 bg-gray-50 p-4">
+                <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
+                  판매종류 및 수량
+                </h2>
+                <div className="mt-3 grid grid-cols-1 gap-x-4 gap-y-2 sm:grid-cols-2">
                   {paymentSales.itemSummary.length ? (
                     paymentSales.itemSummary.map((item) => (
                       <div
@@ -598,145 +756,79 @@ export default function DailyClosingReport({
                           {item.categoryName}
                         </span>
                         <strong className="text-gray-900">
-                          {item.quantity}개
+                          {item.quantity}
+                          {item.categoryName === "택배" ||
+                          item.categoryName === "배달"
+                            ? "건"
+                            : "개"}
                         </strong>
                       </div>
                     ))
                   ) : (
-                    <p className="text-sm text-gray-400">출고 없음</p>
+                    <p className="text-sm text-gray-400">판매 품목 없음</p>
                   )}
                 </div>
               </div>
-              <div className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0">
-                <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
-                  나머지 출고
-                </h2>
-                <div className="mt-3 space-y-2">
-                  {paymentSales.outboundTypeSummary.length ? (
-                    paymentSales.outboundTypeSummary.map((item) => (
-                      <div
-                        key={`${item.type}-${item.label}`}
-                        className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
-                      >
-                        <span className="text-gray-600">{item.label}</span>
-                        <strong className="shrink-0 text-gray-900">
-                          {item.quantity}개
-                        </strong>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-sm text-gray-400">출고 없음</p>
-                  )}
-                </div>
-              </div>
-              <div className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0">
-                <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
-                  수령 방식
-                </h2>
-                <div className="mt-3 space-y-2">
-                  {paymentSales.deliverySummary.length ? (
-                    paymentSales.deliverySummary.map((item) => (
-                      <div
-                        key={item.method}
-                        className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
-                      >
-                        <span className="text-gray-600">{item.label}</span>
-                        <strong className="text-gray-900">
-                          {item.orderCount}건
-                        </strong>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-sm text-gray-400">등록 없음</p>
-                  )}
-                </div>
-              </div>
-            </div>
+            )}
           </div>
-          ) : (
-            <div className="min-h-36 rounded-xl border border-gray-200 bg-gray-50 p-4">
-              <h2 className="border-b border-gray-200 pb-2 text-sm font-bold text-gray-800">
-                판매종류 및 수량
-              </h2>
-              <div className="mt-3 grid grid-cols-1 gap-x-4 gap-y-2 sm:grid-cols-2">
-                {paymentSales.itemSummary.length ? (
-                  paymentSales.itemSummary.map((item) => (
-                    <div
-                      key={item.categoryName}
-                      className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
-                    >
-                      <span className="text-gray-600">{item.categoryName}</span>
-                      <strong className="text-gray-900">
-                        {item.quantity}
-                        {item.categoryName === "택배" ||
-                        item.categoryName === "배달"
-                          ? "건"
-                          : "개"}
-                      </strong>
-                    </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-gray-400">판매 품목 없음</p>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
+        </section>
 
-      <div id="opening-checklist" className="grid scroll-mt-24 gap-4 lg:grid-cols-2">
-        <Checklist
-          title="출근·교대 확인"
-          tasks={openingTasks}
-          values={openingChecks}
-          disabled={isClosed}
-          onToggle={toggleOpening}
-        />
-        <Checklist
-          title="마감 확인"
-          tasks={closingTasks}
-          values={closingChecks}
-          disabled={isClosed}
-          onToggle={(key) => toggle(setClosingChecks, key)}
-        />
-      </div>
-      <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
-        <div className="grid gap-4 lg:grid-cols-2">
-          <label className="text-sm font-semibold text-gray-700">
-            청소 현황·방식
-            <textarea
-              value={cleaningNote}
-              onChange={(event) => setCleaningNote(event.target.value)}
-              disabled={isClosed}
-              placeholder="예: 창문 닦기, 쇼케이스 닦기, 매장 바닥 청소"
-              className="mt-2 h-28 w-full resize-none rounded-xl border border-gray-300 p-3 font-normal outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100"
-            />
-          </label>
-          <label className="text-sm font-semibold text-gray-700">
-            특이사항·전달사항
-            <textarea
-              value={specialNote}
-              onChange={(event) => setSpecialNote(event.target.value)}
-              disabled={isClosed}
-              placeholder="없으면 비워 두어도 됩니다."
-              className="mt-2 h-28 w-full resize-none rounded-xl border border-gray-300 p-3 font-normal outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100"
-            />
-          </label>
+        <div
+          id="opening-checklist"
+          className="grid scroll-mt-24 gap-4 lg:grid-cols-2"
+        >
+          <Checklist
+            title="출근·교대 확인"
+            tasks={openingTasks}
+            values={openingChecks}
+            disabled={isClosed}
+            onToggle={toggleOpening}
+          />
+          <Checklist
+            title="마감 확인"
+            tasks={closingTasks}
+            values={closingChecks}
+            disabled={isClosed}
+            onToggle={(key) => toggle(setClosingChecks, key)}
+          />
         </div>
-      </section>
+        <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <label className="text-sm font-semibold text-gray-700">
+              청소 현황·방식
+              <textarea
+                value={cleaningNote}
+                onChange={(event) => setCleaningNote(event.target.value)}
+                disabled={isClosed}
+                placeholder="예: 창문 닦기, 쇼케이스 닦기, 매장 바닥 청소"
+                className="mt-2 h-28 w-full resize-none rounded-xl border border-gray-300 p-3 font-normal outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100"
+              />
+            </label>
+            <label className="text-sm font-semibold text-gray-700">
+              특이사항·전달사항
+              <textarea
+                value={specialNote}
+                onChange={(event) => setSpecialNote(event.target.value)}
+                disabled={isClosed}
+                placeholder="없으면 비워 두어도 됩니다."
+                className="mt-2 h-28 w-full resize-none rounded-xl border border-gray-300 p-3 font-normal outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100"
+              />
+            </label>
+          </div>
+        </section>
       </div>
 
       <div className="flex items-center justify-between gap-2">
         <div>
-        {canCancelClosing && (
-          <Button
-            variant="gray"
-            onClick={handleCancelClosing}
-            disabled={cancelMutation.isPending}
-          >
-            마감 취소
-          </Button>
-        )}
+          {canCancelClosing && (
+            <Button
+              variant="gray"
+              onClick={handleCancelClosing}
+              disabled={cancelMutation.isPending}
+            >
+              마감 취소
+            </Button>
+          )}
         </div>
         <Button
           onClick={() => closeMutation.mutate()}
@@ -808,7 +900,7 @@ function Checklist({
             )}
             {item.is_opening_gate && (
               <span
-                className={`${item.is_required ? '' : 'ml-auto'} shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-bold text-emerald-700`}
+                className={`${item.is_required ? "" : "ml-auto"} shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-bold text-emerald-700`}
               >
                 오픈
               </span>
@@ -840,15 +932,15 @@ function SalesBreakdownCard({
           {Array.from({ length: rowCount }, (_, index) => {
             const item = items[index];
             return item ? (
-            <div
-              key={item.paymentType}
-              className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
-            >
-              <span className="text-gray-600">{item.label}</span>
-              <strong className="whitespace-nowrap text-gray-900">
-                {formatWon(item.amount)}
-              </strong>
-            </div>
+              <div
+                key={item.paymentType}
+                className="flex items-center justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+              >
+                <span className="text-gray-600">{item.label}</span>
+                <strong className="whitespace-nowrap text-gray-900">
+                  {formatWon(item.amount)}
+                </strong>
+              </div>
             ) : (
               <div
                 key={`empty-${index}`}
@@ -910,7 +1002,10 @@ export function ChecklistEditor({
     const targetIndex = phaseIndexes[position + direction];
     if (targetIndex === undefined) return;
     const next = [...items];
-    [next[currentIndex], next[targetIndex]] = [next[targetIndex], next[currentIndex]];
+    [next[currentIndex], next[targetIndex]] = [
+      next[targetIndex],
+      next[currentIndex],
+    ];
     onChange(next);
   };
 
@@ -943,7 +1038,10 @@ export function ChecklistEditor({
       </div>
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
         {(["opening", "closing"] as const).map((phase) => (
-          <div key={phase} className="rounded-xl border border-gray-200 bg-white p-3">
+          <div
+            key={phase}
+            className="rounded-xl border border-gray-200 bg-white p-3"
+          >
             <div className="mb-3 flex items-center justify-between">
               <h3 className="font-bold text-gray-800">
                 {phase === "opening" ? "출근·교대 확인" : "마감 확인"}
@@ -959,7 +1057,9 @@ export function ChecklistEditor({
                   <div key={item.id} className="flex items-center gap-1.5">
                     <input
                       value={item.label}
-                      onChange={(event) => updateLabel(item.id, event.target.value)}
+                      onChange={(event) =>
+                        updateLabel(item.id, event.target.value)
+                      }
                       placeholder="확인 내용을 입력하세요"
                       className="h-10 min-w-0 flex-1 rounded-lg border border-gray-300 px-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
                     />

--- a/src/app/(auth)/cash-management/_components/ReportSnapshotView.tsx
+++ b/src/app/(auth)/cash-management/_components/ReportSnapshotView.tsx
@@ -14,6 +14,7 @@ import {
   getDailyClosingReportRevisions,
   reviseDailyClosingReport,
 } from "@/app/_domains/_dailyClosing/_services/dailyClosingService";
+import { getDailyPaymentSales } from "@/app/_domains/_cashManagement/_services/cashManagementService";
 
 const formatWon = (value: number) =>
   `${Number(value).toLocaleString("ko-KR")}원`;
@@ -37,10 +38,20 @@ export default function ReportSnapshotView({
   });
   const snapshot = useMemo(
     () =>
-      revisionsQuery.data?.at(-1)?.report_snapshot ??
-      report.report_snapshot,
+      revisionsQuery.data?.at(-1)?.report_snapshot ?? report.report_snapshot,
     [report.report_snapshot, revisionsQuery.data],
   );
+  const inboundSummaryQuery = useQuery({
+    queryKey: ["daily-closing-inbound-summary", snapshot?.businessDate],
+    queryFn: () => getDailyPaymentSales(snapshot!.businessDate),
+    enabled: Boolean(
+      snapshot?.businessDate &&
+        snapshot.inboundSummary?.some(
+          (item) =>
+            item.type === "purchase" && item.aggregationUnit !== "count",
+        ),
+    ),
+  });
   useEffect(() => {
     setEditing(false);
     setRevisionReason("");
@@ -65,6 +76,22 @@ export default function ReportSnapshotView({
         reportId: report.id,
         reportSnapshot: {
           ...draft,
+          inboundSummary: draft.inboundSummary?.map((item) => {
+            if (item.type !== "purchase") return item;
+            const correctedCount =
+              item.aggregationUnit === "count"
+                ? item.quantity
+                : inboundSummaryQuery.data?.inboundSummary.find(
+                    (current) =>
+                      current.type === "purchase" &&
+                      current.label === item.label,
+                  )?.quantity;
+            return {
+              ...item,
+              quantity: correctedCount ?? 0,
+              aggregationUnit: "count" as const,
+            };
+          }),
           capturedAt: new Date().toISOString(),
         },
         revisionReason,
@@ -118,7 +145,9 @@ export default function ReportSnapshotView({
       ]);
       toast.success("마감보고서 사진을 복사했습니다.");
     } catch {
-      toast.error("사진 복사를 지원하지 않는 환경입니다. 사진 저장을 이용해 주세요.");
+      toast.error(
+        "사진 복사를 지원하지 않는 환경입니다. 사진 저장을 이용해 주세요.",
+      );
     }
   };
 
@@ -126,8 +155,8 @@ export default function ReportSnapshotView({
     return (
       <section className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-800">
         이 보고서의 스냅샷이 DB에 저장되지 않았습니다. 최신
-        daily_closing_report.sql 적용 여부를 확인한 뒤 해당 마감을 취소하고
-        다시 마감해 주세요.
+        daily_closing_report.sql 적용 여부를 확인한 뒤 해당 마감을 취소하고 다시
+        마감해 주세요.
       </section>
     );
   }
@@ -231,9 +260,7 @@ export default function ReportSnapshotView({
             </Button>
             <Button
               onClick={() => revisionMutation.mutate()}
-              disabled={
-                revisionMutation.isPending || !revisionReason.trim()
-              }
+              disabled={revisionMutation.isPending || !revisionReason.trim()}
             >
               {revisionMutation.isPending ? "저장 중..." : "수정본 저장"}
             </Button>
@@ -280,14 +307,12 @@ export default function ReportSnapshotView({
         </div>
 
         <ReportSection title="근무자 명단">
-          <div className="overflow-hidden rounded-xl border border-gray-200">
+          <div className="max-w-[500px] overflow-hidden rounded-xl border border-gray-200">
             <table className="w-full border-collapse text-sm [&_td]:border [&_td]:border-gray-200 [&_th]:border [&_th]:border-gray-200">
               <thead className="bg-gray-50 text-gray-600">
                 <tr>
                   <th className="px-3 py-2">근무자</th>
                   <th className="px-3 py-2">근무시간</th>
-                  <th className="px-3 py-2 text-right">실제 근무시간</th>
-                  <th className="px-3 py-2 text-right">입력 근무시간</th>
                 </tr>
               </thead>
               <tbody>
@@ -297,12 +322,6 @@ export default function ReportSnapshotView({
                     <td className="px-3 py-2 text-center">
                       {worker.startTime} ~ {worker.actualEndTime}
                     </td>
-                    <td className="px-3 py-2 text-right">
-                      {worker.actualWorkHours}시간
-                    </td>
-                    <td className="px-3 py-2 text-right font-semibold text-brand-700">
-                      {worker.inputWorkHours}시간
-                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -310,7 +329,7 @@ export default function ReportSnapshotView({
           </div>
         </ReportSection>
 
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[190px_190px_190px_minmax(0,1fr)]">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[170px_170px_140px_minmax(0,1fr)]">
           <SnapshotList
             title="오베이프 매출"
             rows={ovapePayments.map((item) => ({
@@ -354,14 +373,14 @@ export default function ReportSnapshotView({
               <h3 className="border-b border-gray-200 pb-2 font-bold text-gray-800">
                 총 매출
               </h3>
-              <strong className="flex flex-1 items-center justify-center py-3 text-2xl text-brand-700">
+              <strong className="flex flex-1 items-center justify-center whitespace-nowrap py-3 text-xl text-brand-700">
                 {formatWon(snapshot.totalSales)}
               </strong>
             </div>
           </section>
           {snapshot.businessDate >= "2026-07-31" ? (
             <section className="min-h-36 overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
-              <div className="grid min-h-36 sm:h-full sm:grid-cols-[7fr_7fr_4fr]">
+              <div className="grid min-h-36 sm:h-full sm:grid-cols-[180px_180px_130px_minmax(0,1fr)]">
                 <SnapshotListSection
                   title="일반 출고"
                   rows={(snapshot.itemSummary ?? []).map((item) => ({
@@ -387,6 +406,30 @@ export default function ReportSnapshotView({
                     value: `${item.orderCount}건`,
                   }))}
                   emptyText="등록 없음"
+                  className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0"
+                />
+                <SnapshotListSection
+                  title="입고"
+                  rows={(snapshot.inboundSummary ?? []).map((item) => {
+                    const receiptCount =
+                      inboundSummaryQuery.data?.inboundSummary.find(
+                        (current) =>
+                          current.type === "purchase" &&
+                          current.label === item.label,
+                      )?.quantity;
+                    return {
+                      label: item.label,
+                      value:
+                        item.type === "purchase"
+                          ? item.aggregationUnit === "count"
+                            ? `${item.quantity}건`
+                            : receiptCount == null
+                            ? ""
+                            : `${receiptCount}건`
+                          : `${item.quantity}개`,
+                    };
+                  })}
+                  emptyText="입고 없음"
                   className="border-t border-gray-300 p-4 sm:border-l sm:border-t-0"
                 />
               </div>
@@ -472,8 +515,12 @@ function SnapshotListSection({
               key={`${row.label}-${index}`}
               className="flex justify-between gap-2 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
             >
-              <span className="text-gray-600">{row.label}</span>
-              <strong className="shrink-0 text-gray-900">{row.value}</strong>
+              <span className="min-w-0 break-all text-gray-600">
+                {row.label}
+              </span>
+              <strong className="shrink-0 whitespace-nowrap text-gray-900">
+                {row.value}
+              </strong>
             </div>
           ))
         ) : (
@@ -500,9 +547,7 @@ function SnapshotList({
   return (
     <section
       className={`flex min-h-36 flex-col rounded-xl border p-4 ${
-        brand
-          ? "border-brand-200 bg-brand-50"
-          : "border-gray-200 bg-gray-50"
+        brand ? "border-brand-200 bg-brand-50" : "border-gray-200 bg-gray-50"
       }`}
     >
       <h3
@@ -519,13 +564,13 @@ function SnapshotList({
           {Array.from({ length: rowCount }, (_, index) => {
             const row = rows[index];
             return row ? (
-            <div
-              key={`${row.label}-${index}`}
-              className="flex justify-between gap-3 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
-            >
-              <span className="text-gray-600">{row.label}</span>
-              <strong>{row.value}</strong>
-            </div>
+              <div
+                key={`${row.label}-${index}`}
+                className="flex justify-between gap-3 border-b border-gray-200 pb-1.5 text-sm last:border-b-0"
+              >
+                <span className="text-gray-600">{row.label}</span>
+                <strong>{row.value}</strong>
+              </div>
             ) : (
               <div
                 key={`empty-${index}`}
@@ -566,7 +611,9 @@ function SnapshotChecklist({
             key={item.id}
             className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2 text-sm"
           >
-            <span className={item.checked ? "text-emerald-600" : "text-gray-400"}>
+            <span
+              className={item.checked ? "text-emerald-600" : "text-gray-400"}
+            >
               {item.checked ? "✓" : "□"}
             </span>
             <span>{item.label}</span>

--- a/src/app/(auth)/cash-management/page.tsx
+++ b/src/app/(auth)/cash-management/page.tsx
@@ -1,11 +1,11 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { usePathname } from 'next/navigation';
-import toast from 'react-hot-toast';
-import Button from '@/app/_components/Button';
-import Loading from '@/app/_components/Loading';
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
+import toast from "react-hot-toast";
+import Button from "@/app/_components/Button";
+import Loading from "@/app/_components/Loading";
 import {
   getCashClosing,
   getCashClosingHistory,
@@ -13,42 +13,40 @@ import {
   getDailyPaymentSales,
   getPreviousClosing,
   saveCashClosing,
-} from '@/app/_domains/_cashManagement/_services/cashManagementService';
-import { cashManagementKeys } from '@/app/_domains/_cashManagement/_queryKeys/cashManagementKeys';
+} from "@/app/_domains/_cashManagement/_services/cashManagementService";
+import { cashManagementKeys } from "@/app/_domains/_cashManagement/_queryKeys/cashManagementKeys";
 import {
   CASH_DENOMINATIONS,
   CashCounts,
-} from '@/app/_domains/_cashManagement/_types/cashManagement.types';
-import KoreanDatePicker, { formatKoreanDate } from '@/app/_components/KoreanDatePicker';
-import { KoreanDateRangePicker } from '@/app/_components/KoreanDatePicker';
-import { Dropdown, DropdownOption } from '@/app/_components/Dropdown';
-import { getWorkJournalsByDate } from '@/app/_domains/_workJournal/_services/workJournalService';
-import { getDailyClosingReportsByRange } from '@/app/_domains/_dailyClosing/_services/dailyClosingService';
-import { useModal } from '@/app/_contexts/ModalContext';
-import ConfirmModal from '@/app/(auth)/_components/ConfirmModal';
-import { useUser } from '@/app/_contexts/UserContext';
-import { useStaffOpening } from '@/app/_contexts/StaffOpeningContext';
-import DailyClosingReport from './_components/DailyClosingReport';
-import ChecklistManagement from './_components/ChecklistManagement';
-import ReportSnapshotView from './_components/ReportSnapshotView';
-import StaffOpeningProgressBanner from '@/app/(auth)/_components/StaffOpeningProgressBanner';
+} from "@/app/_domains/_cashManagement/_types/cashManagement.types";
+import KoreanDatePicker, {
+  formatKoreanDate,
+} from "@/app/_components/KoreanDatePicker";
+import { KoreanDateRangePicker } from "@/app/_components/KoreanDatePicker";
+import { Dropdown, DropdownOption } from "@/app/_components/Dropdown";
+import { getWorkJournalsByDate } from "@/app/_domains/_workJournal/_services/workJournalService";
+import { getDailyClosingReportsByRange } from "@/app/_domains/_dailyClosing/_services/dailyClosingService";
+import { useModal } from "@/app/_contexts/ModalContext";
+import ConfirmModal from "@/app/(auth)/_components/ConfirmModal";
+import { useUser } from "@/app/_contexts/UserContext";
+import { useStaffOpening } from "@/app/_contexts/StaffOpeningContext";
+import DailyClosingReport from "./_components/DailyClosingReport";
+import ChecklistManagement from "./_components/ChecklistManagement";
+import ReportSnapshotView from "./_components/ReportSnapshotView";
+import StaffOpeningProgressBanner from "@/app/(auth)/_components/StaffOpeningProgressBanner";
 
 type CashManagementTab =
-  | 'save'
-  | 'history'
-  | 'report'
-  | 'reportLookup'
-  | 'checklist';
+  "save" | "history" | "report" | "reportLookup" | "checklist";
 
 const getTodayInKorea = () =>
-  new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'Asia/Seoul',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
+  new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
   }).format(new Date());
 
-const formatWon = (amount: number) => `${amount.toLocaleString('ko-KR')}원`;
+const formatWon = (amount: number) => `${amount.toLocaleString("ko-KR")}원`;
 
 const emptyCashCounts = (): CashCounts =>
   Object.fromEntries(CASH_DENOMINATIONS.map((value) => [String(value), 0]));
@@ -59,17 +57,17 @@ const toNonNegativeNumber = (value: string) => {
 };
 
 const getMonthDateRange = (month: string) => {
-  const [year, monthNumber] = month.split('-').map(Number);
+  const [year, monthNumber] = month.split("-").map(Number);
   const lastDay = new Date(year, monthNumber, 0).getDate();
   return {
     start: `${month}-01`,
-    end: `${month}-${String(lastDay).padStart(2, '0')}`,
+    end: `${month}-${String(lastDay).padStart(2, "0")}`,
   };
 };
 
 export default function CashManagementPage() {
   const pathname = usePathname();
-  const isReportsPage = pathname?.startsWith('/reports');
+  const isReportsPage = pathname?.startsWith("/reports");
   const { isAdmin } = useUser();
   const {
     step: staffOpeningStep,
@@ -79,14 +77,14 @@ export default function CashManagementPage() {
   const queryClient = useQueryClient();
   const { open, close } = useModal();
   const [activeTab, setActiveTab] = useState<CashManagementTab>(
-    isReportsPage ? 'report' : 'save',
+    isReportsPage ? "report" : "save",
   );
   const [tabOrder, setTabOrder] = useState<CashManagementTab[]>([
-    'save',
-    'history',
-    'report',
-    'reportLookup',
-    'checklist',
+    "save",
+    "history",
+    "report",
+    "reportLookup",
+    "checklist",
   ]);
   const [editingTabOrder, setEditingTabOrder] = useState(false);
   const [businessDate, setBusinessDate] = useState(getTodayInKorea);
@@ -94,31 +92,35 @@ export default function CashManagementPage() {
   const [cashIn, setCashIn] = useState(0);
   const [cashOut, setCashOut] = useState(0);
   const [cashCounts, setCashCounts] = useState<CashCounts>(emptyCashCounts);
-  const [note, setNote] = useState('');
+  const [note, setNote] = useState("");
   const today = getTodayInKorea();
-  const [historyViewMode, setHistoryViewMode] = useState<'month' | 'range'>('month');
-  const [historyMonth, setHistoryMonth] = useState(today.slice(0, 7));
-  const [historyStartDate, setHistoryStartDate] = useState(`${today.slice(0, 7)}-01`);
-  const [historyEndDate, setHistoryEndDate] = useState(today);
-  const [reportViewMode, setReportViewMode] = useState<'month' | 'range'>(
-    'range',
+  const [historyViewMode, setHistoryViewMode] = useState<"month" | "range">(
+    "month",
   );
-  const [reportStartDate, setReportStartDate] = useState('');
-  const [reportEndDate, setReportEndDate] = useState('');
-  const [selectedReportId, setSelectedReportId] = useState('');
+  const [historyMonth, setHistoryMonth] = useState(today.slice(0, 7));
+  const [historyStartDate, setHistoryStartDate] = useState(
+    `${today.slice(0, 7)}-01`,
+  );
+  const [historyEndDate, setHistoryEndDate] = useState(today);
+  const [reportViewMode, setReportViewMode] = useState<"month" | "range">(
+    "range",
+  );
+  const [reportStartDate, setReportStartDate] = useState("");
+  const [reportEndDate, setReportEndDate] = useState("");
+  const [selectedReportId, setSelectedReportId] = useState("");
   const [reportEditRequestKey, setReportEditRequestKey] = useState(0);
 
   useEffect(() => {
-    const saved = window.localStorage.getItem('cash-management-tab-order');
+    const saved = window.localStorage.getItem("cash-management-tab-order");
     if (!saved) return;
     try {
       const parsed = JSON.parse(saved) as CashManagementTab[];
       const knownTabs: CashManagementTab[] = [
-        'save',
-        'history',
-        'report',
-        'reportLookup',
-        'checklist',
+        "save",
+        "history",
+        "report",
+        "reportLookup",
+        "checklist",
       ];
       const normalized = parsed.filter((tab) => knownTabs.includes(tab));
       knownTabs.forEach((tab) => {
@@ -126,7 +128,7 @@ export default function CashManagementPage() {
       });
       setTabOrder(normalized);
     } catch {
-      window.localStorage.removeItem('cash-management-tab-order');
+      window.localStorage.removeItem("cash-management-tab-order");
     }
   }, []);
 
@@ -134,10 +136,10 @@ export default function CashManagementPage() {
     setTabOrder((current) => {
       const visibleTabs = current.filter((tab) =>
         isReportsPage
-          ? tab !== 'save' &&
-            tab !== 'history' &&
-            (isAdmin || (tab !== 'reportLookup' && tab !== 'checklist'))
-          : tab === 'save' || tab === 'history',
+          ? tab !== "save" &&
+            tab !== "history" &&
+            (isAdmin || (tab !== "reportLookup" && tab !== "checklist"))
+          : tab === "save" || tab === "history",
       );
       const currentTab = current[index];
       const visibleIndex = visibleTabs.indexOf(currentTab);
@@ -147,7 +149,7 @@ export default function CashManagementPage() {
       const next = [...current];
       [next[index], next[target]] = [next[target], next[index]];
       window.localStorage.setItem(
-        'cash-management-tab-order',
+        "cash-management-tab-order",
         JSON.stringify(next),
       );
       return next;
@@ -155,14 +157,14 @@ export default function CashManagementPage() {
   };
 
   const historyDateRange =
-    historyViewMode === 'month'
+    historyViewMode === "month"
       ? getMonthDateRange(historyMonth)
       : { start: historyStartDate, end: historyEndDate };
   const isHistoryRangeValid =
     Boolean(historyDateRange.start && historyDateRange.end) &&
     historyDateRange.start <= historyDateRange.end;
   const reportDateRange =
-    reportViewMode === 'month'
+    reportViewMode === "month"
       ? getMonthDateRange(today.slice(0, 7))
       : { start: reportStartDate, end: reportEndDate };
   const isReportRangeValid =
@@ -172,27 +174,36 @@ export default function CashManagementPage() {
   const dayQuery = useQuery({
     queryKey: cashManagementKeys.day(businessDate),
     queryFn: async () => {
-      const [closing, previousClosing, sales, paymentSales, workJournals] = await Promise.all([
-        getCashClosing(businessDate),
-        getPreviousClosing(businessDate),
-        getDailyCashSales(businessDate),
-        getDailyPaymentSales(businessDate),
-        getWorkJournalsByDate(businessDate),
-      ]);
+      const [closing, previousClosing, sales, paymentSales, workJournals] =
+        await Promise.all([
+          getCashClosing(businessDate),
+          getPreviousClosing(businessDate),
+          getDailyCashSales(businessDate),
+          getDailyPaymentSales(businessDate),
+          getWorkJournalsByDate(businessDate),
+        ]);
       return { closing, previousClosing, sales, paymentSales, workJournals };
     },
   });
 
   const historyQuery = useQuery({
-    queryKey: cashManagementKeys.history(historyDateRange.start, historyDateRange.end),
-    queryFn: () => getCashClosingHistory(historyDateRange.start, historyDateRange.end),
+    queryKey: cashManagementKeys.history(
+      historyDateRange.start,
+      historyDateRange.end,
+    ),
+    queryFn: () =>
+      getCashClosingHistory(historyDateRange.start, historyDateRange.end),
     enabled: isHistoryRangeValid,
   });
   const reportHistoryQuery = useQuery({
-    queryKey: ['daily-closing-reports', reportDateRange.start, reportDateRange.end],
+    queryKey: [
+      "daily-closing-reports",
+      reportDateRange.start,
+      reportDateRange.end,
+    ],
     queryFn: () =>
       getDailyClosingReportsByRange(reportDateRange.start, reportDateRange.end),
-    enabled: isAdmin && activeTab === 'reportLookup' && isReportRangeValid,
+    enabled: isAdmin && activeTab === "reportLookup" && isReportRangeValid,
   });
 
   useEffect(() => {
@@ -204,7 +215,7 @@ export default function CashManagementPage() {
       setCashIn(closing.cash_in);
       setCashOut(closing.cash_out);
       setCashCounts({ ...emptyCashCounts(), ...closing.cash_counts });
-      setNote(closing.note ?? '');
+      setNote(closing.note ?? "");
       return;
     }
 
@@ -212,20 +223,20 @@ export default function CashManagementPage() {
     setCashIn(0);
     setCashOut(0);
     setCashCounts(emptyCashCounts());
-    setNote('');
+    setNote("");
   }, [dayQuery.data]);
 
   const loadPreviousCashCounts = () => {
     const previousClosing = dayQuery.data?.previousClosing;
     if (!previousClosing) {
-      toast.error('불러올 전날 시재가 없습니다.');
+      toast.error("불러올 전날 시재가 없습니다.");
       return;
     }
     setCashCounts({
       ...emptyCashCounts(),
       ...previousClosing.cash_counts,
     });
-    toast.success('전날 시재를 불러왔습니다.');
+    toast.success("전날 시재를 불러왔습니다.");
   };
 
   const actualCash = useMemo(
@@ -245,6 +256,7 @@ export default function CashManagementPage() {
     eguVapeBreakdown: [],
     itemSummary: [],
     outboundTypeSummary: [],
+    inboundSummary: [],
     deliverySummary: [],
     total: 0,
   };
@@ -255,7 +267,10 @@ export default function CashManagementPage() {
     endTime: journal.end_time.slice(0, 5),
     workerName: journal.worker_name,
   }));
-  const cashWorkerName = workShifts.map((shift) => shift.workerName.trim()).filter(Boolean).join(', ');
+  const cashWorkerName = workShifts
+    .map((shift) => shift.workerName.trim())
+    .filter(Boolean)
+    .join(", ");
   const hasWorkerInfo = Boolean(cashWorkerName);
   const expectedCash = openingCash + sales.total + cashIn - cashOut;
   const difference = actualCash - expectedCash;
@@ -279,7 +294,9 @@ export default function CashManagementPage() {
         note: note.trim(),
       }),
     onSuccess: async () => {
-      toast.success(isEditing ? '시재가 수정되었습니다.' : '시재가 저장되었습니다.');
+      toast.success(
+        isEditing ? "시재가 수정되었습니다." : "시재가 저장되었습니다.",
+      );
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: cashManagementKeys.day(businessDate),
@@ -288,7 +305,7 @@ export default function CashManagementPage() {
           queryKey: cashManagementKeys.history(),
         }),
       ]);
-      window.dispatchEvent(new Event('staff-opening-changed'));
+      window.dispatchEvent(new Event("staff-opening-changed"));
       await refreshStaffOpening();
     },
     onError: (error) => {
@@ -300,31 +317,31 @@ export default function CashManagementPage() {
       toast.error(
         message
           ? `시재 저장 실패: ${message}`
-          : '시재 저장에 실패했습니다. cash_management.sql을 확인해 주세요.',
+          : "시재 저장에 실패했습니다. cash_management.sql을 확인해 주세요.",
       );
     },
   });
 
   const handleSave = () => {
-    if (staffOpeningStep === 'attendance') {
-      toast.error('시재를 저장하기 전에 근무기록에서 먼저 출근 처리해 주세요.');
+    if (staffOpeningStep === "attendance") {
+      toast.error("시재를 저장하기 전에 근무기록에서 먼저 출근 처리해 주세요.");
       return;
     }
     if (!hasWorkerInfo) {
-      toast.error('시재를 저장하려면 해당 날짜의 근무자 정보가 필요합니다.');
+      toast.error("시재를 저장하려면 해당 날짜의 근무자 정보가 필요합니다.");
       return;
     }
     if (!canModifyClosing) {
-      toast.error('staff 계정은 오늘 날짜의 시재만 수정할 수 있습니다.');
+      toast.error("staff 계정은 오늘 날짜의 시재만 수정할 수 있습니다.");
       return;
     }
     if (
-      staffOpeningStep === 'cash' &&
+      staffOpeningStep === "cash" &&
       requiredOpeningCash !== null &&
       actualCash !== requiredOpeningCash
     ) {
       toast.error(
-        `영업 시작 시재는 전날 시재 ${requiredOpeningCash.toLocaleString('ko-KR')}원과 일치해야 합니다.`,
+        `영업 시작 시재는 전날 시재 ${requiredOpeningCash.toLocaleString("ko-KR")}원과 일치해야 합니다.`,
       );
       return;
     }
@@ -337,17 +354,17 @@ export default function CashManagementPage() {
     open({
       content: (
         <ConfirmModal
-          title={isEditing ? '시재 기록 수정' : '시재 차액 확인'}
+          title={isEditing ? "시재 기록 수정" : "시재 차액 확인"}
           description={
             isEditing
               ? hasDifference
-                ? '기존 시재 기록을 수정합니다. 예상 시재와 실제 시재가 다른 상태로 수정하시겠습니까?'
-                : '기존에 저장된 시재 기록을 수정하시겠습니까?'
-              : '예상 시재와 실제 시재가 다릅니다. 그래도 저장하시겠습니까?'
+                ? "기존 시재 기록을 수정합니다. 예상 시재와 실제 시재가 다른 상태로 수정하시겠습니까?"
+                : "기존에 저장된 시재 기록을 수정하시겠습니까?"
+              : "예상 시재와 실제 시재가 다릅니다. 그래도 저장하시겠습니까?"
           }
-          confirmLabel={isEditing ? '수정' : '네'}
+          confirmLabel={isEditing ? "수정" : "네"}
           cancelLabel="아니오"
-          confirmingLabel={isEditing ? '수정 중...' : '저장 중...'}
+          confirmingLabel={isEditing ? "수정 중..." : "저장 중..."}
           onCancel={close}
           onConfirm={async () => {
             try {
@@ -364,9 +381,9 @@ export default function CashManagementPage() {
   };
 
   const handleEditHistory = (date: string) => {
-    setActiveTab('save');
+    setActiveTab("save");
     setBusinessDate(date);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   if (dayQuery.isPending) {
@@ -376,7 +393,7 @@ export default function CashManagementPage() {
   if (dayQuery.isError) {
     return (
       <div className="mx-auto mt-10 max-w-3xl rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700">
-        시재 데이터 표를 불러오지 못했습니다. Supabase에서{' '}
+        시재 데이터 표를 불러오지 못했습니다. Supabase에서{" "}
         <code className="font-semibold">docs/cash_management.sql</code>을 먼저
         실행해 주세요.
       </div>
@@ -387,33 +404,34 @@ export default function CashManagementPage() {
     <main className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6 lg:px-8">
       <StaffOpeningProgressBanner />
       <div className="flex items-end justify-between border-b border-gray-200">
-        <div className="flex min-w-0 overflow-x-auto" role="tablist" aria-label="시재 관리 메뉴">
+        <div
+          className="flex min-w-0 overflow-x-auto"
+          role="tablist"
+          aria-label="시재 관리 메뉴"
+        >
           {tabOrder.map((tab, index) => {
             if (
-              (isReportsPage && (tab === 'save' || tab === 'history')) ||
+              (isReportsPage && (tab === "save" || tab === "history")) ||
               (!isReportsPage &&
-                (tab === 'report' ||
-                  tab === 'reportLookup' ||
-                  tab === 'checklist'))
+                (tab === "report" ||
+                  tab === "reportLookup" ||
+                  tab === "checklist"))
             ) {
               return null;
             }
-            if (
-              !isAdmin &&
-              (tab === 'reportLookup' || tab === 'checklist')
-            ) {
+            if (!isAdmin && (tab === "reportLookup" || tab === "checklist")) {
               return null;
             }
             const label =
-              tab === 'save'
-                ? '시재 저장'
-                : tab === 'history'
-                  ? '시재 이력'
-                  : tab === 'report'
-                    ? '마감보고서'
-                    : tab === 'reportLookup'
-                      ? '보고서 조회'
-                      : '체크리스트 관리';
+              tab === "save"
+                ? "시재 저장"
+                : tab === "history"
+                  ? "시재 이력"
+                  : tab === "report"
+                    ? "마감보고서"
+                    : tab === "reportLookup"
+                      ? "보고서 조회"
+                      : "체크리스트 관리";
             return (
               <div key={tab} className="flex shrink-0 items-center">
                 {editingTabOrder && (
@@ -433,23 +451,23 @@ export default function CashManagementPage() {
                   aria-selected={activeTab === tab}
                   onClick={() => {
                     if (
-                      activeTab === 'reportLookup' &&
-                      tab !== 'reportLookup'
+                      activeTab === "reportLookup" &&
+                      tab !== "reportLookup"
                     ) {
-                      setReportViewMode('range');
-                      setReportStartDate('');
-                      setReportEndDate('');
-                      setSelectedReportId('');
+                      setReportViewMode("range");
+                      setReportStartDate("");
+                      setReportEndDate("");
+                      setSelectedReportId("");
                     }
-                    if (tab === 'report') {
+                    if (tab === "report") {
                       setBusinessDate(today);
                     }
                     setActiveTab(tab);
                   }}
                   className={`cursor-pointer border-b-2 px-5 py-3 text-sm font-semibold transition-colors ${
                     activeTab === tab
-                      ? 'border-brand-500 text-brand-700'
-                      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                      ? "border-brand-500 text-brand-700"
+                      : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
                   }`}
                 >
                   {label}
@@ -469,24 +487,37 @@ export default function CashManagementPage() {
             );
           })}
         </div>
-        {isAdmin && <button
-          type="button"
-          onClick={() => setEditingTabOrder((current) => !current)}
-          className={`mb-2 ml-3 flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border bg-white transition ${
-            editingTabOrder
-              ? 'border-brand-300 text-brand-700 shadow-sm'
-              : 'border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700'
-          }`}
-          aria-label={editingTabOrder ? '탭 순서 변경 완료' : '탭 순서 변경'}
-          title={editingTabOrder ? '탭 순서 변경 완료' : '탭 순서 변경'}
-        >
-          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z" />
-          </svg>
-        </button>}
+        {isAdmin && (
+          <button
+            type="button"
+            onClick={() => setEditingTabOrder((current) => !current)}
+            className={`mb-2 ml-3 flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border bg-white transition ${
+              editingTabOrder
+                ? "border-brand-300 text-brand-700 shadow-sm"
+                : "border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700"
+            }`}
+            aria-label={editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"}
+            title={editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.8}
+                d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z"
+              />
+            </svg>
+          </button>
+        )}
       </div>
 
-      {activeTab === 'save' && (
+      {activeTab === "save" && (
         <>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
             {isEditing && (
@@ -495,305 +526,379 @@ export default function CashManagementPage() {
               </span>
             )}
             <div className="w-full sm:w-[280px]">
-          <KoreanDatePicker
-            value={businessDate}
-            onChange={setBusinessDate}
-            selectedLabel="선택한 시재 날짜"
-          />
+              <KoreanDatePicker
+                value={businessDate}
+                onChange={setBusinessDate}
+                selectedLabel="선택한 시재 날짜"
+              />
             </div>
           </div>
 
-      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        <SummaryCard label="전날 시재" value={openingCash} tone="gray" />
-        <SummaryCard label="오베이프 현금 매출" value={sales.ovape} tone="brand" prefix="+" />
-        <SummaryCard label="이구베이프 현금 매출" value={sales.eguVape} tone="amber" prefix="+" />
-        <SummaryCard label="당일 현금 매출 합계" value={sales.total} tone="green" prefix="+" />
-      </section>
+          <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <SummaryCard label="전날 시재" value={openingCash} tone="gray" />
+            <SummaryCard
+              label="오베이프 현금 매출"
+              value={sales.ovape}
+              tone="brand"
+              prefix="+"
+            />
+            <SummaryCard
+              label="이구베이프 현금 매출"
+              value={sales.eguVape}
+              tone="amber"
+              prefix="+"
+            />
+            <SummaryCard
+              label="당일 현금 매출 합계"
+              value={sales.total}
+              tone="green"
+              prefix="+"
+            />
+          </section>
 
-      <section className="grid items-stretch gap-5 xl:grid-cols-2">
-        <div className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-          <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-5 py-4">
-            <div>
-              <div className="flex flex-wrap items-center gap-2">
-                <h2 className="font-semibold text-gray-900">실제 현금 입력</h2>
-                <Button
-                  size="xs"
-                  variant="gray"
-                  onClick={loadPreviousCashCounts}
-                  className="border-gray-200 bg-white/80 text-[11px] text-gray-600 shadow-xs hover:border-brand-200 hover:text-brand-700"
-                >
-                  전날 시재 불러오기
-                </Button>
-              </div>
-              <p className="mt-1 text-xs text-gray-500">
-                지폐와 동전의 개수를 입력하세요.
-              </p>
-            </div>
-            <div className="text-right">
-              <span className="block text-[11px] font-medium text-gray-400">실제 현금 합계</span>
-              <strong className="mt-0.5 block text-xl text-brand-700">{formatWon(actualCash)}</strong>
-            </div>
-          </div>
-
-          <div className="grid flex-1 border-l border-t border-gray-200 md:grid-cols-2">
-            {CASH_DENOMINATIONS.map((denomination) => {
-              const count = cashCounts[String(denomination)] ?? 0;
-              return (
-                <label
-                  key={denomination}
-                  className="grid grid-cols-[minmax(70px,1fr)_80px_minmax(82px,1fr)] items-center gap-3 border-b border-r border-gray-200 px-5 py-2"
-                >
-                  <span className="text-sm font-medium text-gray-700">
-                    {denomination.toLocaleString('ko-KR')}원
-                  </span>
-                  <input
-                    type="number"
-                    min="0"
-                    value={count || ''}
-                    onChange={(event) =>
-                      setCashCounts((previous) => ({
-                        ...previous,
-                        [String(denomination)]: toNonNegativeNumber(event.target.value),
-                      }))
-                    }
-                    className="w-full rounded-md border border-gray-200 bg-gray-50 px-2 py-2 text-right text-sm outline-none transition focus:border-brand-400 focus:bg-white focus:ring-2 focus:ring-brand-50"
-                    placeholder="0"
-                    aria-label={`${denomination.toLocaleString('ko-KR')}원 개수`}
-                  />
-                  <span className="text-right text-xs tabular-nums text-gray-500">
-                    {formatWon(denomination * count)}
-                  </span>
-                </label>
-              );
-            })}
-          </div>
-        </div>
-
-        <div className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-          <div className="border-b border-gray-200 bg-gray-50 px-5 py-4">
-            <h2 className="font-semibold text-gray-900">근무 및 시재 정산</h2>
-            <p className="mt-1 text-xs text-gray-500">근무 정보와 입출금 내역을 확인하고 시재를 저장하세요.</p>
-          </div>
-
-          <div className="flex flex-1 flex-col">
-            <div className="grid grid-cols-2 gap-4 border-b border-gray-200 p-4">
-              <MoneyInput label="시재 입금 (+)" value={cashIn} onChange={setCashIn} />
-              <MoneyInput label="출금 (-)" value={cashOut} onChange={setCashOut} />
-            </div>
-
-            <div className="grid flex-1 divide-y divide-gray-200 md:grid-cols-2 md:divide-x md:divide-y-0">
-              <div className="p-4">
-                <h3 className="mb-3 text-xs font-semibold text-gray-500">근무자 정보</h3>
-                {workShifts.length > 0 ? (
-                  <div className="space-y-2">
-                    {workShifts.map((shift) => (
-                      <div
-                        key={shift.id}
-                        className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2"
-                      >
-                        <span className="text-sm font-medium text-gray-800">{shift.workerName}</span>
-                        <span className="shrink-0 text-xs text-gray-500">
-                          {shift.startTime} ~ {shift.endTime}
-                        </span>
-                      </div>
-                    ))}
+          <section className="grid items-stretch gap-5 xl:grid-cols-2">
+            <div className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+              <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-5 py-4">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="font-semibold text-gray-900">
+                      실제 현금 입력
+                    </h2>
+                    <Button
+                      size="xs"
+                      variant="gray"
+                      onClick={loadPreviousCashCounts}
+                      className="border-gray-200 bg-white/80 text-[11px] text-gray-600 shadow-xs hover:border-brand-200 hover:text-brand-700"
+                    >
+                      전날 시재 불러오기
+                    </Button>
                   </div>
-                ) : (
-                  <p className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-3 text-center text-xs text-gray-500">
-                    선택한 날짜에 등록된 근무일지가 없습니다.
+                  <p className="mt-1 text-xs text-gray-500">
+                    지폐와 동전의 개수를 입력하세요.
                   </p>
-                )}
-              </div>
-
-              <label className="block p-4">
-                <span className="mb-3 block text-xs font-semibold text-gray-500">메모</span>
-                <textarea
-                  value={note}
-                  onChange={(event) => setNote(event.target.value)}
-                  className="min-h-24 w-full resize-none rounded-lg border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-brand-400 focus:ring-2 focus:ring-brand-50"
-                  placeholder="특이사항을 입력하세요"
-                />
-              </label>
-            </div>
-
-            <div className="border-t border-gray-200 p-4">
-              <h3 className="mb-3 text-xs font-semibold text-gray-500">시재 결과</h3>
-              <div className="grid gap-2 sm:grid-cols-3">
-                <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-                  <AmountRow label="예상" value={expectedCash} strong />
                 </div>
-                <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-                  <AmountRow label="실제" value={actualCash} strong />
-                </div>
-                <div className={`flex min-w-0 flex-col justify-center rounded-lg border px-4 py-3 ${
-                  difference === 0
-                    ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                    : 'border-rose-200 bg-rose-50 text-rose-700'
-                }`}>
-                  <span className="text-xs font-semibold opacity-75">차액</span>
-                  <span className="mt-1 whitespace-nowrap text-right text-base font-bold tabular-nums">
-                    {difference > 0 ? '+' : ''}{formatWon(difference)}
+                <div className="text-right">
+                  <span className="block text-[11px] font-medium text-gray-400">
+                    실제 현금 합계
                   </span>
+                  <strong className="mt-0.5 block text-xl text-brand-700">
+                    {formatWon(actualCash)}
+                  </strong>
                 </div>
               </div>
-              <Button
-              className="mt-3 w-full"
-              disabled={saveMutation.isPending || !canModifyClosing || !hasWorkerInfo}
-              onClick={handleSave}
-            >
-              {!hasWorkerInfo
-                ? '근무자 정보 필요'
-                : !canModifyClosing
-                ? '수정 권한 없음'
-                : saveMutation.isPending
-                ? isEditing
-                  ? '수정 중...'
-                  : '저장 중...'
-                : isEditing
-                  ? '수정 저장'
-                  : '시재 저장'}
-              </Button>
+
+              <div className="grid flex-1 border-l border-t border-gray-200 md:grid-cols-2">
+                {CASH_DENOMINATIONS.map((denomination) => {
+                  const count = cashCounts[String(denomination)] ?? 0;
+                  return (
+                    <label
+                      key={denomination}
+                      className="grid grid-cols-[minmax(70px,1fr)_80px_minmax(82px,1fr)] items-center gap-3 border-b border-r border-gray-200 px-5 py-2"
+                    >
+                      <span className="text-sm font-medium text-gray-700">
+                        {denomination.toLocaleString("ko-KR")}원
+                      </span>
+                      <input
+                        type="number"
+                        min="0"
+                        value={count || ""}
+                        onChange={(event) =>
+                          setCashCounts((previous) => ({
+                            ...previous,
+                            [String(denomination)]: toNonNegativeNumber(
+                              event.target.value,
+                            ),
+                          }))
+                        }
+                        className="w-full rounded-md border border-gray-200 bg-gray-50 px-2 py-2 text-right text-sm outline-none transition focus:border-brand-400 focus:bg-white focus:ring-2 focus:ring-brand-50"
+                        placeholder="0"
+                        aria-label={`${denomination.toLocaleString("ko-KR")}원 개수`}
+                      />
+                      <span className="text-right text-xs tabular-nums text-gray-500">
+                        {formatWon(denomination * count)}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        </div>
-      </section>
+
+            <div className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+              <div className="border-b border-gray-200 bg-gray-50 px-5 py-4">
+                <h2 className="font-semibold text-gray-900">
+                  근무 및 시재 정산
+                </h2>
+                <p className="mt-1 text-xs text-gray-500">
+                  근무 정보와 입출금 내역을 확인하고 시재를 저장하세요.
+                </p>
+              </div>
+
+              <div className="flex flex-1 flex-col">
+                <div className="grid grid-cols-2 gap-4 border-b border-gray-200 p-4">
+                  <MoneyInput
+                    label="시재 입금 (+)"
+                    value={cashIn}
+                    onChange={setCashIn}
+                  />
+                  <MoneyInput
+                    label="출금 (-)"
+                    value={cashOut}
+                    onChange={setCashOut}
+                  />
+                </div>
+
+                <div className="grid flex-1 divide-y divide-gray-200 md:grid-cols-2 md:divide-x md:divide-y-0">
+                  <div className="p-4">
+                    <h3 className="mb-3 text-xs font-semibold text-gray-500">
+                      근무자 정보
+                    </h3>
+                    {workShifts.length > 0 ? (
+                      <div className="space-y-2">
+                        {workShifts.map((shift) => (
+                          <div
+                            key={shift.id}
+                            className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2"
+                          >
+                            <span className="text-sm font-medium text-gray-800">
+                              {shift.workerName}
+                            </span>
+                            <span className="shrink-0 text-xs text-gray-500">
+                              {shift.startTime} ~ {shift.endTime}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-3 text-center text-xs text-gray-500">
+                        선택한 날짜에 등록된 근무일지가 없습니다.
+                      </p>
+                    )}
+                  </div>
+
+                  <label className="block p-4">
+                    <span className="mb-3 block text-xs font-semibold text-gray-500">
+                      메모
+                    </span>
+                    <textarea
+                      value={note}
+                      onChange={(event) => setNote(event.target.value)}
+                      className="min-h-24 w-full resize-none rounded-lg border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-brand-400 focus:ring-2 focus:ring-brand-50"
+                      placeholder="특이사항을 입력하세요"
+                    />
+                  </label>
+                </div>
+
+                <div className="border-t border-gray-200 p-4">
+                  <h3 className="mb-3 text-xs font-semibold text-gray-500">
+                    시재 결과
+                  </h3>
+                  <div className="grid gap-2 sm:grid-cols-3">
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+                      <AmountRow label="예상" value={expectedCash} strong />
+                    </div>
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+                      <AmountRow label="실제" value={actualCash} strong />
+                    </div>
+                    <div
+                      className={`flex min-w-0 flex-col justify-center rounded-lg border px-4 py-3 ${
+                        difference === 0
+                          ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                          : "border-rose-200 bg-rose-50 text-rose-700"
+                      }`}
+                    >
+                      <span className="text-xs font-semibold opacity-75">
+                        차액
+                      </span>
+                      <span className="mt-1 whitespace-nowrap text-right text-base font-bold tabular-nums">
+                        {difference > 0 ? "+" : ""}
+                        {formatWon(difference)}
+                      </span>
+                    </div>
+                  </div>
+                  <Button
+                    className="mt-3 w-full"
+                    disabled={
+                      saveMutation.isPending ||
+                      !canModifyClosing ||
+                      !hasWorkerInfo
+                    }
+                    onClick={handleSave}
+                  >
+                    {!hasWorkerInfo
+                      ? "근무자 정보 필요"
+                      : !canModifyClosing
+                        ? "수정 권한 없음"
+                        : saveMutation.isPending
+                          ? isEditing
+                            ? "수정 중..."
+                            : "저장 중..."
+                          : isEditing
+                            ? "수정 저장"
+                            : "시재 저장"}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </section>
         </>
       )}
 
-      {activeTab === 'history' && (
-      <section className="rounded-xl border border-brand-100 bg-white p-5 shadow-sm">
-        <div className="mb-4 flex justify-end">
-          <div className="flex flex-col gap-2 lg:items-end">
-            <div className="inline-flex self-start rounded-lg bg-gray-100 p-1 lg:self-auto">
-              <button
-                type="button"
-                onClick={() => setHistoryViewMode('month')}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  historyViewMode === 'month'
-                    ? 'bg-white text-brand-700 shadow-sm'
-                    : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                월별 보기
-              </button>
-              <button
-                type="button"
-                onClick={() => setHistoryViewMode('range')}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  historyViewMode === 'range'
-                    ? 'bg-white text-brand-700 shadow-sm'
-                    : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                기간 보기
-              </button>
-            </div>
-            {historyViewMode === 'month' ? (
-              <input
-                type="month"
-                value={historyMonth}
-                onChange={(event) => setHistoryMonth(event.target.value)}
-                className="rounded-lg border border-brand-200 bg-white px-3 py-2 text-sm outline-none focus:border-brand-400"
-              />
-            ) : (
-              <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
-                <div className="w-full sm:w-[245px]">
-                  <KoreanDatePicker
-                    value={historyStartDate}
-                    onChange={setHistoryStartDate}
-                    selectedLabel="시작 날짜"
-                  />
-                </div>
-                <span className="text-center text-sm text-gray-400">~</span>
-                <div className="w-full sm:w-[245px]">
-                  <KoreanDatePicker
-                    value={historyEndDate}
-                    onChange={setHistoryEndDate}
-                    selectedLabel="종료 날짜"
-                  />
-                </div>
+      {activeTab === "history" && (
+        <section className="rounded-xl border border-brand-100 bg-white p-5 shadow-sm">
+          <div className="mb-4 flex justify-end">
+            <div className="flex flex-col gap-2 lg:items-end">
+              <div className="inline-flex self-start rounded-lg bg-gray-100 p-1 lg:self-auto">
+                <button
+                  type="button"
+                  onClick={() => setHistoryViewMode("month")}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
+                    historyViewMode === "month"
+                      ? "bg-white text-brand-700 shadow-sm"
+                      : "text-gray-500 hover:text-gray-700"
+                  }`}
+                >
+                  월별 보기
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setHistoryViewMode("range")}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
+                    historyViewMode === "range"
+                      ? "bg-white text-brand-700 shadow-sm"
+                      : "text-gray-500 hover:text-gray-700"
+                  }`}
+                >
+                  기간 보기
+                </button>
               </div>
-            )}
+              {historyViewMode === "month" ? (
+                <input
+                  type="month"
+                  value={historyMonth}
+                  onChange={(event) => setHistoryMonth(event.target.value)}
+                  className="rounded-lg border border-brand-200 bg-white px-3 py-2 text-sm outline-none focus:border-brand-400"
+                />
+              ) : (
+                <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
+                  <div className="w-full sm:w-[245px]">
+                    <KoreanDatePicker
+                      value={historyStartDate}
+                      onChange={setHistoryStartDate}
+                      selectedLabel="시작 날짜"
+                    />
+                  </div>
+                  <span className="text-center text-sm text-gray-400">~</span>
+                  <div className="w-full sm:w-[245px]">
+                    <KoreanDatePicker
+                      value={historyEndDate}
+                      onChange={setHistoryEndDate}
+                      selectedLabel="종료 날짜"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-        {!isHistoryRangeValid && (
-          <p className="mb-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">
-            종료 날짜는 시작 날짜보다 빠를 수 없습니다.
-          </p>
-        )}
-        {historyQuery.isPending ? (
-          <Loading size="sm" text="이력을 불러오는 중..." />
-        ) : historyQuery.data?.length ? (
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[1160px] border-collapse text-sm [&_td]:border [&_td]:border-gray-200 [&_th]:border [&_th]:border-brand-200">
-              <thead className="bg-brand-50 text-left text-xs text-brand-700">
-                <tr>
-                  <th className="px-3 py-2">날짜</th>
-                  <th className="px-3 py-2">근무자</th>
-                  <th className="px-3 py-2 text-right">오베이프 현금 매출</th>
-                  <th className="px-3 py-2 text-right">이구베이프 현금 매출</th>
-                  <th className="px-3 py-2 text-right">별도 입금</th>
-                  <th className="px-3 py-2 text-right">출금</th>
-                  <th className="px-3 py-2 text-right">예상</th>
-                  <th className="px-3 py-2 text-right">실제</th>
-                  <th className="px-3 py-2 text-right">차액</th>
-                  <th className="px-3 py-2 text-center">작업</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {historyQuery.data.map((closing) => {
-                  const historyDifference = closing.actual_cash - closing.expected_cash;
-                  return (
-                    <tr key={closing.id} className="hover:bg-gray-50">
-                      <td className="whitespace-nowrap px-3 py-2.5">
-                        {formatKoreanDate(closing.business_date)}
-                      </td>
-                      <td className="px-3 py-2.5">{closing.worker_name || '-'}</td>
-                      <td className="px-3 py-2.5 text-right">
-                        {formatWon(closing.ovape_cash_sales)}
-                      </td>
-                      <td className="px-3 py-2.5 text-right">
-                        {formatWon(closing.egu_cash_sales)}
-                      </td>
-                      <td className="px-3 py-2.5 text-right text-emerald-600">
-                        {closing.cash_in > 0 ? '+' : ''}{formatWon(closing.cash_in)}
-                      </td>
-                      <td className="px-3 py-2.5 text-right text-rose-600">
-                        {closing.cash_out > 0 ? '-' : ''}{formatWon(closing.cash_out)}
-                      </td>
-                      <td className="px-3 py-2.5 text-right">{formatWon(closing.expected_cash)}</td>
-                      <td className="px-3 py-2.5 text-right">{formatWon(closing.actual_cash)}</td>
-                      <td
-                        className={`px-3 py-2.5 text-right font-medium ${
-                          historyDifference === 0 ? 'text-emerald-600' : 'text-rose-600'
-                        }`}
-                      >
-                        {historyDifference > 0 ? '+' : ''}{formatWon(historyDifference)}
-                      </td>
-                      <td className="px-3 py-2.5 text-center">
-                        {isAdmin || closing.business_date === today ? (
-                          <Button
-                            size="sm"
-                            variant="gray"
-                            onClick={() => handleEditHistory(closing.business_date)}
-                          >
-                            수정
-                          </Button>
-                        ) : <span className="text-xs text-gray-400">수정 불가</span>}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <p className="py-8 text-center text-sm text-gray-500">저장된 시재가 없습니다.</p>
-        )}
-      </section>
+          {!isHistoryRangeValid && (
+            <p className="mb-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">
+              종료 날짜는 시작 날짜보다 빠를 수 없습니다.
+            </p>
+          )}
+          {historyQuery.isPending ? (
+            <Loading size="sm" text="이력을 불러오는 중..." />
+          ) : historyQuery.data?.length ? (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1160px] border-collapse text-sm [&_td]:border [&_td]:border-gray-200 [&_th]:border [&_th]:border-brand-200">
+                <thead className="bg-brand-50 text-left text-xs text-brand-700">
+                  <tr>
+                    <th className="px-3 py-2">날짜</th>
+                    <th className="px-3 py-2">근무자</th>
+                    <th className="px-3 py-2 text-right">오베이프 현금 매출</th>
+                    <th className="px-3 py-2 text-right">
+                      이구베이프 현금 매출
+                    </th>
+                    <th className="px-3 py-2 text-right">별도 입금</th>
+                    <th className="px-3 py-2 text-right">출금</th>
+                    <th className="px-3 py-2 text-right">예상</th>
+                    <th className="px-3 py-2 text-right">실제</th>
+                    <th className="px-3 py-2 text-right">차액</th>
+                    <th className="px-3 py-2 text-center">작업</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {historyQuery.data.map((closing) => {
+                    const historyDifference =
+                      closing.actual_cash - closing.expected_cash;
+                    return (
+                      <tr key={closing.id} className="hover:bg-gray-50">
+                        <td className="whitespace-nowrap px-3 py-2.5">
+                          {formatKoreanDate(closing.business_date)}
+                        </td>
+                        <td className="px-3 py-2.5">
+                          {closing.worker_name || "-"}
+                        </td>
+                        <td className="px-3 py-2.5 text-right">
+                          {formatWon(closing.ovape_cash_sales)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right">
+                          {formatWon(closing.egu_cash_sales)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right text-emerald-600">
+                          {closing.cash_in > 0 ? "+" : ""}
+                          {formatWon(closing.cash_in)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right text-rose-600">
+                          {closing.cash_out > 0 ? "-" : ""}
+                          {formatWon(closing.cash_out)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right">
+                          {formatWon(closing.expected_cash)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right">
+                          {formatWon(closing.actual_cash)}
+                        </td>
+                        <td
+                          className={`px-3 py-2.5 text-right font-medium ${
+                            historyDifference === 0
+                              ? "text-emerald-600"
+                              : "text-rose-600"
+                          }`}
+                        >
+                          {historyDifference > 0 ? "+" : ""}
+                          {formatWon(historyDifference)}
+                        </td>
+                        <td className="px-3 py-2.5 text-center">
+                          {isAdmin || closing.business_date === today ? (
+                            <Button
+                              size="sm"
+                              variant="gray"
+                              onClick={() =>
+                                handleEditHistory(closing.business_date)
+                              }
+                            >
+                              수정
+                            </Button>
+                          ) : (
+                            <span className="text-xs text-gray-400">
+                              수정 불가
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="py-8 text-center text-sm text-gray-500">
+              저장된 시재가 없습니다.
+            </p>
+          )}
+        </section>
       )}
 
-      {isReportsPage && activeTab === 'report' && (
+      {isReportsPage && activeTab === "report" && (
         <div>
           <DailyClosingReport
             businessDate={businessDate}
@@ -808,7 +913,7 @@ export default function CashManagementPage() {
         </div>
       )}
 
-      {isReportsPage && isAdmin && activeTab === 'reportLookup' && (
+      {isReportsPage && isAdmin && activeTab === "reportLookup" && (
         <div className="space-y-4">
           <section className="rounded-2xl border border-brand-100 bg-white p-4 shadow-sm">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch sm:gap-3">
@@ -818,33 +923,31 @@ export default function CashManagementPage() {
                 </p>
                 <Dropdown controlledValue={reportViewMode}>
                   <Dropdown.Trigger compact>
-                    {reportViewMode === 'month' ? '당월' : '날짜 선택'}
+                    {reportViewMode === "month" ? "당월" : "날짜 선택"}
                   </Dropdown.Trigger>
                   <Dropdown.Content compact>
                     {(
                       [
-                        { value: 'month', label: '당월' },
-                        { value: 'range', label: '날짜 선택' },
+                        { value: "month", label: "당월" },
+                        { value: "range", label: "날짜 선택" },
                       ] as const
                     ).map((option) => (
                       <Dropdown.Item
                         key={option.value}
                         option={option}
                         compact
-                        onSelect={(selected: DropdownOption) =>
-                          {
-                            setReportViewMode(
-                              selected.value as 'month' | 'range',
-                            );
-                            setSelectedReportId('');
-                          }
-                        }
+                        onSelect={(selected: DropdownOption) => {
+                          setReportViewMode(
+                            selected.value as "month" | "range",
+                          );
+                          setSelectedReportId("");
+                        }}
                       />
                     ))}
                   </Dropdown.Content>
                 </Dropdown>
               </div>
-              {reportViewMode === 'range' && (
+              {reportViewMode === "range" && (
                 <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
                   <p className="mb-1 text-xs font-semibold text-gray-600">
                     날짜 선택
@@ -856,7 +959,7 @@ export default function CashManagementPage() {
                     onApply={(start, end) => {
                       setReportStartDate(start);
                       setReportEndDate(end);
-                      setSelectedReportId('');
+                      setSelectedReportId("");
                     }}
                   />
                 </div>
@@ -898,11 +1001,11 @@ export default function CashManagementPage() {
                         key={report.id}
                         onClick={() =>
                           setSelectedReportId((current) =>
-                            current === report.id ? '' : report.id,
+                            current === report.id ? "" : report.id,
                           )
                         }
                         className={`cursor-pointer hover:bg-brand-50 ${
-                          selectedReportId === report.id ? 'bg-brand-50' : ''
+                          selectedReportId === report.id ? "bg-brand-50" : ""
                         }`}
                       >
                         <td className="whitespace-nowrap px-3 py-2.5">
@@ -918,24 +1021,24 @@ export default function CashManagementPage() {
                           <span
                             className={`rounded-full px-2.5 py-1 text-xs font-bold ${
                               report.cash_difference === 0
-                                ? 'bg-emerald-100 text-emerald-700'
-                                : 'bg-rose-100 text-rose-700'
+                                ? "bg-emerald-100 text-emerald-700"
+                                : "bg-rose-100 text-rose-700"
                             }`}
                           >
-                            {report.cash_difference === 0 ? '일치' : '불일치'}
+                            {report.cash_difference === 0 ? "일치" : "불일치"}
                           </span>
                         </td>
                         <td className="px-3 py-2.5 text-right">
                           {Number(report.input_work_hours).toLocaleString(
-                            'ko-KR',
+                            "ko-KR",
                           )}
                           시간
                         </td>
                         <td className="max-w-[240px] px-3 py-2.5 text-gray-600">
-                          {report.cleaning_note || '-'}
+                          {report.cleaning_note || "-"}
                         </td>
                         <td className="max-w-[240px] px-3 py-2.5 text-gray-600">
-                          {report.special_note || '-'}
+                          {report.special_note || "-"}
                         </td>
                         <td className="px-3 py-2.5 text-center">
                           <Button
@@ -966,18 +1069,16 @@ export default function CashManagementPage() {
               (report) => report.id === selectedReportId,
             ) && (
               <ReportSnapshotView
-                report={
-                  reportHistoryQuery.data.find(
-                    (report) => report.id === selectedReportId,
-                  )!
-                }
+                report={reportHistoryQuery.data.find(
+                  (report) => report.id === selectedReportId,
+                )!}
                 editRequestKey={reportEditRequestKey}
               />
             )}
         </div>
       )}
 
-      {isReportsPage && isAdmin && activeTab === 'checklist' && (
+      {isReportsPage && isAdmin && activeTab === "checklist" && (
         <ChecklistManagement />
       )}
     </main>
@@ -988,24 +1089,27 @@ const SummaryCard = ({
   label,
   value,
   tone,
-  prefix = '',
+  prefix = "",
 }: {
   label: string;
   value: number;
-  tone: 'gray' | 'brand' | 'amber' | 'green';
+  tone: "gray" | "brand" | "amber" | "green";
   prefix?: string;
 }) => {
   const toneClass = {
-    gray: 'border-gray-200 bg-gray-50 text-gray-800',
-    brand: 'border-brand-100 bg-brand-50 text-brand-700',
-    amber: 'border-amber-100 bg-amber-50 text-amber-700',
-    green: 'border-emerald-100 bg-emerald-50 text-emerald-700',
+    gray: "border-gray-200 bg-gray-50 text-gray-800",
+    brand: "border-brand-100 bg-brand-50 text-brand-700",
+    amber: "border-amber-100 bg-amber-50 text-amber-700",
+    green: "border-emerald-100 bg-emerald-50 text-emerald-700",
   }[tone];
 
   return (
     <div className={`rounded-xl border p-4 ${toneClass}`}>
       <p className="text-xs font-medium opacity-75">{label}</p>
-      <p className="mt-2 text-lg font-bold">{prefix}{formatWon(value)}</p>
+      <p className="mt-2 text-lg font-bold">
+        {prefix}
+        {formatWon(value)}
+      </p>
     </div>
   );
 };
@@ -1020,17 +1124,21 @@ const MoneyInput = ({
   onChange: (value: number) => void;
 }) => (
   <label className="block">
-    <span className="mb-1 block text-xs font-medium text-gray-600">{label}</span>
+    <span className="mb-1 block text-xs font-medium text-gray-600">
+      {label}
+    </span>
     <div className="relative">
       <input
         type="number"
         min="0"
-        value={value || ''}
+        value={value || ""}
         onChange={(event) => onChange(toNonNegativeNumber(event.target.value))}
         className="w-full rounded-lg border border-gray-200 px-3 py-2 pr-8 text-right text-sm outline-none focus:border-brand-400"
         placeholder="0"
       />
-      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400">원</span>
+      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400">
+        원
+      </span>
     </div>
   </label>
 );
@@ -1039,7 +1147,7 @@ const AmountRow = ({
   label,
   value,
   strong = false,
-  prefix = '',
+  prefix = "",
 }: {
   label: string;
   value: number;
@@ -1048,8 +1156,11 @@ const AmountRow = ({
 }) => (
   <div className="flex min-w-0 flex-col justify-center text-gray-600">
     <span className="text-xs font-semibold text-gray-500">{label}</span>
-    <span className={`mt-1 whitespace-nowrap text-right text-base tabular-nums ${strong ? 'font-bold text-gray-900' : ''}`}>
-      {prefix}{formatWon(value)}
+    <span
+      className={`mt-1 whitespace-nowrap text-right text-base tabular-nums ${strong ? "font-bold text-gray-900" : ""}`}
+    >
+      {prefix}
+      {formatWon(value)}
     </span>
   </div>
 );

--- a/src/app/(auth)/comparison/_components/DeviceComparison/ComparisonExpandView.tsx
+++ b/src/app/(auth)/comparison/_components/DeviceComparison/ComparisonExpandView.tsx
@@ -122,14 +122,16 @@ export default function ComparisonExpandView({
       <div className="relative z-10 w-full max-w-5xl mx-4 bg-white rounded-2xl shadow-2xl overflow-hidden flex flex-col max-h-[85vh]">
         {/* 워터마크 */}
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center z-20">
-          <Image
-            src="/logo.PNG"
-            alt=""
-            width={256}
-            height={256}
-            className="w-64 opacity-[0.06] select-none mix-blend-multiply"
-            draggable={false}
-          />
+          <div className="relative h-64 w-64">
+            <Image
+              src="/logo.PNG"
+              alt=""
+              fill
+              sizes="256px"
+              className="select-none object-contain opacity-[0.06] mix-blend-multiply"
+              draggable={false}
+            />
+          </div>
         </div>
         {/* 헤더 */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-brand-100 shrink-0">

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -17,8 +17,11 @@ import { getCustomerMode } from "@/app/_domains/_customer/_utils/specialCustomer
 const formatAmount = (value: number) => value.toLocaleString("ko-KR");
 
 const getShipmentTypeLabel = (item: NonNullable<StampLogMeta["items"]>[number]) => {
+  if (item.inventoryAction === "adjustment_in") return "재고조정-입고";
+  if (item.inventoryAction === "adjustment_out") return "재고조정-출고";
   if (item.inventoryAction === "exchange_in") return "교환입고";
   if (item.inventoryAction === "exchange_out") return "교환출고";
+  if (item.remark?.startsWith("시연용")) return "시연용";
   if (typeof item.adjustedUnitPrice === "number") return "가격조정";
   if (item.remark?.startsWith("서비스")) return "서비스";
   return "일반판매";
@@ -145,7 +148,7 @@ export default function StampConfirmModal({
   const title =
     mode === "add"
       ? customerMode === "adjustment"
-        ? "재고조정 (입고 또는 출고처리)"
+        ? "재고조정 (입고 또는 출고)"
         : isReservation
           ? "출고 예약 추가"
           : "출고 이력 추가"

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -243,8 +243,8 @@ export default function StampLogForm({
   const visibleRemarkOptions =
     customerMode === "adjustment"
       ? ([
-          { value: "adjustment_in", name: "입고처리" },
-          { value: "adjustment_out", name: "출고처리" },
+          { value: "adjustment_in", name: "재고조정-입고" },
+          { value: "adjustment_out", name: "재고조정-출고" },
         ] as const)
       : customerMode === "demo"
         ? ([{ value: "demo", name: "시연용" }] as const)
@@ -519,7 +519,7 @@ export default function StampLogForm({
       remarkType !== "adjustment_in" &&
       remarkType !== "adjustment_out"
     ) {
-      toast.error("입고처리 또는 출고처리를 선택해 주세요.");
+      toast.error("재고조정-입고 또는 재고조정-출고를 선택해 주세요.");
       return;
     }
 
@@ -536,9 +536,9 @@ export default function StampLogForm({
         ? `시연용${optionalOperationMemo ? `,${optionalOperationMemo}` : ""}`
         : customerMode === "adjustment"
           ? remarkType === "adjustment_in"
-            ? `입고처리${optionalOperationMemo ? `,${optionalOperationMemo}` : ""}`
+            ? `재고조정-입고${optionalOperationMemo ? `,${optionalOperationMemo}` : ""}`
             : remarkType === "adjustment_out"
-              ? `출고처리${optionalOperationMemo ? `,${optionalOperationMemo}` : ""}`
+              ? `재고조정-출고${optionalOperationMemo ? `,${optionalOperationMemo}` : ""}`
               : ""
           : isExchange
             ? `${exchangeLabel}${exchangeMemo.trim() ? `(${exchangeMemo.trim()})` : ""}`
@@ -658,8 +658,11 @@ export default function StampLogForm({
   };
 
   const getShipmentTypeLabel = (line: DraftStampLogLine) => {
+    if (line.inventoryAction === "adjustment_in") return "재고조정-입고";
+    if (line.inventoryAction === "adjustment_out") return "재고조정-출고";
     if (line.inventoryAction === "exchange_in") return "교환입고";
     if (line.inventoryAction === "exchange_out") return "교환출고";
+    if (line.remark?.startsWith("시연용")) return "시연용";
     if (typeof line.adjustedUnitPrice === "number") return "가격조정";
     if (line.remark?.startsWith("서비스")) return "서비스";
     return "일반판매";
@@ -1357,9 +1360,6 @@ export default function StampLogForm({
 
         {(customerMode === "demo" || customerMode === "adjustment") && (
           <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">
-              처리 메모
-            </label>
             <input
               type="text"
               value={operationMemo}
@@ -1368,7 +1368,11 @@ export default function StampLogForm({
               placeholder={
                 customerMode === "demo"
                   ? "시연용 처리 메모 (선택)"
-                  : "입고·출고 처리 메모 (선택)"
+                  : remarkType === "adjustment_in"
+                    ? "재고조정-입고 메모 (선택)"
+                    : remarkType === "adjustment_out"
+                      ? "재고조정-출고 메모 (선택)"
+                      : "처리 메모 (선택)"
               }
             />
           </div>

--- a/src/app/(auth)/inventory/InventoryPageContent.tsx
+++ b/src/app/(auth)/inventory/InventoryPageContent.tsx
@@ -12,7 +12,6 @@ import KoreanDatePicker, {
 } from "@/app/_components/KoreanDatePicker";
 import { useUser } from "@/app/_contexts/UserContext";
 import {
-  adjustInventory,
   getInventoryMovements,
   getInventoryOverview,
   initializeInventory,
@@ -74,11 +73,11 @@ const movementLabels: Record<string, string> = {
   initial: "기초재고",
   purchase_in: "입고",
   adjustment: "재고 조정",
-  reversal: "입고 취소",
+  reversal: "입고/취소",
   sale_out: "출고",
-  exchange_in: "교환/입고",
-  outbound_edit: "출고 수정",
-  outbound_cancel: "출고 취소",
+  exchange_in: "입고/교환",
+  outbound_edit: "출고/수정",
+  outbound_cancel: "출고/취소",
 };
 
 export function InventoryPageContent({
@@ -213,84 +212,92 @@ export function InventoryPageContent({
   return (
     <main className="mx-auto max-w-7xl space-y-4 px-4 py-6 sm:px-6 lg:px-8">
       {inventorySection === "stock" && (
-      <div className="flex items-end justify-between border-b border-gray-200">
-        <div className="flex min-w-0 overflow-x-auto" role="tablist" aria-label="재고 관리 메뉴">
-          {tabOrder.map((item, index) =>
-            item === "receive" || (item === "initial" && !isAdmin) ? null : (
-              <div key={item} className="flex shrink-0 items-center">
-                {editingTabOrder && (
+        <div className="flex items-end justify-between border-b border-gray-200">
+          <div
+            className="flex min-w-0 overflow-x-auto"
+            role="tablist"
+            aria-label="재고 관리 메뉴"
+          >
+            {tabOrder.map((item, index) =>
+              item === "receive" || (item === "initial" && !isAdmin) ? null : (
+                <div key={item} className="flex shrink-0 items-center">
+                  {editingTabOrder && (
+                    <button
+                      type="button"
+                      onClick={() => moveTab(index, -1)}
+                      disabled={index === 0}
+                      className="h-7 w-6 text-xs text-gray-400 hover:text-brand-600 disabled:opacity-20"
+                      aria-label={`${tabLabels[item]} 왼쪽으로 이동`}
+                    >
+                      ‹
+                    </button>
+                  )}
                   <button
                     type="button"
-                    onClick={() => moveTab(index, -1)}
-                    disabled={index === 0}
-                    className="h-7 w-6 text-xs text-gray-400 hover:text-brand-600 disabled:opacity-20"
-                    aria-label={`${tabLabels[item]} 왼쪽으로 이동`}
+                    role="tab"
+                    aria-selected={tab === item}
+                    onClick={() => setTab(item)}
+                    className={`border-b-2 px-4 py-3 text-sm font-semibold transition-colors ${
+                      tab === item
+                        ? "border-brand-500 text-brand-700"
+                        : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
+                    }`}
                   >
-                    ‹
+                    {tabLabels[item]}
                   </button>
-                )}
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={tab === item}
-                  onClick={() => setTab(item)}
-                  className={`border-b-2 px-4 py-3 text-sm font-semibold transition-colors ${
-                    tab === item
-                      ? "border-brand-500 text-brand-700"
-                      : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
-                  }`}
-                >
-                  {tabLabels[item]}
-                </button>
-                {editingTabOrder && (
-                  <button
-                    type="button"
-                    onClick={() => moveTab(index, 1)}
-                    disabled={index === tabOrder.length - 1}
-                    className="h-7 w-6 text-xs text-gray-400 hover:text-brand-600 disabled:opacity-20"
-                    aria-label={`${tabLabels[item]} 오른쪽으로 이동`}
-                  >
-                    ›
-                  </button>
-                )}
-              </div>
-            ),
+                  {editingTabOrder && (
+                    <button
+                      type="button"
+                      onClick={() => moveTab(index, 1)}
+                      disabled={index === tabOrder.length - 1}
+                      className="h-7 w-6 text-xs text-gray-400 hover:text-brand-600 disabled:opacity-20"
+                      aria-label={`${tabLabels[item]} 오른쪽으로 이동`}
+                    >
+                      ›
+                    </button>
+                  )}
+                </div>
+              ),
+            )}
+          </div>
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={() => setEditingTabOrder((current) => !current)}
+              className={`mb-2 ml-3 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-white transition ${
+                editingTabOrder
+                  ? "border-brand-300 text-brand-700 shadow-sm"
+                  : "border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700"
+              }`}
+              aria-label={
+                editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"
+              }
+              title={editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"}
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.8}
+                  d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z"
+                />
+              </svg>
+            </button>
           )}
         </div>
-        {isAdmin && <button
-          type="button"
-          onClick={() => setEditingTabOrder((current) => !current)}
-          className={`mb-2 ml-3 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-white transition ${
-            editingTabOrder
-              ? "border-brand-300 text-brand-700 shadow-sm"
-              : "border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700"
-          }`}
-          aria-label={
-            editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"
-          }
-          title={editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"}
-        >
-          <svg
-            className="h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.8}
-              d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z"
-            />
-          </svg>
-        </button>}
-      </div>
       )}
       {inventorySection === "receive" && (
         <div className="flex items-end justify-between border-b border-gray-200">
           <div className="flex" role="tablist" aria-label="입고 관리 메뉴">
-            {receiveTabOrder.map((item, index) => (
+            {receiveTabOrder
+              .filter((item) => isAdmin || item === "receive")
+              .map((item, index) => (
               <div key={item} className="flex items-center">
                 {editingReceiveTabOrder && (
                   <button
@@ -328,33 +335,44 @@ export function InventoryPageContent({
                   </button>
                 )}
               </div>
-            ))}
+              ))}
           </div>
-          {isAdmin && <button
-            type="button"
-            onClick={() =>
-              setEditingReceiveTabOrder((current) => !current)
-            }
-            className={`mb-2 ml-3 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-white transition ${
-              editingReceiveTabOrder
-                ? "border-brand-300 text-brand-700 shadow-sm"
-                : "border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700"
-            }`}
-            aria-label={
-              editingReceiveTabOrder
-                ? "입고 탭 순서 변경 완료"
-                : "입고 탭 순서 변경"
-            }
-            title={
-              editingReceiveTabOrder
-                ? "입고 탭 순서 변경 완료"
-                : "입고 탭 순서 변경"
-            }
-          >
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z" />
-            </svg>
-          </button>}
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={() => setEditingReceiveTabOrder((current) => !current)}
+              className={`mb-2 ml-3 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-white transition ${
+                editingReceiveTabOrder
+                  ? "border-brand-300 text-brand-700 shadow-sm"
+                  : "border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700"
+              }`}
+              aria-label={
+                editingReceiveTabOrder
+                  ? "입고 탭 순서 변경 완료"
+                  : "입고 탭 순서 변경"
+              }
+              title={
+                editingReceiveTabOrder
+                  ? "입고 탭 순서 변경 완료"
+                  : "입고 탭 순서 변경"
+              }
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.8}
+                  d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z"
+                />
+              </svg>
+            </button>
+          )}
         </div>
       )}
 
@@ -379,18 +397,14 @@ export function InventoryPageContent({
           onSaved={refresh}
         />
       ) : tab === "stock" ? (
-        <StockOverview
-          items={items.filter((item) => item.is_tracked)}
-          isAdmin={isAdmin}
-          onSaved={refresh}
-        />
+        <StockOverview items={items.filter((item) => item.is_tracked)} />
       ) : tab === "untracked" ? (
         <UntrackedOverview
           items={items.filter((item) => !item.is_tracked && item.is_use)}
           isAdmin={isAdmin}
           onSettings={() => setSettingsOpen(true)}
         />
-      ) : tab === "receive" && receiveView === "suppliers" ? (
+      ) : tab === "receive" && receiveView === "suppliers" && isAdmin ? (
         <SupplierManagementTab isAdmin={isAdmin} />
       ) : tab === "receive" ? (
         <ReceiptManager
@@ -811,15 +825,7 @@ function InitialStockSetup({
   );
 }
 
-function StockOverview({
-  items,
-  isAdmin,
-  onSaved,
-}: {
-  items: InventoryItem[];
-  isAdmin: boolean;
-  onSaved: () => Promise<void>;
-}) {
+function StockOverview({ items }: { items: InventoryItem[] }) {
   const [nameSearch, setNameSearch] = useState("");
   const [codeSearch, setCodeSearch] = useState("");
   const [categorySearch, setCategorySearch] = useState("");
@@ -827,18 +833,12 @@ function StockOverview({
     "all",
   );
   const [usage, setUsage] = useState<"all" | "active" | "inactive">("active");
-  const [adjusting, setAdjusting] = useState<InventoryItem | null>(null);
   const [dateMode, setDateMode] = useState<"today" | "custom">("today");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [visibleCount, setVisibleCount] = useState(10);
   type SortKey =
-    | "category"
-    | "code"
-    | "name"
-    | "usage"
-    | "quantity"
-    | "updated";
+    "category" | "code" | "name" | "usage" | "quantity" | "updated";
   const [sort, setSort] = useState<{
     key: SortKey;
     direction: "asc" | "desc";
@@ -849,52 +849,49 @@ function StockOverview({
     return new Date(date.getTime() - offset).toISOString().slice(0, 10);
   };
   const filtered = items.filter((item) => {
-      const matchesName = item.item_name
-        .toLocaleLowerCase("ko-KR")
-        .includes(nameSearch.trim().toLocaleLowerCase("ko-KR"));
-      const matchesCode = (item.item_code ?? "")
-        .toLocaleLowerCase("ko-KR")
-        .includes(codeSearch.trim().toLocaleLowerCase("ko-KR"));
-      const matchesCategory = (item.category_name ?? "")
-        .toLocaleLowerCase("ko-KR")
-        .includes(categorySearch.trim().toLocaleLowerCase("ko-KR"));
-      const itemStatus =
-        item.quantity < 0 ? "negative" : item.quantity === 0 ? "out" : "normal";
-      const date = item.updated_at ? localDate(item.updated_at) : "";
-      const matchesDate =
-        dateMode === "today" ||
-        (Boolean(date) &&
-          Boolean(startDate) &&
-          (endDate
-            ? date >= startDate && date <= endDate
-            : date === startDate));
-      return (
-        matchesName &&
-        matchesCode &&
-        matchesCategory &&
-        matchesDate &&
-        (usage === "all" ||
-          (usage === "active" ? item.is_use : !item.is_use)) &&
-        (status === "all" || status === itemStatus)
-      );
-    });
+    const matchesName = item.item_name
+      .toLocaleLowerCase("ko-KR")
+      .includes(nameSearch.trim().toLocaleLowerCase("ko-KR"));
+    const matchesCode = (item.item_code ?? "")
+      .toLocaleLowerCase("ko-KR")
+      .includes(codeSearch.trim().toLocaleLowerCase("ko-KR"));
+    const matchesCategory = (item.category_name ?? "")
+      .toLocaleLowerCase("ko-KR")
+      .includes(categorySearch.trim().toLocaleLowerCase("ko-KR"));
+    const itemStatus =
+      item.quantity < 0 ? "negative" : item.quantity === 0 ? "out" : "normal";
+    const date = item.updated_at ? localDate(item.updated_at) : "";
+    const matchesDate =
+      dateMode === "today" ||
+      (Boolean(date) &&
+        Boolean(startDate) &&
+        (endDate ? date >= startDate && date <= endDate : date === startDate));
+    return (
+      matchesName &&
+      matchesCode &&
+      matchesCategory &&
+      matchesDate &&
+      (usage === "all" || (usage === "active" ? item.is_use : !item.is_use)) &&
+      (status === "all" || status === itemStatus)
+    );
+  });
   const sortedItems = sort
     ? [...filtered].sort((a, b) => {
-      const values = {
-        category: [a.category_name ?? "", b.category_name ?? ""],
-        code: [a.item_code, b.item_code],
-        name: [a.item_name, b.item_name],
-        usage: [a.is_use ? 1 : 0, b.is_use ? 1 : 0],
-        quantity: [a.quantity, b.quantity],
-        updated: [a.updated_at ?? "", b.updated_at ?? ""],
+        const values = {
+          category: [a.category_name ?? "", b.category_name ?? ""],
+          code: [a.item_code, b.item_code],
+          name: [a.item_name, b.item_name],
+          usage: [a.is_use ? 1 : 0, b.is_use ? 1 : 0],
+          quantity: [a.quantity, b.quantity],
+          updated: [a.updated_at ?? "", b.updated_at ?? ""],
         }[sort.key];
-      const result =
-        typeof values[0] === "number"
-          ? (values[0] as number) - (values[1] as number)
-          : String(values[0]).localeCompare(String(values[1]), "ko-KR", {
-              numeric: true,
-              sensitivity: "base",
-            });
+        const result =
+          typeof values[0] === "number"
+            ? (values[0] as number) - (values[1] as number)
+            : String(values[0]).localeCompare(String(values[1]), "ko-KR", {
+                numeric: true,
+                sensitivity: "base",
+              });
         return sort.direction === "asc" ? result : -result;
       })
     : filtered;
@@ -920,13 +917,12 @@ function StockOverview({
   const copyForKakao = async () => {
     const text = [
       "품목 코드\t품목명\t현재 재고",
-      ...sortedItems.map(
-        (item) =>
-          [
-            item.item_code || "-",
-            item.item_name,
-            item.quantity === 0 ? "품절" : `${item.quantity}개`,
-          ].join("\t"),
+      ...sortedItems.map((item) =>
+        [
+          item.item_code || "-",
+          item.item_name,
+          item.quantity === 0 ? "품절" : `${item.quantity}개`,
+        ].join("\t"),
       ),
     ].join("\n");
     await navigator.clipboard.writeText(text);
@@ -944,263 +940,262 @@ function StockOverview({
     <div className="space-y-4">
       <section className="rounded-2xl border border-gray-200 bg-white p-3 shadow-sm">
         <div className="space-y-3">
-        <div className="flex flex-col gap-2 lg:flex-row lg:items-stretch lg:gap-3">
-          <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
-            <p className="mb-1 text-xs font-semibold text-gray-600">
-              재고 상태
-            </p>
-            <Dropdown controlledValue={status}>
-              <Dropdown.Trigger compact>
-                {
-                  [
-                    { value: "all", label: "전체" },
-                    { value: "normal", label: "정상" },
-                    { value: "out", label: "품절" },
-                    { value: "negative", label: "마이너스" },
-                  ].find((option) => option.value === status)?.label
-                }
-              </Dropdown.Trigger>
-              <Dropdown.Content compact>
-                {(
-                  [
-                    { value: "all", label: "전체" },
-                    { value: "normal", label: "정상" },
-                    { value: "out", label: "품절" },
-                    { value: "negative", label: "마이너스" },
-                  ] as const
-                ).map((option) => (
-                  <Dropdown.Item
-                    key={option.value}
-                    option={option}
-                    compact
-                    onSelect={(selected: DropdownOption) =>
-                      setStatus(
-                        selected.value as
-                          | "all"
-                          | "normal"
-                          | "out"
-                          | "negative",
-                      )
-                    }
-                  />
-                ))}
-              </Dropdown.Content>
-            </Dropdown>
-          </div>
-
-          <div className="h-px w-full bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
-
-          <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
-            <p className="mb-1 text-xs font-semibold text-gray-600">
-              사용 구분
-            </p>
-            <Dropdown controlledValue={usage}>
-              <Dropdown.Trigger compact>
-                {
-                  [
-                    { value: "all", label: "전체" },
-                    { value: "active", label: "사용" },
-                    { value: "inactive", label: "미사용" },
-                  ].find((option) => option.value === usage)?.label
-                }
-              </Dropdown.Trigger>
-              <Dropdown.Content compact>
-              {(
-                [
-                  { value: "all", label: "전체" },
-                  { value: "active", label: "사용" },
-                  { value: "inactive", label: "미사용" },
-                ] as const
-              ).map((option) => (
-                <Dropdown.Item
-                  key={option.value}
-                  option={option}
-                  compact
-                  onSelect={(selected: DropdownOption) =>
-                    setUsage(
-                      selected.value as "all" | "active" | "inactive",
-                    )
-                  }
-                />
-              ))}
-              </Dropdown.Content>
-            </Dropdown>
-          </div>
-
-          <div className="h-px w-full bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
-
-          <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
-            <p className="mb-1 text-xs font-semibold text-gray-600">
-              조회 기간
-            </p>
-            <Dropdown controlledValue={dateMode}>
-              <Dropdown.Trigger compact>
-                {
-                  [
-                    { value: "today", label: "당일" },
-                    { value: "custom", label: "날짜 선택" },
-                  ].find((option) => option.value === dateMode)?.label
-                }
-              </Dropdown.Trigger>
-              <Dropdown.Content compact>
-                {(
-                  [
-                    { value: "today", label: "당일" },
-                    { value: "custom", label: "날짜 선택" },
-                  ] as const
-                ).map((option) => (
-                  <Dropdown.Item
-                    key={option.value}
-                    option={option}
-                    compact
-                    onSelect={(selected: DropdownOption) => {
-                      const nextMode = selected.value as "today" | "custom";
-                      if (nextMode === "today") {
-                        setStartDate("");
-                        setEndDate("");
-                      }
-                      setDateMode(nextMode);
-                    }}
-                  />
-                ))}
-              </Dropdown.Content>
-            </Dropdown>
-          </div>
-          {dateMode === "custom" && (
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-stretch lg:gap-3">
             <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
               <p className="mb-1 text-xs font-semibold text-gray-600">
-                날짜 선택
+                재고 상태
               </p>
-              <KoreanDateRangePicker
-                startDate={startDate}
-                endDate={endDate}
-                iconOnly
-                onApply={(start, end) => {
-                  setStartDate(start);
-                  setEndDate(end);
-                }}
-              />
+              <Dropdown controlledValue={status}>
+                <Dropdown.Trigger compact>
+                  {
+                    [
+                      { value: "all", label: "전체" },
+                      { value: "normal", label: "정상" },
+                      { value: "out", label: "품절" },
+                      { value: "negative", label: "마이너스" },
+                    ].find((option) => option.value === status)?.label
+                  }
+                </Dropdown.Trigger>
+                <Dropdown.Content compact>
+                  {(
+                    [
+                      { value: "all", label: "전체" },
+                      { value: "normal", label: "정상" },
+                      { value: "out", label: "품절" },
+                      { value: "negative", label: "마이너스" },
+                    ] as const
+                  ).map((option) => (
+                    <Dropdown.Item
+                      key={option.value}
+                      option={option}
+                      compact
+                      onSelect={(selected: DropdownOption) =>
+                        setStatus(
+                          selected.value as
+                            "all" | "normal" | "out" | "negative",
+                        )
+                      }
+                    />
+                  ))}
+                </Dropdown.Content>
+              </Dropdown>
             </div>
-          )}
 
-          <div className="h-px w-full bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
+            <div className="h-px w-full bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
 
-          <div className="w-full rounded-xl border border-gray-200 bg-gray-50/70 p-3 lg:flex-1">
-            <div className="grid gap-3 sm:grid-cols-3">
-              <label className="block w-full">
-                <span className="mb-2 block text-xs font-semibold text-gray-500">
-                  품목명
-                </span>
-                <span className="relative block">
-                  <svg
-                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+            <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
+              <p className="mb-1 text-xs font-semibold text-gray-600">
+                사용 구분
+              </p>
+              <Dropdown controlledValue={usage}>
+                <Dropdown.Trigger compact>
+                  {
+                    [
+                      { value: "all", label: "전체" },
+                      { value: "active", label: "사용" },
+                      { value: "inactive", label: "미사용" },
+                    ].find((option) => option.value === usage)?.label
+                  }
+                </Dropdown.Trigger>
+                <Dropdown.Content compact>
+                  {(
+                    [
+                      { value: "all", label: "전체" },
+                      { value: "active", label: "사용" },
+                      { value: "inactive", label: "미사용" },
+                    ] as const
+                  ).map((option) => (
+                    <Dropdown.Item
+                      key={option.value}
+                      option={option}
+                      compact
+                      onSelect={(selected: DropdownOption) =>
+                        setUsage(
+                          selected.value as "all" | "active" | "inactive",
+                        )
+                      }
                     />
-                  </svg>
-                  <input
-                    value={nameSearch}
-                    onChange={(event) => setNameSearch(event.target.value)}
-                    placeholder="품목명 입력"
-                    className="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-10 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
-                  />
-                  {nameSearch && (
-                    <button
-                      type="button"
-                      onClick={() => setNameSearch("")}
-                      aria-label="품목명 검색어 지우기"
-                      className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-gray-100 text-base font-medium text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 active:bg-gray-300"
-                    >
-                      ×
-                    </button>
-                  )}
-                </span>
-              </label>
-              <label className="block w-full sm:border-l sm:border-gray-200 sm:pl-3">
-                <span className="mb-2 block text-xs font-semibold text-gray-500">
-                  품목 코드
-                </span>
-                <span className="relative block">
-                  <svg
-                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                  ))}
+                </Dropdown.Content>
+              </Dropdown>
+            </div>
+
+            <div className="h-px w-full bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
+
+            <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
+              <p className="mb-1 text-xs font-semibold text-gray-600">
+                조회 기간
+              </p>
+              <Dropdown controlledValue={dateMode}>
+                <Dropdown.Trigger compact>
+                  {
+                    [
+                      { value: "today", label: "당일" },
+                      { value: "custom", label: "날짜 선택" },
+                    ].find((option) => option.value === dateMode)?.label
+                  }
+                </Dropdown.Trigger>
+                <Dropdown.Content compact>
+                  {(
+                    [
+                      { value: "today", label: "당일" },
+                      { value: "custom", label: "날짜 선택" },
+                    ] as const
+                  ).map((option) => (
+                    <Dropdown.Item
+                      key={option.value}
+                      option={option}
+                      compact
+                      onSelect={(selected: DropdownOption) => {
+                        const nextMode = selected.value as "today" | "custom";
+                        if (nextMode === "today") {
+                          setStartDate("");
+                          setEndDate("");
+                        }
+                        setDateMode(nextMode);
+                      }}
                     />
-                  </svg>
-                  <input
-                    value={codeSearch}
-                    onChange={(event) => setCodeSearch(event.target.value)}
-                    placeholder="품목 코드 입력"
-                    className="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-10 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
-                  />
-                  {codeSearch && (
-                    <button
-                      type="button"
-                      onClick={() => setCodeSearch("")}
-                      aria-label="품목 코드 검색어 지우기"
-                      className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-gray-100 text-base font-medium text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 active:bg-gray-300"
+                  ))}
+                </Dropdown.Content>
+              </Dropdown>
+            </div>
+            {dateMode === "custom" && (
+              <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
+                <p className="mb-1 text-xs font-semibold text-gray-600">
+                  날짜 선택
+                </p>
+                <KoreanDateRangePicker
+                  startDate={startDate}
+                  endDate={endDate}
+                  iconOnly
+                  onApply={(start, end) => {
+                    setStartDate(start);
+                    setEndDate(end);
+                  }}
+                />
+              </div>
+            )}
+
+            <div className="h-px w-full bg-gray-200 lg:h-auto lg:w-px lg:self-stretch" />
+
+            <div className="w-full rounded-xl border border-gray-200 bg-gray-50/70 p-3 lg:flex-1">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <label className="block w-full">
+                  <span className="mb-2 block text-xs font-semibold text-gray-500">
+                    품목명
+                  </span>
+                  <span className="relative block">
+                    <svg
+                      className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
                     >
-                      ×
-                    </button>
-                  )}
-                </span>
-              </label>
-              <label className="block w-full sm:border-l sm:border-gray-200 sm:pl-3">
-                <span className="mb-2 block text-xs font-semibold text-gray-500">
-                  품목 종류
-                </span>
-                <span className="relative block">
-                  <svg
-                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                      />
+                    </svg>
+                    <input
+                      value={nameSearch}
+                      onChange={(event) => setNameSearch(event.target.value)}
+                      placeholder="품목명 입력"
+                      className="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-10 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
                     />
-                  </svg>
-                  <input
-                    value={categorySearch}
-                    onChange={(event) => setCategorySearch(event.target.value)}
-                    placeholder="품목 종류 입력"
-                    className="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-10 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
-                  />
-                  {categorySearch && (
-                    <button
-                      type="button"
-                      onClick={() => setCategorySearch("")}
-                      aria-label="품목 종류 검색어 지우기"
-                      className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-gray-100 text-base font-medium text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 active:bg-gray-300"
+                    {nameSearch && (
+                      <button
+                        type="button"
+                        onClick={() => setNameSearch("")}
+                        aria-label="품목명 검색어 지우기"
+                        className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-gray-100 text-base font-medium text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 active:bg-gray-300"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </span>
+                </label>
+                <label className="block w-full sm:border-l sm:border-gray-200 sm:pl-3">
+                  <span className="mb-2 block text-xs font-semibold text-gray-500">
+                    품목 코드
+                  </span>
+                  <span className="relative block">
+                    <svg
+                      className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
                     >
-                      ×
-                    </button>
-                  )}
-                </span>
-              </label>
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                      />
+                    </svg>
+                    <input
+                      value={codeSearch}
+                      onChange={(event) => setCodeSearch(event.target.value)}
+                      placeholder="품목 코드 입력"
+                      className="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-10 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                    />
+                    {codeSearch && (
+                      <button
+                        type="button"
+                        onClick={() => setCodeSearch("")}
+                        aria-label="품목 코드 검색어 지우기"
+                        className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-gray-100 text-base font-medium text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 active:bg-gray-300"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </span>
+                </label>
+                <label className="block w-full sm:border-l sm:border-gray-200 sm:pl-3">
+                  <span className="mb-2 block text-xs font-semibold text-gray-500">
+                    품목 종류
+                  </span>
+                  <span className="relative block">
+                    <svg
+                      className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                      />
+                    </svg>
+                    <input
+                      value={categorySearch}
+                      onChange={(event) =>
+                        setCategorySearch(event.target.value)
+                      }
+                      placeholder="품목 종류 입력"
+                      className="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-10 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                    />
+                    {categorySearch && (
+                      <button
+                        type="button"
+                        onClick={() => setCategorySearch("")}
+                        aria-label="품목 종류 검색어 지우기"
+                        className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-gray-100 text-base font-medium text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 active:bg-gray-300"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
-        </div>
         </div>
       </section>
 
@@ -1228,88 +1223,74 @@ function StockOverview({
       <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
         <div className="overflow-auto rounded-xl border border-gray-200">
           <table className="w-full min-w-[850px] border-collapse text-sm">
-          <thead className="bg-brand-50 text-brand-700">
-            <tr>
-              {headings.map((heading) => (
-                <th
-                  key={heading.key}
-                  className="border border-brand-200 p-0 text-left"
-                >
-                  <button
-                    onClick={() => changeSort(heading.key)}
-                    className="flex min-h-12 w-full items-center justify-between gap-2 px-4 py-3 font-semibold"
+            <thead className="bg-brand-50 text-brand-700">
+              <tr>
+                {headings.map((heading) => (
+                  <th
+                    key={heading.key}
+                    className="border border-brand-200 p-0 text-left"
                   >
-                    <span>{heading.label}</span>
-                    <span
-                      className={
-                        sort?.key === heading.key
-                          ? "text-brand-700"
-                          : "text-gray-300"
-                      }
+                    <button
+                      onClick={() => changeSort(heading.key)}
+                      className="flex min-h-12 w-full items-center justify-between gap-2 px-4 py-3 font-semibold"
                     >
-                      {sort?.key === heading.key
-                        ? sort.direction === "asc"
-                          ? "▲"
-                          : "▼"
-                        : "↕"}
-                    </span>
-                  </button>
-                </th>
-              ))}
-              <th className="border border-brand-200 px-4 py-3 text-left">
-                관리
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {visibleItems.map((item) => {
-              const negative = item.quantity < 0;
-              const out = item.quantity === 0;
-              return (
-                <tr key={item.item_name} className="hover:bg-brand-50/30">
-                  <td className="border border-gray-200 px-4 py-3">
-                    <span
-                      className={`rounded-full px-2.5 py-1 text-xs font-semibold ${item.is_use ? "bg-emerald-100 text-emerald-700" : "bg-gray-100 text-gray-500"}`}
-                    >
-                      {item.is_use ? "사용" : "미사용"}
-                    </span>
-                  </td>
-                  <td className="border border-gray-200 px-4 py-3">
-                    {item.category_name ?? (
-                      <span className="text-amber-600">품목 정보 없음</span>
-                    )}
-                  </td>
-                  <td className="border border-gray-200 px-4 py-3 font-mono text-gray-500">
-                    {item.item_code || "-"}
-                  </td>
-                  <td className="border border-gray-200 px-4 py-3 font-semibold">
-                    {item.item_name}
-                  </td>
-                  <td
-                    className={`border border-gray-200 px-4 py-3 text-right text-lg font-bold ${negative ? "text-rose-600" : out ? "text-gray-400" : "text-gray-900"}`}
-                  >
-                    {out ? "품절" : `${item.quantity.toLocaleString()}개`}
-                  </td>
-                  <td className="border border-gray-200 px-4 py-3 text-gray-500">
-                    {item.updated_at
-                      ? new Date(item.updated_at).toLocaleString("ko-KR")
-                      : "-"}
-                  </td>
-                  <td className="border border-gray-200 px-4 py-3">
-                    {isAdmin && (
-                      <Button
-                        size="xs"
-                        variant="gray"
-                        onClick={() => setAdjusting(item)}
+                      <span>{heading.label}</span>
+                      <span
+                        className={
+                          sort?.key === heading.key
+                            ? "text-brand-700"
+                            : "text-gray-300"
+                        }
                       >
-                        조정
-                      </Button>
-                    )}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
+                        {sort?.key === heading.key
+                          ? sort.direction === "asc"
+                            ? "▲"
+                            : "▼"
+                          : "↕"}
+                      </span>
+                    </button>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {visibleItems.map((item) => {
+                const negative = item.quantity < 0;
+                const out = item.quantity === 0;
+                return (
+                  <tr key={item.item_name} className="hover:bg-brand-50/30">
+                    <td className="border border-gray-200 px-4 py-3">
+                      <span
+                        className={`rounded-full px-2.5 py-1 text-xs font-semibold ${item.is_use ? "bg-emerald-100 text-emerald-700" : "bg-gray-100 text-gray-500"}`}
+                      >
+                        {item.is_use ? "사용" : "미사용"}
+                      </span>
+                    </td>
+                    <td className="border border-gray-200 px-4 py-3">
+                      {item.category_name ?? (
+                        <span className="text-amber-600">품목 정보 없음</span>
+                      )}
+                    </td>
+                    <td className="border border-gray-200 px-4 py-3 font-mono text-gray-500">
+                      {item.item_code || "-"}
+                    </td>
+                    <td className="border border-gray-200 px-4 py-3 font-semibold">
+                      {item.item_name}
+                    </td>
+                    <td
+                      className={`border border-gray-200 px-4 py-3 text-right text-lg font-bold ${negative ? "text-rose-600" : out ? "text-gray-400" : "text-gray-900"}`}
+                    >
+                      {out ? "품절" : `${item.quantity.toLocaleString()}개`}
+                    </td>
+                    <td className="border border-gray-200 px-4 py-3 text-gray-500">
+                      {item.updated_at
+                        ? new Date(item.updated_at).toLocaleString("ko-KR")
+                        : "-"}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
           </table>
         </div>
         {visibleCount < filtered.length && (
@@ -1324,16 +1305,6 @@ function StockOverview({
           </div>
         )}
       </section>
-      {adjusting && (
-        <AdjustmentOverlay
-          item={adjusting}
-          onClose={() => setAdjusting(null)}
-          onSaved={async () => {
-            setAdjusting(null);
-            await onSaved();
-          }}
-        />
-      )}
     </div>
   );
 }
@@ -1446,50 +1417,48 @@ function UntrackedOverview({
         )}
       </div>
       <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
-      <div className="overflow-auto rounded-xl border border-gray-200">
-        <table className="w-full min-w-[620px] border-collapse text-sm">
-          <thead className="bg-gray-50 text-gray-600">
-            <tr>
-                {["품목 종류", "품목 코드", "품목명"].map(
-                (label) => (
+        <div className="overflow-auto rounded-xl border border-gray-200">
+          <table className="w-full min-w-[620px] border-collapse text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                {["품목 종류", "품목 코드", "품목명"].map((label) => (
                   <th
                     key={label}
                     className="border border-gray-200 px-4 py-3 text-left"
                   >
                     {label}
                   </th>
-                ),
-              )}
-            </tr>
-          </thead>
-          <tbody>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
               {filteredItems.length ? (
                 filteredItems.map((item) => (
-                <tr key={item.item_name}>
-                <td className="border border-gray-200 px-4 py-3">
-                  {item.category_name ?? "미분류"}
-                </td>
-                <td className="border border-gray-200 px-4 py-3 font-mono text-gray-500">
-                  {item.item_code}
-                </td>
-                <td className="border border-gray-200 px-4 py-3 font-medium">
-                  {item.item_name}
-                </td>
+                  <tr key={item.item_name}>
+                    <td className="border border-gray-200 px-4 py-3">
+                      {item.category_name ?? "미분류"}
+                    </td>
+                    <td className="border border-gray-200 px-4 py-3 font-mono text-gray-500">
+                      {item.item_code}
+                    </td>
+                    <td className="border border-gray-200 px-4 py-3 font-medium">
+                      {item.item_name}
+                    </td>
                   </tr>
-              ))
-            ) : (
-              <tr>
-                <td
+                ))
+              ) : (
+                <tr>
+                  <td
                     colSpan={3}
-                  className="px-4 py-12 text-center text-sm text-gray-400"
-                >
+                    className="px-4 py-12 text-center text-sm text-gray-400"
+                  >
                     조건에 맞는 수량 미관리 품목이 없습니다.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
       </section>
     </div>
   );
@@ -1512,10 +1481,7 @@ const splitPurchaseOrderNote = (value: string | null | undefined) => {
   };
 };
 
-const mergePurchaseOrderNote = (
-  status: TaxInvoiceStatus,
-  note: string,
-) =>
+const mergePurchaseOrderNote = (status: TaxInvoiceStatus, note: string) =>
   [`[[tax_invoice:${status}]]`, note.trim()].filter(Boolean).join("\n");
 
 function QuantityEditControl({
@@ -2005,8 +1971,8 @@ function ReceiptManager({
                         )}
                       </div>
                     </div>
-                    </div>
                   </div>
+                </div>
               )}
 
               {createStep === 2 && (
@@ -2371,9 +2337,7 @@ function ReceiptManager({
                 >
                   이미 추가된 품목입니다.
                 </h3>
-                <p className="mt-2 text-sm text-gray-600">
-                  추가하시겠습니까?
-                </p>
+                <p className="mt-2 text-sm text-gray-600">추가하시겠습니까?</p>
                 <div className="mt-5 flex justify-end gap-2">
                   <Button
                     variant="gray"
@@ -2661,8 +2625,9 @@ function PurchaseOrderList({
   const [arrivalDates, setArrivalDates] = useState<Record<string, string>>({});
   const [arrivalNotes, setArrivalNotes] = useState<Record<string, string>>({});
   const [pending, setPending] = useState(false);
-  const [adjustmentOrder, setAdjustmentOrder] =
-    useState<PurchaseOrder | null>(null);
+  const [adjustmentOrder, setAdjustmentOrder] = useState<PurchaseOrder | null>(
+    null,
+  );
   const [editingOrder, setEditingOrder] = useState<PurchaseOrder | null>(null);
   const [categoryManagerOpen, setCategoryManagerOpen] = useState(false);
   const adjustmentCategoriesQuery = useQuery({
@@ -2747,10 +2712,7 @@ function PurchaseOrderList({
   const waitingOrders = orders.filter((order) => order.status === "pending");
   const partialOrders = orders.filter((order) => order.status === "partial");
   const draftBaselineRef = useRef(
-    new Map<
-      string,
-      { orderedQuantity: number; pendingQuantity: number }
-    >(),
+    new Map<string, { orderedQuantity: number; pendingQuantity: number }>(),
   );
   useEffect(() => {
     if (
@@ -2803,10 +2765,7 @@ function PurchaseOrderList({
                 baseline.orderedQuantity,
               );
             }
-            await setPurchaseArrivalQuantity(
-              line.id,
-              baseline.pendingQuantity,
-            );
+            await setPurchaseArrivalQuantity(line.id, baseline.pendingQuantity);
           }
         }
         await onSaved();
@@ -2831,31 +2790,31 @@ function PurchaseOrderList({
   const closedOrders = orders.filter((order) => order.status === "closed");
   const filterHistoryOrders = (targetOrders: PurchaseOrder[]) =>
     targetOrders.filter((order) => {
-    const matchesSupplier = (order.inventory_suppliers?.name ?? "")
-      .toLocaleLowerCase("ko-KR")
-      .includes(historySupplierSearch.trim().toLocaleLowerCase("ko-KR"));
-    const normalizedItemSearch = historyItemSearch
-      .trim()
-      .toLocaleLowerCase("ko-KR");
-    const matchesItem =
-      !normalizedItemSearch ||
-      order.inventory_purchase_order_lines.some((line) =>
-        line.item_name
-          .toLocaleLowerCase("ko-KR")
-          .includes(normalizedItemSearch),
+      const matchesSupplier = (order.inventory_suppliers?.name ?? "")
+        .toLocaleLowerCase("ko-KR")
+        .includes(historySupplierSearch.trim().toLocaleLowerCase("ko-KR"));
+      const normalizedItemSearch = historyItemSearch
+        .trim()
+        .toLocaleLowerCase("ko-KR");
+      const matchesItem =
+        !normalizedItemSearch ||
+        order.inventory_purchase_order_lines.some((line) =>
+          line.item_name
+            .toLocaleLowerCase("ko-KR")
+            .includes(normalizedItemSearch),
+        );
+      const receiptDates = order.inventory_purchase_receipts.map(
+        (receipt) => receipt.arrived_on,
       );
-    const receiptDates = order.inventory_purchase_receipts.map(
-      (receipt) => receipt.arrived_on,
-    );
-    const matchesDate =
-      historyDateMode === "all" ||
-      (Boolean(historyStartDate) &&
-        receiptDates.some((date) =>
-          historyEndDate
-            ? date >= historyStartDate && date <= historyEndDate
-            : date === historyStartDate,
-        ));
-    return matchesSupplier && matchesItem && matchesDate;
+      const matchesDate =
+        historyDateMode === "all" ||
+        (Boolean(historyStartDate) &&
+          receiptDates.some((date) =>
+            historyEndDate
+              ? date >= historyStartDate && date <= historyEndDate
+              : date === historyStartDate,
+          ));
+      return matchesSupplier && matchesItem && matchesDate;
     });
   const filteredCompletedOrders = filterHistoryOrders(completedOrders);
   const filteredClosedOrders = filterHistoryOrders(closedOrders);
@@ -2932,26 +2891,26 @@ function PurchaseOrderList({
       </div>
       {(listTab === "waiting" || listTab === "partial") &&
         visibleOrders.length > 0 && (
-        <div className="flex items-center gap-2 overflow-x-auto rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
-          <span className="shrink-0 text-xs font-bold text-gray-500">
-            거래처 바로가기
-          </span>
-          {visibleOrders.map((order) => (
-            <button
-              type="button"
-              key={order.id}
-              onClick={() =>
-                document
-                  .getElementById(`purchase-order-${order.id}`)
-                  ?.scrollIntoView({ behavior: "smooth", block: "start" })
-              }
-              className="shrink-0 rounded-full border border-gray-200 bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-700 hover:border-brand-300 hover:bg-brand-50 hover:text-brand-700"
-            >
-              {order.inventory_suppliers?.name ?? "거래처 정보 없음"}
-            </button>
-          ))}
-        </div>
-      )}
+          <div className="flex items-center gap-2 overflow-x-auto rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
+            <span className="shrink-0 text-xs font-bold text-gray-500">
+              거래처 바로가기
+            </span>
+            {visibleOrders.map((order) => (
+              <button
+                type="button"
+                key={order.id}
+                onClick={() =>
+                  document
+                    .getElementById(`purchase-order-${order.id}`)
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" })
+                }
+                className="shrink-0 rounded-full border border-gray-200 bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-700 hover:border-brand-300 hover:bg-brand-50 hover:text-brand-700"
+              >
+                {order.inventory_suppliers?.name ?? "거래처 정보 없음"}
+              </button>
+            ))}
+          </div>
+        )}
       {(listTab === "completed" || listTab === "closed") && (
         <div className="flex flex-col gap-2 rounded-2xl border border-gray-200 bg-white p-3 shadow-sm lg:flex-row lg:items-stretch lg:gap-3">
           <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[120px] sm:shrink-0">
@@ -3016,7 +2975,12 @@ function PurchaseOrderList({
                   viewBox="0 0 24 24"
                   aria-hidden="true"
                 >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                  />
                 </svg>
                 <input
                   value={historySupplierSearch}
@@ -3251,185 +3215,305 @@ function PurchaseOrderList({
               className={`${open ? "block" : "hidden"} overflow-auto bg-gray-50 px-4 sm:px-5`}
             >
               <div className="min-w-[820px] overflow-hidden rounded-xl border border-brand-200 bg-white">
-              <table className="purchase-order-table purchase-order-table--clean-edges w-full table-fixed border-collapse bg-white text-sm">
-                <colgroup>
-                  <col className="w-[240px]" />
-                  <col className="w-[84px]" />
-                  {showPartialDetails && <col className="w-[90px]" />}
-                  {showPartialDetails && <col className="w-[90px]" />}
-                  {showPartialDetails && <col className="w-[100px]" />}
-                  <col className="w-[84px]" />
-                  <col className="w-[280px]" />
-                  <col className="w-[120px]" />
-                </colgroup>
-                <thead className="bg-brand-50 text-brand-700">
-                  <tr>
-                    {[
-                      "품목명",
-                      "주문 수량",
-                      "누적 입고",
-                      "남은 수량",
-                      "입고 차이",
-                      "입고 수량",
-                      "개별 메모",
-                      "수량 확인",
-                    ]
-                      .filter(
-                        (label) =>
-                          showPartialDetails ||
-                          (label !== "누적 입고" &&
-                            label !== "남은 수량" &&
-                            label !== "입고 차이"),
-                      )
-                      .map((label) => (
-                        <th
-                          key={label}
-                          className="border border-brand-200 px-3 py-3 text-left"
-                        >
-                          {label}
-                          {false && label === "개별 메모" && (
-                            <button
-                              type="button"
-                              aria-label="개별 메모 열 너비 조절"
-                              title="좌우로 드래그해 너비 조절"
-                              onPointerDown={(event) => {
-                                const startX = event.clientX;
-                                const startWidth = purchaseNoteWidth;
-                                const handleMove = (
-                                  moveEvent: PointerEvent,
-                                ) => {
-                                  const nextWidth = Math.max(
-                                    140,
-                                    startWidth + moveEvent.clientX - startX,
-                                  );
-                                  setPurchaseNoteWidth(nextWidth);
-                                  window.localStorage.setItem(
-                                    "purchase-note-column-width",
-                                    String(Math.round(nextWidth)),
-                                  );
-                                };
-                                const handleUp = () => {
-                                  document.removeEventListener(
+                <table className="purchase-order-table purchase-order-table--clean-edges w-full table-fixed border-collapse bg-white text-sm">
+                  <colgroup>
+                    <col className="w-[240px]" />
+                    <col className="w-[84px]" />
+                    {showPartialDetails && <col className="w-[90px]" />}
+                    {showPartialDetails && <col className="w-[90px]" />}
+                    {showPartialDetails && <col className="w-[100px]" />}
+                    <col className="w-[84px]" />
+                    <col className="w-[280px]" />
+                    <col className="w-[120px]" />
+                  </colgroup>
+                  <thead className="bg-brand-50 text-brand-700">
+                    <tr>
+                      {[
+                        "품목명",
+                        "주문 수량",
+                        "누적 입고",
+                        "남은 수량",
+                        "입고 차이",
+                        "입고 수량",
+                        "개별 메모",
+                        "수량 확인",
+                      ]
+                        .filter(
+                          (label) =>
+                            showPartialDetails ||
+                            (label !== "누적 입고" &&
+                              label !== "남은 수량" &&
+                              label !== "입고 차이"),
+                        )
+                        .map((label) => (
+                          <th
+                            key={label}
+                            className="border border-brand-200 px-3 py-3 text-left"
+                          >
+                            {label}
+                            {false && label === "개별 메모" && (
+                              <button
+                                type="button"
+                                aria-label="개별 메모 열 너비 조절"
+                                title="좌우로 드래그해 너비 조절"
+                                onPointerDown={(event) => {
+                                  const startX = event.clientX;
+                                  const startWidth = purchaseNoteWidth;
+                                  const handleMove = (
+                                    moveEvent: PointerEvent,
+                                  ) => {
+                                    const nextWidth = Math.max(
+                                      140,
+                                      startWidth + moveEvent.clientX - startX,
+                                    );
+                                    setPurchaseNoteWidth(nextWidth);
+                                    window.localStorage.setItem(
+                                      "purchase-note-column-width",
+                                      String(Math.round(nextWidth)),
+                                    );
+                                  };
+                                  const handleUp = () => {
+                                    document.removeEventListener(
+                                      "pointermove",
+                                      handleMove,
+                                    );
+                                    document.removeEventListener(
+                                      "pointerup",
+                                      handleUp,
+                                    );
+                                  };
+                                  document.addEventListener(
                                     "pointermove",
                                     handleMove,
                                   );
-                                  document.removeEventListener(
+                                  document.addEventListener(
                                     "pointerup",
                                     handleUp,
                                   );
-                                };
-                                document.addEventListener(
-                                  "pointermove",
-                                  handleMove,
-                                );
-                                document.addEventListener(
-                                  "pointerup",
-                                  handleUp,
-                                );
-                              }}
-                              className="absolute -right-1 top-0 z-20 h-full w-4 cursor-col-resize touch-none after:absolute after:bottom-2 after:left-1/2 after:top-2 after:w-0.5 after:-translate-x-1/2 after:bg-brand-300 hover:after:bg-brand-600"
-                            />
-                          )}
-                        </th>
-                      ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {order.inventory_purchase_order_lines.map((line) => {
-                    const lineRemaining = Math.max(
-                      0,
-                      line.ordered_quantity - line.received_quantity,
-                    );
-                    const arrivalDifference =
-                      line.pending_quantity - lineRemaining;
-                    const quantityCheckLabel =
-                      arrivalDifference === 0
-                        ? "수량 일치 체크"
-                        : arrivalDifference > 0
-                          ? `${arrivalDifference}개 추가입고 체크`
-                          : `${Math.abs(arrivalDifference)}개 미입고 체크`;
-                    const value =
-                      quantities[line.id] ?? String(line.pending_quantity);
-                    const editingQuantity =
-                      editingQuantities[line.id] ||
-                      (!savedQuantities[line.id] &&
-                        line.pending_quantity === 0);
-                    return (
-                      <tr key={line.id}>
-                        <td className="border border-gray-200 px-3 py-3 font-semibold">
-                          {line.item_name}
-                        </td>
-                        <td className="border border-gray-200 px-3 py-3 text-right">
-                          {order.status === "pending" &&
-                          editingOrderedQuantities[line.id] ? (
-                            <QuantityEditControl
-                              min={1}
-                              disabled={pending}
-                              value={
-                                orderedQuantities[line.id] ??
-                                String(line.ordered_quantity)
-                              }
-                              onChange={(nextValue) =>
-                                setOrderedQuantities((current) => ({
-                                  ...current,
-                                  [line.id]: nextValue,
-                                }))
-                              }
-                              onSave={() => {
-                                const nextQuantity = Number(
+                                }}
+                                className="absolute -right-1 top-0 z-20 h-full w-4 cursor-col-resize touch-none after:absolute after:bottom-2 after:left-1/2 after:top-2 after:w-0.5 after:-translate-x-1/2 after:bg-brand-300 hover:after:bg-brand-600"
+                              />
+                            )}
+                          </th>
+                        ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {order.inventory_purchase_order_lines.map((line) => {
+                      const lineRemaining = Math.max(
+                        0,
+                        line.ordered_quantity - line.received_quantity,
+                      );
+                      const arrivalDifference =
+                        line.pending_quantity - lineRemaining;
+                      const quantityCheckLabel =
+                        arrivalDifference === 0
+                          ? "수량 일치 체크"
+                          : arrivalDifference > 0
+                            ? `${arrivalDifference}개 추가입고 체크`
+                            : `${Math.abs(arrivalDifference)}개 미입고 체크`;
+                      const value =
+                        quantities[line.id] ?? String(line.pending_quantity);
+                      const editingQuantity =
+                        editingQuantities[line.id] ||
+                        (!savedQuantities[line.id] &&
+                          line.pending_quantity === 0);
+                      return (
+                        <tr key={line.id}>
+                          <td className="border border-gray-200 px-3 py-3 font-semibold">
+                            {line.item_name}
+                          </td>
+                          <td className="border border-gray-200 px-3 py-3 text-right">
+                            {order.status === "pending" &&
+                            editingOrderedQuantities[line.id] ? (
+                              <QuantityEditControl
+                                min={1}
+                                disabled={pending}
+                                value={
                                   orderedQuantities[line.id] ??
-                                    line.ordered_quantity,
-                                );
-                                if (
-                                  !Number.isInteger(nextQuantity) ||
-                                  nextQuantity < 1
-                                ) {
-                                  toast.error(
-                                    "주문 수량은 1개 이상 입력해 주세요.",
-                                  );
-                                  return;
+                                  String(line.ordered_quantity)
                                 }
-                                void (async () => {
-                                  const saved = await run(
-                                    () =>
-                                      updatePurchaseOrderQuantity(
-                                        line.id,
-                                        nextQuantity,
-                                      ),
-                                    "주문 수량을 변경했습니다.",
+                                onChange={(nextValue) =>
+                                  setOrderedQuantities((current) => ({
+                                    ...current,
+                                    [line.id]: nextValue,
+                                  }))
+                                }
+                                onSave={() => {
+                                  const nextQuantity = Number(
+                                    orderedQuantities[line.id] ??
+                                      line.ordered_quantity,
                                   );
-                                  if (saved) {
-                                    setEditingOrderedQuantities((current) => ({
-                                      ...current,
-                                      [line.id]: false,
-                                    }));
+                                  if (
+                                    !Number.isInteger(nextQuantity) ||
+                                    nextQuantity < 1
+                                  ) {
+                                    toast.error(
+                                      "주문 수량은 1개 이상 입력해 주세요.",
+                                    );
+                                    return;
                                   }
-                                })();
-                              }}
-                              onCancel={() => {
-                                setOrderedQuantities((current) => ({
-                                  ...current,
-                                  [line.id]: String(line.ordered_quantity),
-                                }));
-                                setEditingOrderedQuantities((current) => ({
-                                  ...current,
-                                  [line.id]: false,
-                                }));
-                              }}
-                            />
-                          ) : (
-                            <div className="flex w-full items-center justify-start gap-1">
-                              {order.status === "pending" && isAdmin && (
+                                  void (async () => {
+                                    const saved = await run(
+                                      () =>
+                                        updatePurchaseOrderQuantity(
+                                          line.id,
+                                          nextQuantity,
+                                        ),
+                                      "주문 수량을 변경했습니다.",
+                                    );
+                                    if (saved) {
+                                      setEditingOrderedQuantities(
+                                        (current) => ({
+                                          ...current,
+                                          [line.id]: false,
+                                        }),
+                                      );
+                                    }
+                                  })();
+                                }}
+                                onCancel={() => {
+                                  setOrderedQuantities((current) => ({
+                                    ...current,
+                                    [line.id]: String(line.ordered_quantity),
+                                  }));
+                                  setEditingOrderedQuantities((current) => ({
+                                    ...current,
+                                    [line.id]: false,
+                                  }));
+                                }}
+                              />
+                            ) : (
+                              <div className="flex w-full items-center justify-start gap-1">
+                                {order.status === "pending" && isAdmin && (
+                                  <Button
+                                    size="icon-xs"
+                                    variant="secondary"
+                                    aria-label="주문 수량 수정"
+                                    onClick={() => {
+                                      setOrderedQuantities((current) => ({
+                                        ...current,
+                                        [line.id]: String(
+                                          line.ordered_quantity,
+                                        ),
+                                      }));
+                                      setEditingOrderedQuantities(
+                                        (current) => ({
+                                          ...current,
+                                          [line.id]: true,
+                                        }),
+                                      );
+                                    }}
+                                  >
+                                    ✏️
+                                  </Button>
+                                )}
+                                <strong className="text-gray-900">
+                                  {line.ordered_quantity}개
+                                </strong>
+                              </div>
+                            )}
+                          </td>
+                          {showPartialDetails && (
+                            <td className="border border-gray-200 px-3 py-3 text-right">
+                              {line.received_quantity}개
+                            </td>
+                          )}
+                          {showPartialDetails && (
+                            <td className="border border-gray-200 px-3 py-3 text-right font-bold text-gray-900">
+                              {lineRemaining}개
+                            </td>
+                          )}
+                          {showPartialDetails && (
+                            <td className="border border-gray-200 px-3 py-3 text-right font-bold">
+                              {line.pending_quantity > 0 &&
+                              arrivalDifference === 0 ? (
+                                <span className="inline-flex rounded-full bg-emerald-50 px-2 py-1 text-xs font-bold text-emerald-700">
+                                  수량 일치
+                                </span>
+                              ) : line.pending_quantity > 0 &&
+                                arrivalDifference > 0 ? (
+                                <span className="inline-flex rounded-full bg-blue-50 px-2 py-1 text-xs font-bold text-blue-700">
+                                  {arrivalDifference}개 추가 입고
+                                </span>
+                              ) : line.pending_quantity > 0 ? (
+                                <span className="inline-flex rounded-full bg-amber-50 px-2 py-1 text-xs font-bold text-amber-700">
+                                  {Math.abs(arrivalDifference)}개 미입고
+                                </span>
+                              ) : (
+                                "-"
+                              )}
+                            </td>
+                          )}
+                          <td className="border border-gray-200 p-2">
+                            {open && editingQuantity ? (
+                              <QuantityEditControl
+                                min={0}
+                                disabled={
+                                  pending ||
+                                  !Number.isInteger(Number(value)) ||
+                                  Number(value) < 0
+                                }
+                                value={value}
+                                onChange={(nextValue) =>
+                                  setQuantities((current) => ({
+                                    ...current,
+                                    [line.id]: nextValue,
+                                  }))
+                                }
+                                onSave={() => {
+                                  const qty = Number(value);
+                                  if (
+                                    qty > lineRemaining &&
+                                    !window.confirm(
+                                      `주문 잔량은 ${lineRemaining}개입니다. ${qty}개로 저장할까요?`,
+                                    )
+                                  )
+                                    return;
+                                  void (async () => {
+                                    const saved = await run(
+                                      () =>
+                                        setPurchaseArrivalQuantity(
+                                          line.id,
+                                          qty,
+                                        ),
+                                      "도착 수량을 저장했습니다.",
+                                    );
+                                    if (saved) {
+                                      setSavedQuantities((current) => ({
+                                        ...current,
+                                        [line.id]: true,
+                                      }));
+                                      setEditingQuantities((current) => ({
+                                        ...current,
+                                        [line.id]: false,
+                                      }));
+                                    }
+                                  })();
+                                }}
+                                onCancel={() => {
+                                  setQuantities((current) => ({
+                                    ...current,
+                                    [line.id]: String(line.pending_quantity),
+                                  }));
+                                  setEditingQuantities((current) => ({
+                                    ...current,
+                                    [line.id]: false,
+                                  }));
+                                }}
+                              />
+                            ) : open ? (
+                              <div className="flex w-full items-center justify-start gap-1">
                                 <Button
                                   size="icon-xs"
                                   variant="secondary"
-                                  aria-label="주문 수량 수정"
+                                  aria-label="입고 수량 수정"
                                   onClick={() => {
-                                    setOrderedQuantities((current) => ({
+                                    setQuantities((current) => ({
                                       ...current,
-                                      [line.id]: String(line.ordered_quantity),
+                                      [line.id]: String(line.pending_quantity),
                                     }));
-                                    setEditingOrderedQuantities((current) => ({
+                                    setEditingQuantities((current) => ({
                                       ...current,
                                       [line.id]: true,
                                     }));
@@ -3437,357 +3521,249 @@ function PurchaseOrderList({
                                 >
                                   ✏️
                                 </Button>
-                              )}
-                              <strong className="text-gray-900">
-                                {line.ordered_quantity}개
+                                <strong className="text-gray-900">
+                                  {line.pending_quantity}개
+                                </strong>
+                              </div>
+                            ) : (
+                              <strong className="block text-right text-gray-900">
+                                {line.received_quantity}개
                               </strong>
-                            </div>
-                          )}
-                        </td>
-                        {showPartialDetails && (
-                          <td className="border border-gray-200 px-3 py-3 text-right">
-                            {line.received_quantity}개
+                            )}
                           </td>
-                        )}
-                        {showPartialDetails && (
-                          <td className="border border-gray-200 px-3 py-3 text-right font-bold text-gray-900">
-                            {lineRemaining}개
-                          </td>
-                        )}
-                        {showPartialDetails && (
-                          <td className="border border-gray-200 px-3 py-3 text-right font-bold">
-                            {line.pending_quantity > 0 &&
-                            arrivalDifference === 0 ? (
-                              <span className="inline-flex rounded-full bg-emerald-50 px-2 py-1 text-xs font-bold text-emerald-700">
-                                수량 일치
-                              </span>
-                            ) : line.pending_quantity > 0 &&
-                              arrivalDifference > 0 ? (
-                              <span className="inline-flex rounded-full bg-blue-50 px-2 py-1 text-xs font-bold text-blue-700">
-                                {arrivalDifference}개 추가 입고
-                              </span>
-                            ) : line.pending_quantity > 0 ? (
-                              <span className="inline-flex rounded-full bg-amber-50 px-2 py-1 text-xs font-bold text-amber-700">
-                                {Math.abs(arrivalDifference)}개 미입고
-                              </span>
+                          <td className="border border-gray-200 px-3 py-3 text-gray-500">
+                            {line.note || line.quantity_check_note ? (
+                              <div className="space-y-1">
+                                {line.note && (
+                                  <p>{cleanQuantityMemo(line.note)}</p>
+                                )}
+                                {line.quantity_check_note && (
+                                  <p className="font-semibold text-brand-700">
+                                    {line.quantity_check_note}
+                                  </p>
+                                )}
+                              </div>
                             ) : (
                               "-"
                             )}
                           </td>
-                        )}
-                        <td className="border border-gray-200 p-2">
-                          {open && editingQuantity ? (
-                            <QuantityEditControl
-                              min={0}
-                              disabled={
-                                pending ||
-                                !Number.isInteger(Number(value)) ||
-                                Number(value) < 0
-                              }
-                              value={value}
-                              onChange={(nextValue) =>
-                                setQuantities((current) => ({
-                                  ...current,
-                                  [line.id]: nextValue,
-                                }))
-                              }
-                              onSave={() => {
-                                const qty = Number(value);
-                                if (
-                                  qty > lineRemaining &&
-                                  !window.confirm(
-                                    `주문 잔량은 ${lineRemaining}개입니다. ${qty}개로 저장할까요?`,
-                                  )
-                                )
-                                  return;
-                                void (async () => {
-                                  const saved = await run(
-                                    () =>
-                                      setPurchaseArrivalQuantity(line.id, qty),
-                                    "도착 수량을 저장했습니다.",
-                                  );
-                                  if (saved) {
-                                    setSavedQuantities((current) => ({
-                                      ...current,
-                                      [line.id]: true,
-                                    }));
-                                    setEditingQuantities((current) => ({
-                                      ...current,
-                                      [line.id]: false,
-                                    }));
-                                  }
-                                })();
-                              }}
-                              onCancel={() => {
-                                setQuantities((current) => ({
-                                  ...current,
-                                  [line.id]: String(line.pending_quantity),
-                                }));
-                                setEditingQuantities((current) => ({
-                                  ...current,
-                                  [line.id]: false,
-                                }));
-                              }}
-                            />
-                          ) : open ? (
-                            <div className="flex w-full items-center justify-start gap-1">
-                              <Button
-                                size="icon-xs"
-                                variant="secondary"
-                                aria-label="입고 수량 수정"
-                                onClick={() => {
-                                  setQuantities((current) => ({
-                                    ...current,
-                                    [line.id]: String(line.pending_quantity),
-                                  }));
-                                  setEditingQuantities((current) => ({
-                                    ...current,
-                                    [line.id]: true,
-                                  }));
-                                }}
+                          <td className="border border-gray-200 px-3 py-3">
+                            {!open ? (
+                              <span
+                                className={`rounded-full px-2 py-1 text-xs font-bold ${order.status === "completed" && line.received_quantity === line.ordered_quantity ? "bg-emerald-100 text-emerald-700" : order.status === "completed" && line.received_quantity > line.ordered_quantity ? "bg-blue-100 text-blue-700" : (order.status === "completed" || order.status === "closed") && line.received_quantity < line.ordered_quantity ? "bg-amber-100 text-amber-700" : "bg-gray-100 text-gray-600"}`}
                               >
-                                ✏️
+                                {order.status === "completed"
+                                  ? line.received_quantity ===
+                                    line.ordered_quantity
+                                    ? "전체 입고 완료"
+                                    : line.received_quantity >
+                                        line.ordered_quantity
+                                      ? `${line.received_quantity - line.ordered_quantity}개 추가 입고`
+                                      : `${line.ordered_quantity - line.received_quantity}개 미입고`
+                                  : order.status === "closed" &&
+                                      line.received_quantity <
+                                        line.ordered_quantity
+                                    ? `${line.ordered_quantity - line.received_quantity}개 미입고`
+                                    : "처리 종료"}
+                              </span>
+                            ) : line.quantity_checked_at ? (
+                              <span
+                                className={`rounded-full px-2 py-1 text-xs font-bold ${arrivalDifference < 0 ? "bg-amber-100 text-amber-700" : arrivalDifference > 0 ? "bg-blue-100 text-blue-700" : "bg-emerald-100 text-emerald-700"}`}
+                              >
+                                {quantityCheckLabel}
+                              </span>
+                            ) : open ? (
+                              <Button
+                                size="xs"
+                                onClick={() =>
+                                  void run(
+                                    () => checkPurchaseArrivalQuantity(line.id),
+                                    "수량 체크를 완료했습니다.",
+                                  )
+                                }
+                                disabled={pending}
+                              >
+                                {quantityCheckLabel}
                               </Button>
-                              <strong className="text-gray-900">
-                                {line.pending_quantity}개
-                              </strong>
-                            </div>
-                          ) : (
-                            <strong className="block text-right text-gray-900">
-                              {line.received_quantity}개
-                            </strong>
-                          )}
-                        </td>
-                        <td className="border border-gray-200 px-3 py-3 text-gray-500">
-                          {line.note || line.quantity_check_note ? (
-                            <div className="space-y-1">
-                              {line.note && (
-                                <p>{cleanQuantityMemo(line.note)}</p>
-                              )}
-                              {line.quantity_check_note && (
-                                <p className="font-semibold text-brand-700">
-                                  {line.quantity_check_note}
-                                </p>
-                              )}
-                            </div>
-                          ) : (
-                            "-"
-                          )}
-                        </td>
-                        <td className="border border-gray-200 px-3 py-3">
-                          {!open ? (
-                            <span
-                              className={`rounded-full px-2 py-1 text-xs font-bold ${order.status === "completed" && line.received_quantity === line.ordered_quantity ? "bg-emerald-100 text-emerald-700" : order.status === "completed" && line.received_quantity > line.ordered_quantity ? "bg-blue-100 text-blue-700" : (order.status === "completed" || order.status === "closed") && line.received_quantity < line.ordered_quantity ? "bg-amber-100 text-amber-700" : "bg-gray-100 text-gray-600"}`}
-                            >
-                              {order.status === "completed"
-                                ? line.received_quantity ===
-                                  line.ordered_quantity
-                                  ? "전체 입고 완료"
-                                  : line.received_quantity >
-                                      line.ordered_quantity
-                                    ? `${line.received_quantity - line.ordered_quantity}개 추가 입고`
-                                    : `${line.ordered_quantity - line.received_quantity}개 미입고`
-                                : order.status === "closed" &&
-                                    line.received_quantity <
-                                      line.ordered_quantity
-                                  ? `${line.ordered_quantity - line.received_quantity}개 미입고`
-                                  : "처리 종료"}
-                            </span>
-                          ) : line.quantity_checked_at ? (
-                            <span
-                              className={`rounded-full px-2 py-1 text-xs font-bold ${arrivalDifference < 0 ? "bg-amber-100 text-amber-700" : arrivalDifference > 0 ? "bg-blue-100 text-blue-700" : "bg-emerald-100 text-emerald-700"}`}
-                            >
-                              {quantityCheckLabel}
-                            </span>
-                          ) : open ? (
-                            <Button
-                              size="xs"
-                              onClick={() =>
-                                void run(
-                                  () => checkPurchaseArrivalQuantity(line.id),
-                                  "수량 체크를 완료했습니다.",
-                                )
-                              }
-                              disabled={pending}
-                            >
-                              {quantityCheckLabel}
-                            </Button>
-                          ) : (
-                            <span className="text-gray-400">대기</span>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+                            ) : (
+                              <span className="text-gray-400">대기</span>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
               </div>
             </div>
             {!open &&
               listTab !== "closed" &&
               order.inventory_purchase_receipts.length > 0 && (
-              <div className="overflow-auto bg-gray-50 px-4 pb-4 sm:px-5 sm:pb-5">
-                <div className="min-w-[1080px] overflow-hidden rounded-xl border border-brand-200 bg-white">
-                <table className="purchase-order-table purchase-order-table--clean-edges w-full table-fixed border-collapse bg-white text-sm">
-                  <colgroup>
-                    <col className="w-[190px]" />
-                    <col className="w-[220px]" />
-                    <col className="w-[90px]" />
-                    {showCompletedCumulativeDetails && (
-                      <col className="w-[120px]" />
-                    )}
-                    {showCompletedCumulativeDetails && (
-                      <col className="w-[100px]" />
-                    )}
-                    <col className="w-[100px]" />
-                    <col className="w-[140px]" />
-                    <col className="w-[260px]" />
-                  </colgroup>
-                  <thead className="bg-brand-50 text-brand-700">
-                    <tr>
-                      {[
-                        "도착일",
-                        "품목명",
-                        "주문 수량",
-                        "이전 입고 수량",
-                        "남은 수량",
-                        "입고 수량",
-                        "입고 차이",
-                        "개별 메모",
-                      ]
-                        .filter(
-                          (label) =>
-                            showCompletedCumulativeDetails ||
-                            (label !== "이전 입고 수량" &&
-                              label !== "남은 수량"),
-                        )
-                        .map((label) => (
-                        <th
-                          key={label}
-                          className="whitespace-nowrap border border-brand-200 px-3 py-3 text-left"
-                        >
-                          {label}
-                        </th>
-                        ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedReceipts.flatMap((receipt, receiptIndex) =>
-                      receipt.inventory_purchase_receipt_lines.map(
-                        (receiptLine) => {
-                          const orderLine =
-                            order.inventory_purchase_order_lines.find(
-                              (line) => line.id === receiptLine.order_line_id,
-                            );
-                          const previousReceived = sortedReceipts
-                            .slice(0, receiptIndex)
-                            .filter((previous) => !previous.reversed_at)
-                            .flatMap(
-                              (previous) =>
-                                previous.inventory_purchase_receipt_lines,
-                            )
+                <div className="overflow-auto bg-gray-50 px-4 pb-4 sm:px-5 sm:pb-5">
+                  <div className="min-w-[1080px] overflow-hidden rounded-xl border border-brand-200 bg-white">
+                    <table className="purchase-order-table purchase-order-table--clean-edges w-full table-fixed border-collapse bg-white text-sm">
+                      <colgroup>
+                        <col className="w-[190px]" />
+                        <col className="w-[220px]" />
+                        <col className="w-[90px]" />
+                        {showCompletedCumulativeDetails && (
+                          <col className="w-[120px]" />
+                        )}
+                        {showCompletedCumulativeDetails && (
+                          <col className="w-[100px]" />
+                        )}
+                        <col className="w-[100px]" />
+                        <col className="w-[140px]" />
+                        <col className="w-[260px]" />
+                      </colgroup>
+                      <thead className="bg-brand-50 text-brand-700">
+                        <tr>
+                          {[
+                            "도착일",
+                            "품목명",
+                            "주문 수량",
+                            "이전 입고 수량",
+                            "남은 수량",
+                            "입고 수량",
+                            "입고 차이",
+                            "개별 메모",
+                          ]
                             .filter(
-                              (previousLine) =>
-                                previousLine.order_line_id ===
-                                receiptLine.order_line_id,
+                              (label) =>
+                                showCompletedCumulativeDetails ||
+                                (label !== "이전 입고 수량" &&
+                                  label !== "남은 수량"),
                             )
-                            .reduce(
-                              (sum, previousLine) =>
-                                sum + previousLine.quantity,
-                              0,
-                            );
-                          const orderedQuantity =
-                            orderLine?.ordered_quantity ?? 0;
-                          const remainingBefore = Math.max(
-                            0,
-                            orderedQuantity - previousReceived,
-                          );
-                          const difference =
-                            receiptLine.quantity - remainingBefore;
-                          return (
-                            <tr
-                              key={receiptLine.id}
-                              className={
-                                receipt.reversed_at
-                                  ? "bg-gray-50 opacity-60"
-                                  : ""
-                              }
-                            >
-                              <td className="border border-gray-200 px-3 py-3">
-                                {formatKoreanDate(receipt.arrived_on)}
-                                {receipt.note && (
-                                  <p className="mt-1 text-xs text-gray-500">
-                                    입고 메모: {receipt.note}
-                                  </p>
-                                )}
-                                {receipt.reversed_at && (
-                                  <span className="ml-2 text-xs font-bold text-rose-600">
-                                    취소됨
-                                  </span>
-                                )}
-                              </td>
-                              <td className="border border-gray-200 px-3 py-3 font-semibold">
-                                {receiptLine.item_name}
-                              </td>
-                              <td className="border border-gray-200 px-3 py-3 text-right">
-                                {orderedQuantity}개
-                              </td>
-                              {showCompletedCumulativeDetails && (
-                                <td className="border border-gray-200 px-3 py-3 text-right">
-                                  {previousReceived}개
-                                </td>
-                              )}
-                              {showCompletedCumulativeDetails && (
-                                <td className="border border-gray-200 px-3 py-3 text-right font-bold">
-                                  {remainingBefore}개
-                                </td>
-                              )}
-                              <td className="border border-gray-200 px-3 py-3 text-right font-bold">
-                                {receiptLine.quantity}개
-                              </td>
-                              <td className="border border-gray-200 px-3 py-3 text-right">
-                                <span
-                                  className={`inline-flex rounded-full px-2 py-1 text-xs font-bold ${difference === 0 ? "bg-emerald-50 text-emerald-700" : difference > 0 ? "bg-blue-50 text-blue-700" : "bg-amber-50 text-amber-700"}`}
+                            .map((label) => (
+                              <th
+                                key={label}
+                                className="whitespace-nowrap border border-brand-200 px-3 py-3 text-left"
+                              >
+                                {label}
+                              </th>
+                            ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {sortedReceipts.flatMap((receipt, receiptIndex) =>
+                          receipt.inventory_purchase_receipt_lines.map(
+                            (receiptLine) => {
+                              const orderLine =
+                                order.inventory_purchase_order_lines.find(
+                                  (line) =>
+                                    line.id === receiptLine.order_line_id,
+                                );
+                              const previousReceived = sortedReceipts
+                                .slice(0, receiptIndex)
+                                .filter((previous) => !previous.reversed_at)
+                                .flatMap(
+                                  (previous) =>
+                                    previous.inventory_purchase_receipt_lines,
+                                )
+                                .filter(
+                                  (previousLine) =>
+                                    previousLine.order_line_id ===
+                                    receiptLine.order_line_id,
+                                )
+                                .reduce(
+                                  (sum, previousLine) =>
+                                    sum + previousLine.quantity,
+                                  0,
+                                );
+                              const orderedQuantity =
+                                orderLine?.ordered_quantity ?? 0;
+                              const remainingBefore = Math.max(
+                                0,
+                                orderedQuantity - previousReceived,
+                              );
+                              const difference =
+                                receiptLine.quantity - remainingBefore;
+                              return (
+                                <tr
+                                  key={receiptLine.id}
+                                  className={
+                                    receipt.reversed_at
+                                      ? "bg-gray-50 opacity-60"
+                                      : ""
+                                  }
                                 >
-                                  {difference === 0
-                                    ? "수량 일치"
-                                    : difference > 0
-                                      ? `${difference}개 추가 입고`
-                                      : `${Math.abs(difference)}개 미입고`}
-                                </span>
-                              </td>
-                              <td className="border border-gray-200 px-3 py-3 text-gray-600">
-                                {receiptLine.note ||
-                                receiptLine.quantity_check_note ||
-                                orderLine?.note ? (
-                                  <div className="space-y-1">
-                                    {(receiptLine.note || orderLine?.note) && (
-                                      <p>
-                                        {cleanQuantityMemo(
-                                          receiptLine.note || orderLine?.note,
+                                  <td className="border border-gray-200 px-3 py-3">
+                                    {formatKoreanDate(receipt.arrived_on)}
+                                    {receipt.note && (
+                                      <p className="mt-1 text-xs text-gray-500">
+                                        입고 메모: {receipt.note}
+                                      </p>
+                                    )}
+                                    {receipt.reversed_at && (
+                                      <span className="ml-2 text-xs font-bold text-rose-600">
+                                        취소됨
+                                      </span>
+                                    )}
+                                  </td>
+                                  <td className="border border-gray-200 px-3 py-3 font-semibold">
+                                    {receiptLine.item_name}
+                                  </td>
+                                  <td className="border border-gray-200 px-3 py-3 text-right">
+                                    {orderedQuantity}개
+                                  </td>
+                                  {showCompletedCumulativeDetails && (
+                                    <td className="border border-gray-200 px-3 py-3 text-right">
+                                      {previousReceived}개
+                                    </td>
+                                  )}
+                                  {showCompletedCumulativeDetails && (
+                                    <td className="border border-gray-200 px-3 py-3 text-right font-bold">
+                                      {remainingBefore}개
+                                    </td>
+                                  )}
+                                  <td className="border border-gray-200 px-3 py-3 text-right font-bold">
+                                    {receiptLine.quantity}개
+                                  </td>
+                                  <td className="border border-gray-200 px-3 py-3 text-right">
+                                    <span
+                                      className={`inline-flex rounded-full px-2 py-1 text-xs font-bold ${difference === 0 ? "bg-emerald-50 text-emerald-700" : difference > 0 ? "bg-blue-50 text-blue-700" : "bg-amber-50 text-amber-700"}`}
+                                    >
+                                      {difference === 0
+                                        ? "수량 일치"
+                                        : difference > 0
+                                          ? `${difference}개 추가 입고`
+                                          : `${Math.abs(difference)}개 미입고`}
+                                    </span>
+                                  </td>
+                                  <td className="border border-gray-200 px-3 py-3 text-gray-600">
+                                    {receiptLine.note ||
+                                    receiptLine.quantity_check_note ||
+                                    orderLine?.note ? (
+                                      <div className="space-y-1">
+                                        {(receiptLine.note ||
+                                          orderLine?.note) && (
+                                          <p>
+                                            {cleanQuantityMemo(
+                                              receiptLine.note ||
+                                                orderLine?.note,
+                                            )}
+                                          </p>
                                         )}
-                                      </p>
+                                        {receiptLine.quantity_check_note && (
+                                          <p className="font-semibold text-brand-700">
+                                            {receiptLine.quantity_check_note}
+                                          </p>
+                                        )}
+                                      </div>
+                                    ) : (
+                                      "-"
                                     )}
-                                    {receiptLine.quantity_check_note && (
-                                      <p className="font-semibold text-brand-700">
-                                        {receiptLine.quantity_check_note}
-                                      </p>
-                                    )}
-                                  </div>
-                                ) : (
-                                  "-"
-                                )}
-                              </td>
-                            </tr>
-                          );
-                        },
-                      ),
-                    )}
-                  </tbody>
-                </table>
+                                  </td>
+                                </tr>
+                              );
+                            },
+                          ),
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
             {!open && order.status === "closed" && (
               <div className="bg-gray-50 px-4 pb-4 sm:px-5 sm:pb-5">
                 <div className="mb-3 flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-3 sm:flex-row sm:items-center sm:justify-between">
@@ -3825,62 +3801,62 @@ function PurchaseOrderList({
                 </div>
                 <div className="overflow-auto">
                   <div className="min-w-[760px] overflow-hidden rounded-xl border border-amber-200 bg-white">
-                <table className="purchase-order-table purchase-order-table--clean-edges w-full table-fixed border-collapse bg-white text-sm">
-                  <thead className="bg-amber-50 text-amber-800">
-                    <tr>
-                      <th className="border border-amber-200 px-3 py-3 text-left">
-                        품목명
-                      </th>
-                      <th className="w-28 border border-amber-200 px-3 py-3 text-right">
-                        주문 수량
-                      </th>
-                      <th className="w-28 border border-amber-200 px-3 py-3 text-right">
-                        입고 수량
-                      </th>
-                      <th className="w-28 border border-amber-200 px-3 py-3 text-right">
-                        미입고 수량
-                      </th>
-                      <th className="w-72 border border-amber-200 px-3 py-3 text-left">
-                        종료 내용
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {visibleClosedLines.map((line) => {
-                      const missingQuantity = Math.max(
-                        0,
-                        line.ordered_quantity - line.received_quantity,
-                      );
-                      return (
-                      <tr key={`closed-${line.id}`}>
-                        <td className="border border-gray-200 px-3 py-3 break-words font-semibold">
-                          {line.item_name}
-                        </td>
-                        <td className="border border-gray-200 px-3 py-3 text-right">
-                          {line.ordered_quantity}개
-                        </td>
-                        <td className="border border-gray-200 px-3 py-3 text-right">
-                          {line.received_quantity}개
-                        </td>
-                        <td
-                          className={`border border-gray-200 px-3 py-3 text-right font-bold ${missingQuantity > 0 ? "text-amber-700" : "text-emerald-700"}`}
-                        >
-                          {missingQuantity}개
-                        </td>
-                        <td className="border border-gray-200 px-3 py-3 break-words text-gray-600">
-                          {missingQuantity > 0 ? (
-                            order.closed_reason || "미입고 종료"
-                          ) : (
-                            <span className="font-semibold text-emerald-700">
-                              입고 완료
-                            </span>
-                          )}
-                        </td>
-                      </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                    <table className="purchase-order-table purchase-order-table--clean-edges w-full table-fixed border-collapse bg-white text-sm">
+                      <thead className="bg-amber-50 text-amber-800">
+                        <tr>
+                          <th className="border border-amber-200 px-3 py-3 text-left">
+                            품목명
+                          </th>
+                          <th className="w-28 border border-amber-200 px-3 py-3 text-right">
+                            주문 수량
+                          </th>
+                          <th className="w-28 border border-amber-200 px-3 py-3 text-right">
+                            입고 수량
+                          </th>
+                          <th className="w-28 border border-amber-200 px-3 py-3 text-right">
+                            미입고 수량
+                          </th>
+                          <th className="w-72 border border-amber-200 px-3 py-3 text-left">
+                            종료 내용
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {visibleClosedLines.map((line) => {
+                          const missingQuantity = Math.max(
+                            0,
+                            line.ordered_quantity - line.received_quantity,
+                          );
+                          return (
+                            <tr key={`closed-${line.id}`}>
+                              <td className="border border-gray-200 px-3 py-3 break-words font-semibold">
+                                {line.item_name}
+                              </td>
+                              <td className="border border-gray-200 px-3 py-3 text-right">
+                                {line.ordered_quantity}개
+                              </td>
+                              <td className="border border-gray-200 px-3 py-3 text-right">
+                                {line.received_quantity}개
+                              </td>
+                              <td
+                                className={`border border-gray-200 px-3 py-3 text-right font-bold ${missingQuantity > 0 ? "text-amber-700" : "text-emerald-700"}`}
+                              >
+                                {missingQuantity}개
+                              </td>
+                              <td className="border border-gray-200 px-3 py-3 break-words text-gray-600">
+                                {missingQuantity > 0 ? (
+                                  order.closed_reason || "미입고 종료"
+                                ) : (
+                                  <span className="font-semibold text-emerald-700">
+                                    입고 완료
+                                  </span>
+                                )}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
                   </div>
                 </div>
               </div>
@@ -4108,8 +4084,7 @@ function PurchaseOrderEditOverlay({
         (line) =>
           !line.itemName.trim() ||
           !Number.isInteger(Number(line.orderedQuantity)) ||
-          Number(line.orderedQuantity) <
-            Math.max(1, line.receivedQuantity),
+          Number(line.orderedQuantity) < Math.max(1, line.receivedQuantity),
       )
     ) {
       toast.error("품목명과 주문수량을 확인해 주세요.");
@@ -4128,10 +4103,7 @@ function PurchaseOrderEditOverlay({
         orderId: order.id,
         supplierId,
         orderedOn,
-        note: mergePurchaseOrderNote(
-          parsedNote.taxInvoiceStatus,
-          overallNote,
-        ),
+        note: mergePurchaseOrderNote(parsedNote.taxInvoiceStatus, overallNote),
         lines: lines.map((line) => ({
           id: line.id,
           item_name: line.itemName.trim(),
@@ -4139,9 +4111,9 @@ function PurchaseOrderEditOverlay({
           unit_price:
             isAdmin && line.unitPrice !== ""
               ? Math.max(0, Math.floor(Number(line.unitPrice)))
-              : order.inventory_purchase_order_lines.find(
-                    (item) => item.id === line.id,
-                  )?.unit_price ?? null,
+              : (order.inventory_purchase_order_lines.find(
+                  (item) => item.id === line.id,
+                )?.unit_price ?? null),
           note: line.note.trim(),
         })),
         receipts: receipts.map((receipt) => ({
@@ -4174,7 +4146,8 @@ function PurchaseOrderEditOverlay({
         <div className="border-b border-gray-200 px-5 py-4">
           <h2 className="text-lg font-bold text-gray-900">입고 내용 수정</h2>
           <p className="mt-1 text-xs text-gray-500">
-            입고 상태와 관계없이 원본 정보를 수정할 수 있습니다. 실제 입고수량은 재고 이력과 연결되어 수정 대상에서 제외됩니다.
+            입고 상태와 관계없이 원본 정보를 수정할 수 있습니다. 실제 입고수량은
+            재고 이력과 연결되어 수정 대상에서 제외됩니다.
           </p>
         </div>
         <div className="space-y-5 p-5">
@@ -4639,9 +4612,7 @@ function PurchaseAdjustmentOverlay({
                     className="w-full"
                     onClick={() => addRow(kind)}
                   >
-                    {kind === "discount"
-                      ? "할인 항목 추가"
-                      : "지불 항목 추가"}
+                    {kind === "discount" ? "할인 항목 추가" : "지불 항목 추가"}
                   </Button>
                 </div>
               </section>
@@ -4747,7 +4718,9 @@ function PurchaseAdjustmentCategoryOverlay({
                         variant="danger"
                         disabled={pending}
                         onClick={() => {
-                          if (window.confirm(`‘${item.name}’ 항목을 삭제할까요?`))
+                          if (
+                            window.confirm(`‘${item.name}’ 항목을 삭제할까요?`)
+                          )
                             void run(
                               () =>
                                 deactivatePurchaseAdjustmentCategory(item.id),
@@ -4841,10 +4814,7 @@ function SupplierManageOverlay({
   const mergeSupplierNote = (homepageUrl: string, note: string) => {
     const cleanUrl = homepageUrl.trim();
     const cleanNote = note.trim();
-    return [
-      cleanUrl ? `[[homepage_url:${cleanUrl}]]` : "",
-      cleanNote,
-    ]
+    return [cleanUrl ? `[[homepage_url:${cleanUrl}]]` : "", cleanNote]
       .filter(Boolean)
       .join("\n");
   };
@@ -4980,24 +4950,24 @@ function SupplierManageOverlay({
         }`}
       >
         {!embedded && (
-        <header className="flex items-center justify-between border-b border-gray-100 px-5 py-4 sm:px-7">
-          <div>
-            <h2 className="text-xl font-bold text-gray-950">거래처 관리</h2>
-            <p className="mt-1 text-sm text-gray-500">
-              입고 주문에 사용할 거래처 정보와 주문 마감 시간을 관리합니다.
-            </p>
-          </div>
-          {!embedded && (
-            <button
-              type="button"
-              aria-label="닫기"
-              onClick={onClose}
-              className="flex h-10 w-10 items-center justify-center rounded-full text-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700"
-            >
-              ×
-            </button>
-          )}
-        </header>
+          <header className="flex items-center justify-between border-b border-gray-100 px-5 py-4 sm:px-7">
+            <div>
+              <h2 className="text-xl font-bold text-gray-950">거래처 관리</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                입고 주문에 사용할 거래처 정보와 주문 마감 시간을 관리합니다.
+              </p>
+            </div>
+            {!embedded && (
+              <button
+                type="button"
+                aria-label="닫기"
+                onClick={onClose}
+                className="flex h-10 w-10 items-center justify-center rounded-full text-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+              >
+                ×
+              </button>
+            )}
+          </header>
         )}
 
         <div className="grid min-h-0 flex-1 overflow-y-auto lg:grid-cols-[340px_1fr] lg:overflow-hidden">
@@ -5287,10 +5257,7 @@ function SupplierManageOverlay({
                   <Button className="hidden" variant="gray" onClick={startNew}>
                     입력 초기화
                   </Button>
-                  <Button
-                    onClick={save}
-                    disabled={saving || !form.name.trim()}
-                  >
+                  <Button onClick={save} disabled={saving || !form.name.trim()}>
                     {saving
                       ? "저장 중..."
                       : selectedId
@@ -5470,17 +5437,44 @@ function MovementHistory({
   ) => {
     if (!movement.counterparty_name) return movement.note || "-";
 
-    if (movement.movement_type === "sale_out") {
-      return `${movement.counterparty_name} 구매`;
-    }
     if (movement.movement_type === "outbound_edit") {
       return `${movement.counterparty_name} 수정`;
     }
     if (movement.movement_type === "outbound_cancel") {
       return `${movement.counterparty_name} 취소`;
     }
-    if (movement.movement_type === "exchange_in") {
-      return `${movement.counterparty_name} 교환`;
+    if (
+      movement.inventory_action === "adjustment_out" ||
+      (movement.counterparty_name.trim() === "재고조정" &&
+        movement.movement_type === "sale_out")
+    ) {
+      return "재고조정 출고";
+    }
+    if (
+      movement.inventory_action === "adjustment_in" ||
+      (movement.counterparty_name.trim() === "재고조정" &&
+        movement.movement_type === "exchange_in")
+    ) {
+      return "재고조정 입고";
+    }
+    if (
+      movement.counterparty_name.trim() === "시연용" ||
+      movement.item_remark?.trim().startsWith("시연용")
+    ) {
+      return "시연용 처리";
+    }
+    if (movement.inventory_action === "exchange_out") {
+      return `${movement.counterparty_name} 교환출고`;
+    }
+    if (
+      movement.inventory_action === "exchange_in" ||
+      movement.movement_type === "exchange_in"
+    ) {
+      return `${movement.counterparty_name} 교환입고`;
+    }
+
+    if (movement.movement_type === "sale_out") {
+      return `${movement.counterparty_name} 구매`;
     }
     if (movement.movement_type === "purchase_in") {
       return `${movement.counterparty_name} 입고`;
@@ -5493,6 +5487,45 @@ function MovementHistory({
     }
     return movement.note || "-";
   };
+  const getMovementTypeLabel = (
+    movement: Awaited<ReturnType<typeof getInventoryMovements>>[number],
+  ) => {
+    if (
+      movement.movement_type === "outbound_edit" ||
+      movement.movement_type === "outbound_cancel" ||
+      movement.movement_type === "reversal"
+    ) {
+      return movementLabels[movement.movement_type];
+    }
+    if (
+      movement.inventory_action === "adjustment_out" ||
+      (movement.counterparty_name?.trim() === "재고조정" &&
+        movement.movement_type === "sale_out")
+    ) {
+      return "출고/조정";
+    }
+    if (
+      movement.inventory_action === "adjustment_in" ||
+      (movement.counterparty_name?.trim() === "재고조정" &&
+        movement.movement_type === "exchange_in")
+    ) {
+      return "입고/조정";
+    }
+    if (
+      movement.counterparty_name?.trim() === "시연용" ||
+      movement.item_remark?.trim().startsWith("시연용")
+    ) {
+      return "출고/시연용";
+    }
+    if (movement.inventory_action === "exchange_out") return "출고/교환";
+    if (
+      movement.inventory_action === "exchange_in" ||
+      movement.movement_type === "exchange_in"
+    ) {
+      return "입고/교환";
+    }
+    return movementLabels[movement.movement_type] ?? movement.movement_type;
+  };
   const automaticNotes = new Set([
     "출고 처리",
     "출고 수정",
@@ -5503,14 +5536,10 @@ function MovementHistory({
     note && !automaticNotes.has(note.trim()) ? note : "-";
   const dateFilteredMovements = movements.filter((movement) => {
     const date = localDate(movement.created_at);
-    return (
-      dateMode === "today"
-        ? date === today
-        : Boolean(startDate) &&
-          (endDate
-            ? date >= startDate && date <= endDate
-            : date === startDate)
-    );
+    return dateMode === "today"
+      ? date === today
+      : Boolean(startDate) &&
+          (endDate ? date >= startDate && date <= endDate : date === startDate);
   });
   const filtered = dateFilteredMovements.filter((movement) => {
     const keyword = search.trim().toLocaleLowerCase("ko-KR");
@@ -5649,123 +5678,124 @@ function MovementHistory({
         </span>
       </div>
       <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
-      {loading ? (
-        <Loading size="sm" text="이력을 불러오는 중..." />
-      ) : (
-        <div className="mt-3 overflow-auto rounded-xl border border-gray-200">
-          <table className="w-full min-w-[850px] border-collapse text-sm">
-            <thead className="bg-brand-50 text-brand-700">
-              <tr>
-                {[
-                  "처리일",
-                  "구분",
-                  "품목명",
-                  "변동",
-                  "처리 후",
-                  "단가",
-                  "이동 경로",
-                  "메모",
-                  "관리",
-                ].map((label) => (
-                  <th
-                    key={label}
-                    className="border border-brand-200 px-3 py-3 text-left"
-                  >
-                    {label}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {visibleMovements.length ? (
-                visibleMovements.map((movement) => (
-                  <tr key={movement.id}>
-                    <td className="whitespace-nowrap border border-gray-200 px-3 py-3">
-                      {new Date(movement.created_at).toLocaleString("ko-KR")}
-                    </td>
-                    <td className="border border-gray-200 px-3 py-3">
-                      {movementLabels[movement.movement_type] ??
-                        movement.movement_type}
-                    </td>
-                    <td className="border border-gray-200 px-3 py-3 font-semibold">
-                      {movement.item_name}
-                    </td>
-                    <td
-                      className={`border border-gray-200 px-3 py-3 text-right font-bold ${movement.quantity_delta > 0 ? "text-blue-600" : "text-rose-600"}`}
+        {loading ? (
+          <Loading size="sm" text="이력을 불러오는 중..." />
+        ) : (
+          <div className="mt-3 overflow-auto rounded-xl border border-gray-200">
+            <table className="w-full min-w-[850px] border-collapse text-sm">
+              <thead className="bg-brand-50 text-brand-700">
+                <tr>
+                  {[
+                    "처리일",
+                    "구분",
+                    "품목명",
+                    "변동",
+                    "처리 후",
+                    "단가",
+                    "이동 경로",
+                    "메모",
+                    "관리",
+                  ].map((label) => (
+                    <th
+                      key={label}
+                      className="border border-brand-200 px-3 py-3 text-left"
                     >
-                      {movement.quantity_delta > 0 ? "+" : ""}
-                      {movement.quantity_delta}
-                    </td>
-                    <td className="border border-gray-200 px-3 py-3 text-right">
-                      {movement.quantity_after}
-                    </td>
-                    <td className="border border-gray-200 px-3 py-3 text-right">
-                      {movement.unit_price != null
-                        ? `${movement.unit_price.toLocaleString()}원`
-                        : "-"}
-                    </td>
-                    <td className="whitespace-nowrap border border-gray-200 px-3 py-3 font-medium">
-                      {movement.counterparty_id ? (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            router.push(`/customers/${movement.counterparty_id}`)
-                          }
-                          className="font-semibold text-brand-700 underline decoration-brand-200 underline-offset-4 hover:text-brand-800 hover:decoration-brand-500"
-                        >
-                          {getMovementRoute(movement)}
-                        </button>
-                      ) : movement.purchase_order_id ? (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            onOpenPurchaseOrder(movement.purchase_order_id!)
-                          }
-                          className="font-semibold text-brand-700 underline decoration-brand-200 underline-offset-4 hover:text-brand-800 hover:decoration-brand-500"
-                        >
-                          {getMovementRoute(movement)}
-                        </button>
-                      ) : (
-                        <span className="text-gray-700">
-                          {getMovementRoute(movement)}
-                        </span>
-                      )}
-                    </td>
-                    <td className="border border-gray-200 px-3 py-3 text-gray-500">
-                      {getDetailMemo(movement.note)}
-                    </td>
-                    <td className="border border-gray-200 px-3 py-3">
-                      {isAdmin &&
-                        movement.movement_type === "purchase_in" &&
-                        movement.reference_type === "purchase_receipt" &&
-                        movement.reference_id &&
-                        !reversedIds.has(movement.id) && (
-                          <Button
-                            size="xs"
-                            variant="danger"
-                            onClick={() => setMovementToReverse(movement)}
-                            disabled={reverseMutation.isPending}
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {visibleMovements.length ? (
+                  visibleMovements.map((movement) => (
+                    <tr key={movement.id}>
+                      <td className="whitespace-nowrap border border-gray-200 px-3 py-3">
+                        {new Date(movement.created_at).toLocaleString("ko-KR")}
+                      </td>
+                      <td className="border border-gray-200 px-3 py-3">
+                        {getMovementTypeLabel(movement)}
+                      </td>
+                      <td className="border border-gray-200 px-3 py-3 font-semibold">
+                        {movement.item_name}
+                      </td>
+                      <td
+                        className={`border border-gray-200 px-3 py-3 text-right font-bold ${movement.quantity_delta > 0 ? "text-blue-600" : "text-rose-600"}`}
+                      >
+                        {movement.quantity_delta > 0 ? "+" : ""}
+                        {movement.quantity_delta}
+                      </td>
+                      <td className="border border-gray-200 px-3 py-3 text-right">
+                        {movement.quantity_after}
+                      </td>
+                      <td className="border border-gray-200 px-3 py-3 text-right">
+                        {movement.unit_price != null
+                          ? `${movement.unit_price.toLocaleString()}원`
+                          : "-"}
+                      </td>
+                      <td className="whitespace-nowrap border border-gray-200 px-3 py-3 font-medium">
+                        {movement.counterparty_id ? (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              router.push(
+                                `/customers/${movement.counterparty_id}`,
+                              )
+                            }
+                            className="font-semibold text-brand-700 underline decoration-brand-200 underline-offset-4 hover:text-brand-800 hover:decoration-brand-500"
                           >
-                            입고 취소
-                          </Button>
+                            {getMovementRoute(movement)}
+                          </button>
+                        ) : movement.purchase_order_id ? (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              onOpenPurchaseOrder(movement.purchase_order_id!)
+                            }
+                            className="font-semibold text-brand-700 underline decoration-brand-200 underline-offset-4 hover:text-brand-800 hover:decoration-brand-500"
+                          >
+                            {getMovementRoute(movement)}
+                          </button>
+                        ) : (
+                          <span className="text-gray-700">
+                            {getMovementRoute(movement)}
+                          </span>
                         )}
+                      </td>
+                      <td className="border border-gray-200 px-3 py-3 text-gray-500">
+                        {getDetailMemo(movement.note)}
+                      </td>
+                      <td className="border border-gray-200 px-3 py-3">
+                        {isAdmin &&
+                          movement.movement_type === "purchase_in" &&
+                          movement.reference_type === "purchase_receipt" &&
+                          movement.reference_id &&
+                          !reversedIds.has(movement.id) && (
+                            <Button
+                              size="xs"
+                              variant="danger"
+                              onClick={() => setMovementToReverse(movement)}
+                              disabled={reverseMutation.isPending}
+                            >
+                              입고 취소
+                            </Button>
+                          )}
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td
+                      colSpan={9}
+                      className="px-4 py-12 text-center text-gray-400"
+                    >
+                      조건에 맞는 재고 변동이 없습니다.
                     </td>
                   </tr>
-                ))
-              ) : (
-                <tr>
-                  <td
-                    colSpan={9}
-                    className="px-4 py-12 text-center text-gray-400"
-                  >
-                    조건에 맞는 재고 변동이 없습니다.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      )}
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
         {visibleCount < filtered.length && (
           <div className="mt-4 flex justify-center">
             <button
@@ -5970,77 +6000,6 @@ function TrackingSettingsOverlay({
           </Button>
         </footer>
       </section>
-    </div>
-  );
-}
-
-function AdjustmentOverlay({
-  item,
-  onClose,
-  onSaved,
-}: {
-  item: InventoryItem;
-  onClose: () => void;
-  onSaved: () => Promise<void>;
-}) {
-  const [quantity, setQuantity] = useState(String(item.quantity));
-  const [note, setNote] = useState("");
-  const mutation = useMutation({
-    mutationFn: () => adjustInventory(item.item_name, Number(quantity), note),
-    onSuccess: async () => {
-      toast.success("재고를 조정했습니다.");
-      await onSaved();
-    },
-    onError: (error) =>
-      toast.error(error.message || "재고 조정에 실패했습니다."),
-  });
-  return (
-    <div
-      className="fixed inset-0 z-[90] flex items-center justify-center bg-gray-950/50 p-4"
-      onPointerDown={(event) =>
-        event.target === event.currentTarget && onClose()
-      }
-    >
-      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl">
-        <h2 className="text-lg font-semibold">재고 조정</h2>
-        <p className="mt-1 text-sm text-gray-500">
-          {item.item_name} · 현재 {item.quantity}개
-        </p>
-        <label className="mt-5 block text-sm font-medium">
-          실제 재고 수량
-          <input
-            type="number"
-            inputMode="numeric"
-            value={quantity}
-            onChange={(event) => setQuantity(event.target.value)}
-            className="mt-2 min-h-12 w-full rounded-lg border border-gray-200 px-4 text-right text-lg font-bold"
-          />
-        </label>
-        <label className="mt-4 block text-sm font-medium">
-          조정 사유
-          <textarea
-            value={note}
-            onChange={(event) => setNote(event.target.value)}
-            className="mt-2 h-24 w-full resize-none rounded-lg border border-gray-200 p-3 text-sm"
-            placeholder="재고 실사, 파손 확인 등"
-          />
-        </label>
-        <div className="mt-5 flex justify-end gap-2">
-          <Button variant="gray" onClick={onClose}>
-            취소
-          </Button>
-          <Button
-            onClick={() => mutation.mutate()}
-            disabled={
-              !note.trim() ||
-              !Number.isInteger(Number(quantity)) ||
-              mutation.isPending
-            }
-          >
-            조정 저장
-          </Button>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/app/(auth)/work-journal/_components/AttendanceRecordModal.tsx
+++ b/src/app/(auth)/work-journal/_components/AttendanceRecordModal.tsx
@@ -31,6 +31,14 @@ const getCurrentTimeInKorea = () =>
     hour12: false,
   }).format(new Date());
 
+const formatKoreanTime = (time: string) => {
+  const [hourText, minute = "00"] = time.split(":");
+  const hour = Number(hourText);
+  if (!Number.isFinite(hour)) return time;
+  const period = hour < 12 ? "오전" : "오후";
+  return `${period} ${hour % 12 || 12}:${minute}`;
+};
+
 const getCreatedTimeInKorea = (createdAt?: string) => {
   if (!createdAt) return getCurrentTimeInKorea();
   const date = new Date(createdAt);
@@ -70,16 +78,13 @@ export default function AttendanceRecordModal({
     editingJournal && editingJournal.work_date < today,
   );
   const initialMode =
-    editingJournal &&
-    (editingJournal.status !== "working" || isPastJournal)
+    editingJournal && (editingJournal.status !== "working" || isPastJournal)
       ? "end"
       : editingJournal
         ? "start"
         : "";
   const [step, setStep] = useState<1 | 2>(editingJournal ? 2 : 1);
-  const [workDate, setWorkDate] = useState(
-    editingJournal?.work_date ?? today,
-  );
+  const [workDate, setWorkDate] = useState(editingJournal?.work_date ?? today);
   const [workerName, setWorkerName] = useState(
     editingJournal?.worker_name ?? "",
   );
@@ -87,7 +92,7 @@ export default function AttendanceRecordModal({
   const [verified, setVerified] = useState(Boolean(editingJournal));
   const [mode, setMode] = useState<"start" | "end" | "">(initialMode);
   const [startTime, setStartTime] = useState(
-    editingJournal?.start_time.slice(0, 5) ?? getCurrentTimeInKorea(),
+    editingJournal?.start_time.slice(0, 5) ?? "11:00",
   );
   const [actualStartTime, setActualStartTime] = useState(() =>
     getCreatedTimeInKorea(editingJournal?.created_at),
@@ -101,7 +106,10 @@ export default function AttendanceRecordModal({
     editingJournal?.end_time.slice(0, 5) ?? getCurrentTimeInKorea(),
   );
   const [workType, setWorkType] = useState<"solo" | "shift">(
-    editingJournal?.work_type ?? "solo",
+    editingJournal?.work_type ?? "shift",
+  );
+  const [startType, setStartType] = useState<"solo" | "first" | "handover">(
+    editingJournal?.work_type === "shift" ? "first" : "solo",
   );
   const [note, setNote] = useState(editingJournal?.note ?? "");
   const initialInputWorkHours = Number(editingJournal?.input_work_hours ?? 0);
@@ -116,20 +124,17 @@ export default function AttendanceRecordModal({
   });
   const selectedJournal = useMemo(
     () =>
-      journalsQuery.data?.find(
-        (journal) => journal.worker_name === workerName,
-      ),
+      journalsQuery.data?.find((journal) => journal.worker_name === workerName),
     [journalsQuery.data, workerName],
   );
-  const previousJournal = useMemo(
-    () =>
-      [...(journalsQuery.data ?? [])]
-        .filter((journal) => journal.worker_name !== workerName)
-        .sort((a, b) => b.start_time.localeCompare(a.start_time))[0],
-    [journalsQuery.data, workerName],
+  const isHandoverWorker = Boolean(
+    journalsQuery.data?.some(
+      (journal) =>
+        journal.worker_name !== workerName &&
+        (journal.status === "handover_pending" ||
+          (Boolean(editingJournal) && journal.start_time < startTime)),
+    ),
   );
-  const isShiftRequired =
-    !editingJournal && previousJournal?.work_type === "shift";
   const openJournal =
     selectedJournal && selectedJournal.status === "working"
       ? selectedJournal
@@ -190,7 +195,7 @@ export default function AttendanceRecordModal({
         endTime: expectedEndTime,
         workHours: calculateHours(startTime, expectedEndTime),
         note,
-        workType,
+        workType: startType === "first" ? "shift" : "solo",
         pin,
       }),
     onSuccess: async () => {
@@ -219,6 +224,7 @@ export default function AttendanceRecordModal({
         workerName,
         pin,
         actualEndTime: confirmedEndTime,
+        inputEndTime: expectedEndTime,
         workHours: calculateHours(
           openJournal.start_time.slice(0, 5),
           confirmedEndTime,
@@ -228,11 +234,13 @@ export default function AttendanceRecordModal({
         workType: openJournal.work_type ?? "solo",
       });
     },
-    onSuccess: async () => {
+    onSuccess: async (status) => {
       toast.success(
-        openJournal?.work_type === "shift"
-          ? "퇴근 기록을 저장하고 인수인계 대기로 전환했습니다."
-          : "퇴근 기록을 확정했습니다.",
+        status === "shift_completed"
+          ? "후속 근무자를 확인하여 교대 완료 처리했습니다."
+          : status === "handover_pending"
+            ? "퇴근 기록을 저장하고 인수인계 대기로 전환했습니다."
+            : "퇴근 기록을 확정했습니다.",
       );
       await onSaved();
       onClose();
@@ -266,10 +274,14 @@ export default function AttendanceRecordModal({
           status !== "working"
             ? checkoutHours
             : calculateHours(startTime, expectedEndTime),
-        inputWorkHours:
-          status !== "working" ? Number(inputWorkHours) : null,
+        inputWorkHours: status !== "working" ? Number(inputWorkHours) : null,
         note,
-        workType,
+        workType:
+          mode === "start"
+            ? startType === "first"
+              ? "shift"
+              : "solo"
+            : workType,
         status,
         actualStartTime: isAdmin ? actualStartTime : undefined,
       });
@@ -296,10 +308,7 @@ export default function AttendanceRecordModal({
     if (nextMode === "end" && openJournal) {
       setStartTime(openJournal.start_time.slice(0, 5));
       setActualStartTime(getCreatedTimeInKorea(openJournal.created_at));
-      setExpectedEndTime(
-        openJournal.expected_end_time?.slice(0, 5) ||
-          openJournal.end_time.slice(0, 5),
-      );
+      setExpectedEndTime("22:00");
       setWorkType(openJournal.work_type ?? "solo");
       setNote(openJournal.note ?? "");
       const currentTime = getCurrentTimeInKorea();
@@ -309,20 +318,27 @@ export default function AttendanceRecordModal({
   };
 
   const canContinue = verified && Boolean(mode);
-  const canConfirmStart = Boolean(startTime && expectedEndTime);
+  const canConfirmStart = Boolean(startTime);
   const canConfirmEnd = Boolean(
     actualEndTime &&
-      checkoutHours > 0 &&
-      Number.isFinite(Number(inputWorkHours)) &&
-      Number(inputWorkHours) > 0 &&
-      Number(inputWorkHours) <= 24,
+    checkoutHours > 0 &&
+    Number.isFinite(Number(inputWorkHours)) &&
+    Number(inputWorkHours) > 0 &&
+    Number(inputWorkHours) <= 24,
   );
 
+  const handleStartTypeChange = (nextType: "solo" | "first" | "handover") => {
+    setStartType(nextType);
+    setStartTime(nextType === "handover" ? "17:00" : "11:00");
+  };
+
   useEffect(() => {
-    if (mode === "start" && isShiftRequired) {
-      setWorkType("shift");
+    if (mode === "start" && !editingJournal && journalsQuery.isSuccess) {
+      const nextType = isHandoverWorker ? "handover" : "solo";
+      setStartType(nextType);
+      setStartTime(nextType === "handover" ? "17:00" : "11:00");
     }
-  }, [isShiftRequired, mode]);
+  }, [editingJournal, isHandoverWorker, journalsQuery.isSuccess, mode]);
 
   return (
     <div className="fixed inset-0 z-[140] flex items-center justify-center bg-gray-950/50 p-3 sm:p-6">
@@ -439,9 +455,7 @@ export default function AttendanceRecordModal({
                     maxLength={4}
                     value={pin}
                     onChange={(event) => {
-                      setPin(
-                        event.target.value.replace(/\D/g, "").slice(0, 4),
-                      );
+                      setPin(event.target.value.replace(/\D/g, "").slice(0, 4));
                       resetVerification();
                     }}
                     placeholder="4자리"
@@ -495,47 +509,41 @@ export default function AttendanceRecordModal({
           ) : mode === "start" ? (
             <div className="space-y-4">
               <div className="grid gap-3 sm:grid-cols-2">
-                {isAdmin && isEditing ? (
+                {isAdmin && isEditing && (
                   <TimeField
-                    label="실제 출근시간"
+                    label="출근 처리"
                     value={actualStartTime}
                     onChange={setActualStartTime}
                   />
-                ) : (
-                  <ReadOnlyField
-                    label="실제 출근시간"
-                    value={actualStartTime}
-                  />
                 )}
                 <TimeField
-                  label="입력 출근시간"
+                  label="출근시간 입력"
                   value={startTime}
                   onChange={setStartTime}
                 />
-                <TimeField
-                  label="예상 퇴근시간"
-                  value={expectedEndTime}
-                  onChange={setExpectedEndTime}
-                />
               </div>
               <label className="block text-sm font-semibold text-gray-700">
-                근무 유형
+                출근 유형
                 <select
-                  value={workType}
-                  disabled={isShiftRequired}
+                  value={startType}
                   onChange={(event) =>
-                    setWorkType(event.target.value as "solo" | "shift")
+                    handleStartTypeChange(
+                      event.target.value as "solo" | "first" | "handover",
+                    )
                   }
-                  className="mt-1 h-11 w-full cursor-pointer rounded-lg border border-gray-300 bg-white px-3 outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-700"
+                  className="mt-1 h-11 w-full cursor-pointer rounded-lg border border-gray-300 bg-white px-3 outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
                 >
                   <option value="solo">혼자 근무</option>
-                  <option value="shift">교대 근무</option>
+                  <option value="first">교대 근무자 (첫 근무)</option>
+                  <option value="handover">교대 근무자 (마지막 근무)</option>
                 </select>
-                {isShiftRequired && (
-                  <span className="mt-1.5 block text-xs font-medium text-brand-600">
-                    이전 근무자가 교대 근무로 등록하여 자동으로 고정됩니다.
-                  </span>
-                )}
+                <span className="mt-1.5 block text-xs font-medium text-gray-600">
+                  {startType === "first"
+                    ? "퇴근하면 다음 근무자의 출근을 기다립니다."
+                    : startType === "handover"
+                      ? "이전 근무자의 인수인계를 받고, 퇴근하면 바로 종료됩니다."
+                      : "교대 없이 근무하며, 퇴근하면 바로 종료됩니다."}
+                </span>
               </label>
               <NoteField value={note} onChange={setNote} />
             </div>
@@ -543,47 +551,40 @@ export default function AttendanceRecordModal({
             <div className="space-y-4">
               {isAdmin && isEditing && (
                 <p className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700">
-                  관리자 보정 모드입니다. 실제 출근·퇴근시간과 입력
-                  근무시간을 수정하면 실제 근무시간이 자동 계산됩니다.
+                  관리자 보정 모드입니다. 출근·퇴근 처리시각과 입력 근무시간을
+                  수정하면 실제 근무시간이 자동 계산됩니다.
                 </p>
               )}
               <div className="grid gap-3 sm:grid-cols-2">
-                {isAdmin && isEditing ? (
+                {isAdmin && isEditing && (
                   <TimeField
-                    label="실제 출근시간"
+                    label="출근 처리"
                     value={actualStartTime}
                     onChange={setActualStartTime}
-                  />
-                ) : (
-                  <ReadOnlyField
-                    label="실제 출근시간"
-                    value={actualStartTime}
                   />
                 )}
                 <ReadOnlyField
                   label="입력 출근시간"
-                  value={startTime}
+                  value={formatKoreanTime(startTime)}
                 />
-                <ReadOnlyField
-                  label="예상 퇴근시간"
+                <TimeField
+                  label="퇴근시간 입력"
                   value={expectedEndTime}
+                  onChange={setExpectedEndTime}
                 />
-                {isAdmin && isEditing ? (
+                {isAdmin && isEditing && (
                   <TimeField
-                    label="실제 퇴근시간"
+                    label="퇴근 처리"
                     value={actualEndTime}
                     onChange={setActualEndTime}
                   />
-                ) : (
+                )}
+                {isAdmin && isEditing && (
                   <ReadOnlyField
-                    label="실제 퇴근시간"
-                    value={actualEndTime}
+                    label="실제 근무시간"
+                    value={`${checkoutHours}시간`}
                   />
                 )}
-                <ReadOnlyField
-                  label="실제 근무시간"
-                  value={`${checkoutHours}시간`}
-                />
                 <label className="block text-sm font-semibold text-gray-700 sm:col-span-2">
                   입력 근무시간
                   <div className="relative mt-1">
@@ -593,6 +594,7 @@ export default function AttendanceRecordModal({
                       max="24"
                       step="0.01"
                       value={inputWorkHours}
+                      placeholder="1시간 단위로 입력해주세요."
                       onChange={(event) =>
                         setInputWorkHours(event.target.value)
                       }
@@ -607,7 +609,8 @@ export default function AttendanceRecordModal({
               <NoteField value={note} onChange={setNote} />
               {workType === "shift" && (
                 <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700">
-                  교대 근무 퇴근 전에는 시재 확인과 인수인계 내용을 확인해 주세요.
+                  교대 근무 퇴근 전에는 시재 확인과 인수인계 내용을 확인해
+                  주세요.
                 </p>
               )}
             </div>
@@ -625,10 +628,7 @@ export default function AttendanceRecordModal({
             </Button>
           )}
           {step === 1 ? (
-            <Button
-              onClick={() => setStep(2)}
-              disabled={!canContinue}
-            >
+            <Button onClick={() => setStep(2)} disabled={!canContinue}>
               다음
             </Button>
           ) : isEditing ? (

--- a/src/app/(auth)/work-journal/page.tsx
+++ b/src/app/(auth)/work-journal/page.tsx
@@ -46,7 +46,134 @@ const formatHours = (hours: number) =>
     : `${hours.toFixed(2).replace(/0+$/, "")}시간`;
 
 const getPayableHours = (journal: WorkJournalType) =>
-  Number(journal.input_work_hours ?? journal.work_hours);
+  Number(journal.input_work_hours ?? 0);
+
+type WorkJournalColumnKey =
+  | "date"
+  | "worker"
+  | "status"
+  | "checkIn"
+  | "checkOut"
+  | "actualHours"
+  | "inputStart"
+  | "expectedEnd"
+  | "inputHours"
+  | "note"
+  | "actions";
+
+const defaultWorkJournalColumnWidths: Record<WorkJournalColumnKey, number> = {
+  date: 180,
+  worker: 100,
+  status: 105,
+  checkIn: 100,
+  checkOut: 100,
+  actualHours: 120,
+  inputStart: 100,
+  expectedEnd: 110,
+  inputHours: 120,
+  note: 220,
+  actions: 190,
+};
+
+const workJournalColumnKeys = Object.keys(
+  defaultWorkJournalColumnWidths,
+) as WorkJournalColumnKey[];
+
+const loadWorkJournalColumnWidths = (role: "admin" | "staff") => {
+  if (typeof window === "undefined")
+    return { ...defaultWorkJournalColumnWidths };
+  try {
+    const saved = JSON.parse(
+      window.localStorage.getItem(`work-journal-column-widths-${role}`) ?? "{}",
+    ) as Partial<Record<WorkJournalColumnKey, number>>;
+    return Object.fromEntries(
+      workJournalColumnKeys.map((key) => [
+        key,
+        Math.min(
+          360,
+          Math.max(
+            70,
+            Number(saved[key]) || defaultWorkJournalColumnWidths[key],
+          ),
+        ),
+      ]),
+    ) as Record<WorkJournalColumnKey, number>;
+  } catch {
+    return { ...defaultWorkJournalColumnWidths };
+  }
+};
+
+function ResizableWorkJournalHeader({
+  label,
+  width,
+  onResize,
+  editable,
+  align = "left",
+}: {
+  label: string;
+  width: number;
+  onResize: (width: number) => void;
+  editable: boolean;
+  align?: "left" | "right" | "center";
+}) {
+  const drag = useRef<{ x: number; width: number } | null>(null);
+  return (
+    <th
+      className={`relative select-none px-3 py-2.5 ${
+        align === "right"
+          ? "text-right"
+          : align === "center"
+            ? "text-center"
+            : "text-left"
+      }`}
+      style={{ width }}
+    >
+      {label}
+      {editable && (
+        <button
+          type="button"
+          aria-label={`${label} 열 너비 조절`}
+          title="좌우로 드래그해 열 너비 조절"
+          onPointerDown={(event) => {
+            drag.current = { x: event.clientX, width };
+            event.currentTarget.setPointerCapture(event.pointerId);
+          }}
+          onPointerMove={(event) => {
+            if (!drag.current) return;
+            onResize(
+              Math.min(
+                360,
+                Math.max(
+                  70,
+                  drag.current.width + event.clientX - drag.current.x,
+                ),
+              ),
+            );
+          }}
+          onPointerUp={(event) => {
+            drag.current = null;
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }}
+          className="group absolute -right-1.5 top-0 z-10 flex h-full w-5 cursor-col-resize touch-none items-center justify-center pr-1"
+        >
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="h-4 w-4 text-brand-200 transition-colors group-hover:text-brand-500"
+          >
+            <circle cx="9" cy="6" r="1.6" />
+            <circle cx="15" cy="6" r="1.6" />
+            <circle cx="9" cy="12" r="1.6" />
+            <circle cx="15" cy="12" r="1.6" />
+            <circle cx="9" cy="18" r="1.6" />
+            <circle cx="15" cy="18" r="1.6" />
+          </svg>
+        </button>
+      )}
+    </th>
+  );
+}
 
 const formatKoreanDate = (date: string) => {
   if (!date) return "";
@@ -74,13 +201,21 @@ export default function WorkJournalPage() {
   const queryClient = useQueryClient();
   const { isAdmin } = useUser();
   const today = getTodayInKorea();
-  const [activeTab, setActiveTab] = useState<
-    "records" | "payment" | "workers"
-  >("records");
+  const [activeTab, setActiveTab] = useState<"records" | "payment" | "workers">(
+    "records",
+  );
   const [tabOrder, setTabOrder] = useState<
     ("records" | "workers" | "payment")[]
   >(["records", "workers", "payment"]);
   const [editingTabOrder, setEditingTabOrder] = useState(false);
+  const [columnEditing, setColumnEditing] = useState(false);
+  const [columnWidthSnapshot, setColumnWidthSnapshot] = useState<Record<
+    WorkJournalColumnKey,
+    number
+  > | null>(null);
+  const [columnWidths, setColumnWidths] = useState(() =>
+    loadWorkJournalColumnWidths(isAdmin ? "admin" : "staff"),
+  );
   const [showWorkForm, setShowWorkForm] = useState(false);
   const [recordWorkerName, setRecordWorkerName] = useState("");
   const [recordWorkerPin, setRecordWorkerPin] = useState("");
@@ -104,17 +239,54 @@ export default function WorkJournalPage() {
   const [editingJournalId, setEditingJournalId] = useState("");
 
   useEffect(() => {
+    setColumnWidths(loadWorkJournalColumnWidths(isAdmin ? "admin" : "staff"));
+    setColumnWidthSnapshot(null);
+    setColumnEditing(false);
+  }, [isAdmin]);
+
+  const resizeColumn = (key: WorkJournalColumnKey, width: number) => {
+    setColumnWidths((current) => ({
+      ...current,
+      [key]: Math.round(width),
+    }));
+  };
+  const startColumnEditing = () => {
+    setColumnWidthSnapshot({ ...columnWidths });
+    setColumnEditing(true);
+  };
+  const saveColumnWidths = () => {
+    window.localStorage.setItem(
+      `work-journal-column-widths-${isAdmin ? "admin" : "staff"}`,
+      JSON.stringify(columnWidths),
+    );
+    setColumnWidthSnapshot(null);
+    setColumnEditing(false);
+  };
+  const cancelColumnEditing = () => {
+    if (columnWidthSnapshot) setColumnWidths(columnWidthSnapshot);
+    setColumnWidthSnapshot(null);
+    setColumnEditing(false);
+  };
+  const visibleWorkJournalColumnKeys = isAdmin
+    ? workJournalColumnKeys
+    : workJournalColumnKeys.filter(
+        (key) => !["checkIn", "checkOut", "actualHours"].includes(key),
+      );
+  const workJournalTableWidth = visibleWorkJournalColumnKeys.reduce(
+    (sum, key) => sum + columnWidths[key],
+    0,
+  );
+
+  useEffect(() => {
     const saved = window.localStorage.getItem("work-journal-tab-order");
     if (!saved) return;
     try {
-      const parsed = JSON.parse(saved) as (
-        | "records"
-        | "workers"
-        | "payment"
-      )[];
+      const parsed = JSON.parse(saved) as ("records" | "workers" | "payment")[];
       if (
         parsed.length === 3 &&
-        ["records", "workers", "payment"].every((tab) => parsed.includes(tab as "records" | "workers" | "payment"))
+        ["records", "workers", "payment"].every((tab) =>
+          parsed.includes(tab as "records" | "workers" | "payment"),
+        )
       ) {
         setTabOrder(parsed);
       }
@@ -169,7 +341,7 @@ export default function WorkJournalPage() {
   const summary = useMemo(() => {
     const journals = journalsQuery.data ?? [];
     const totalHours = journals.reduce(
-      (sum, journal) => sum + Number(journal.work_hours),
+      (sum, journal) => sum + Number(journal.input_work_hours ?? 0),
       0,
     );
     return {
@@ -459,7 +631,11 @@ export default function WorkJournalPage() {
     <main className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6 lg:px-8">
       <StaffOpeningProgressBanner />
       <div className="flex items-end justify-between border-b border-gray-200">
-        <div className="flex min-w-0 overflow-x-auto" role="tablist" aria-label="근무기록 메뉴">
+        <div
+          className="flex min-w-0 overflow-x-auto"
+          role="tablist"
+          aria-label="근무기록 메뉴"
+        >
           {tabOrder.map((tab, index) => {
             if (!isAdmin && tab !== "records") return null;
             const label =
@@ -509,21 +685,34 @@ export default function WorkJournalPage() {
             );
           })}
         </div>
-        {isAdmin && <button
-          type="button"
-          onClick={() => setEditingTabOrder((current) => !current)}
-          className={`mb-2 ml-3 flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border bg-white transition ${
-            editingTabOrder
-              ? "border-brand-300 text-brand-700 shadow-sm"
-              : "border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700"
-          }`}
-          aria-label={editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"}
-          title={editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"}
-        >
-          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z" />
-          </svg>
-        </button>}
+        {isAdmin && (
+          <button
+            type="button"
+            onClick={() => setEditingTabOrder((current) => !current)}
+            className={`mb-2 ml-3 flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border bg-white transition ${
+              editingTabOrder
+                ? "border-brand-300 text-brand-700 shadow-sm"
+                : "border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700"
+            }`}
+            aria-label={editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"}
+            title={editingTabOrder ? "탭 순서 변경 완료" : "탭 순서 변경"}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.8}
+                d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z"
+              />
+            </svg>
+          </button>
+        )}
       </div>
 
       {activeTab === "workers" && isAdmin && (
@@ -602,33 +791,33 @@ export default function WorkJournalPage() {
                 <Dropdown.Trigger compact>
                   {recordWorkerName || "선택"}
                 </Dropdown.Trigger>
-                 <Dropdown.Content compact>
-                   {isAdmin && (
-                     <Dropdown.Item
-                       option={{ value: "전체", label: "전체" }}
-                       compact
-                       onSelect={(selected: DropdownOption) => {
-                         const selectedName = String(selected.value);
-                         setRecordWorkerName(selectedName);
-                         setRecordWorkerPin("");
-                         setVerifiedWorkerName(selectedName);
-                         setViewMode("month");
-                         setSelectedMonth(today.slice(0, 7));
-                         setStartDate(`${today.slice(0, 7)}-01`);
-                         setEndDate(today);
-                       }}
-                     />
-                   )}
-                   {(workersQuery.data ?? []).map((name) => (
+                <Dropdown.Content compact>
+                  {isAdmin && (
+                    <Dropdown.Item
+                      option={{ value: "전체", label: "전체" }}
+                      compact
+                      onSelect={(selected: DropdownOption) => {
+                        const selectedName = String(selected.value);
+                        setRecordWorkerName(selectedName);
+                        setRecordWorkerPin("");
+                        setVerifiedWorkerName(selectedName);
+                        setViewMode("month");
+                        setSelectedMonth(today.slice(0, 7));
+                        setStartDate(`${today.slice(0, 7)}-01`);
+                        setEndDate(today);
+                      }}
+                    />
+                  )}
+                  {(workersQuery.data ?? []).map((name) => (
                     <Dropdown.Item
                       key={name}
                       option={{ value: name, label: name }}
                       compact
-                       onSelect={(selected: DropdownOption) => {
-                         const selectedName = String(selected.value);
-                         setRecordWorkerName(selectedName);
-                         setRecordWorkerPin("");
-                         setVerifiedWorkerName(isAdmin ? selectedName : "");
+                      onSelect={(selected: DropdownOption) => {
+                        const selectedName = String(selected.value);
+                        setRecordWorkerName(selectedName);
+                        setRecordWorkerPin("");
+                        setVerifiedWorkerName(isAdmin ? selectedName : "");
                         setViewMode("month");
                         setSelectedMonth(today.slice(0, 7));
                         setStartDate(`${today.slice(0, 7)}-01`);
@@ -714,7 +903,8 @@ export default function WorkJournalPage() {
                           option={option}
                           compact
                           onSelect={(selected: DropdownOption) => {
-                            const nextMode = selected.value as "month" | "range";
+                            const nextMode = selected.value as
+                              "month" | "range";
                             setViewMode(nextMode);
                             if (nextMode === "month") {
                               setSelectedMonth(today.slice(0, 7));
@@ -810,7 +1000,9 @@ export default function WorkJournalPage() {
                   value={workerPin}
                   disabled={Boolean(editingJournalId)}
                   onChange={(event) =>
-                    setWorkerPin(event.target.value.replace(/\D/g, "").slice(0, 4))
+                    setWorkerPin(
+                      event.target.value.replace(/\D/g, "").slice(0, 4),
+                    )
                   }
                   className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-center text-sm outline-none focus:border-brand-400 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100"
                   placeholder="4자리"
@@ -892,9 +1084,9 @@ export default function WorkJournalPage() {
           isAdmin={isAdmin}
           editingJournal={
             editingJournalId
-              ? journalsQuery.data?.find(
+              ? (journalsQuery.data?.find(
                   (journal) => journal.id === editingJournalId,
-                ) ?? null
+                ) ?? null)
               : null
           }
           onClose={() => {
@@ -903,7 +1095,9 @@ export default function WorkJournalPage() {
           }}
           onSaved={async () => {
             await Promise.all([
-              queryClient.invalidateQueries({ queryKey: workJournalKeys.all() }),
+              queryClient.invalidateQueries({
+                queryKey: workJournalKeys.all(),
+              }),
               queryClient.invalidateQueries({
                 queryKey: workJournalKeys.workers(),
               }),
@@ -922,161 +1116,299 @@ export default function WorkJournalPage() {
             </div>
           ) : (
             <>
-          {viewMode === "range" && startDate > endDate && (
-            <p className="mb-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">
-              종료 날짜는 시작 날짜보다 빠를 수 없습니다.
-            </p>
-          )}
+              {viewMode === "range" && startDate > endDate && (
+                <p className="mb-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">
+                  종료 날짜는 시작 날짜보다 빠를 수 없습니다.
+                </p>
+              )}
 
-          <div className="mb-5 grid gap-3 sm:grid-cols-2">
-            <SummaryCard
-              label="총 근무시간"
-              value={formatHours(summary.totalHours)}
-            />
-            <SummaryCard
-              label="출근 횟수"
-              value={`${summary.attendanceCount}회`}
-            />
-          </div>
+              <div className="mb-5 grid gap-3 sm:grid-cols-2">
+                <SummaryCard
+                  label="입력 근무시간"
+                  value={formatHours(summary.totalHours)}
+                />
+                <SummaryCard
+                  label="출근 횟수"
+                  value={`${summary.attendanceCount}회`}
+                />
+              </div>
 
-          {journalsQuery.isPending ? (
-            <Loading size="sm" text="근무 기록을 불러오는 중..." />
-          ) : journalsQuery.data?.length ? (
-            <div className="overflow-x-auto rounded-lg border border-gray-100">
-              <table className="w-full min-w-[1240px] border-collapse text-sm [&_td]:border [&_td]:border-gray-200 [&_th]:border [&_th]:border-brand-200">
-                <thead className="bg-brand-50 text-left text-xs text-brand-700">
-                  <tr>
-                    <th className="px-3 py-2.5">근무 날짜</th>
-                    <th className="px-3 py-2.5">근무자 이름</th>
-                    <th className="px-3 py-2.5">근무 상태</th>
-                    <th className="px-3 py-2.5">실제 출근</th>
-                    <th className="px-3 py-2.5">실제 퇴근</th>
-                    <th className="px-3 py-2.5 text-right">실제 근무시간</th>
-                    <th className="px-3 py-2.5">입력 출근</th>
-                    <th className="px-3 py-2.5">예상 퇴근</th>
-                    <th className="px-3 py-2.5 text-right">입력 근무시간</th>
-                    <th className="px-3 py-2.5">특이사항</th>
-                    <th className="px-3 py-2.5 text-center">작업</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-100">
-                  {journalsQuery.data.map((journal) => (
-                    <tr key={journal.id} className="hover:bg-gray-50">
-                      <td className="px-3 py-2.5 whitespace-nowrap">
-                        {formatKoreanDate(journal.work_date)}
-                      </td>
-                      <td className="px-3 py-2.5 font-medium text-gray-900">
-                        {journal.worker_name}
-                      </td>
-                      <td className="px-3 py-2.5 whitespace-nowrap">
-                        <span
-                          className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${
-                            journal.status === "handover_pending"
-                              ? "bg-amber-100 text-amber-700"
-                              : journal.status === "shift_completed"
-                                ? "bg-blue-100 text-blue-700"
-                                : journal.status === "closed"
-                                  ? "bg-emerald-100 text-emerald-700"
-                                  : "bg-brand-100 text-brand-700"
-                          }`}
-                        >
-                          {getWorkStatusLabel(journal.status)}
-                        </span>
-                      </td>
-                      <td className="px-3 py-2.5">
-                        {new Intl.DateTimeFormat("en-GB", {
-                          timeZone: "Asia/Seoul",
-                          hour: "2-digit",
-                          minute: "2-digit",
-                          hour12: false,
-                        }).format(new Date(journal.created_at))}
-                      </td>
-                      <td className="px-3 py-2.5">
-                        {isWorkEnded(journal.status)
-                          ? journal.end_time.slice(0, 5)
-                          : "-"}
-                      </td>
-                      <td className="px-3 py-2.5 text-right font-medium">
-                        {isWorkEnded(journal.status)
-                          ? formatHours(Number(journal.work_hours))
-                          : "-"}
-                      </td>
-                      <td className="px-3 py-2.5">
-                        {journal.start_time.slice(0, 5)}
-                      </td>
-                      <td className="px-3 py-2.5">
-                        {journal.expected_end_time?.slice(0, 5) ||
-                          journal.end_time.slice(0, 5)}
-                      </td>
-                      <td className="px-3 py-2.5 text-right font-semibold text-brand-700">
-                        {Number(journal.input_work_hours ?? 0) > 0
-                          ? formatHours(Number(journal.input_work_hours))
-                          : "-"}
-                      </td>
-                      <td className="max-w-xs px-3 py-2.5">
-                        <p className="truncate" title={journal.note ?? ""}>
-                          {journal.note || "-"}
-                        </p>
-                      </td>
-                      <td className="px-3 py-2.5 text-center">
-                        <div className="flex justify-center gap-1">
-                          {isAdmin &&
-                            journal.status === "handover_pending" && (
+              <div className="mb-3 flex justify-end gap-2">
+                {columnEditing && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={saveColumnWidths}
+                      className="min-h-9 rounded-lg bg-brand-500 px-3 text-xs font-semibold text-white shadow-sm hover:bg-brand-600"
+                    >
+                      변경값 저장
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelColumnEditing}
+                      className="min-h-9 rounded-lg border border-gray-300 bg-white px-3 text-xs font-semibold text-gray-600 shadow-sm hover:bg-gray-50"
+                    >
+                      취소
+                    </button>
+                  </>
+                )}
+                <button
+                  type="button"
+                  onClick={columnEditing ? undefined : startColumnEditing}
+                  aria-label="표 열 너비 변경"
+                  title={columnEditing ? "열 너비 편집 중" : "표 열 너비 변경"}
+                  className={`flex h-9 w-9 items-center justify-center rounded-lg border bg-white transition ${
+                    columnEditing
+                      ? "border-brand-300 text-brand-700 shadow-sm"
+                      : "border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-brand-700"
+                  }`}
+                >
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.8}
+                      d="M12 15.25A3.25 3.25 0 1 0 12 8.75a3.25 3.25 0 0 0 0 6.5Zm7.25-3.25c0-.48-.05-.95-.14-1.4l2.02-1.57-2-3.46-2.48 1a7.4 7.4 0 0 0-2.42-1.4L13.88 2.5h-4l-.35 2.67a7.4 7.4 0 0 0-2.42 1.4l-2.48-1-2 3.46 2.02 1.57a7.18 7.18 0 0 0 0 2.8l-2.02 1.57 2 3.46 2.48-1a7.4 7.4 0 0 0 2.42 1.4l.35 2.67h4l.35-2.67a7.4 7.4 0 0 0 2.42-1.4l2.48 1 2-3.46-2.02-1.57c.09-.45.14-.92.14-1.4Z"
+                    />
+                  </svg>
+                </button>
+              </div>
+
+              {journalsQuery.isPending ? (
+                <Loading size="sm" text="근무 기록을 불러오는 중..." />
+              ) : journalsQuery.data?.length ? (
+                <div className="overflow-x-auto rounded-lg border border-gray-100">
+                  <table
+                    className="table-fixed border-collapse text-sm [&_td]:border [&_td]:border-gray-200 [&_th]:border [&_th]:border-brand-200"
+                    style={{
+                      width: workJournalTableWidth,
+                      minWidth: workJournalTableWidth,
+                    }}
+                  >
+                    <colgroup>
+                      {visibleWorkJournalColumnKeys.map((key) => (
+                        <col key={key} style={{ width: columnWidths[key] }} />
+                      ))}
+                    </colgroup>
+                    <thead className="bg-brand-50 text-left text-xs text-brand-700">
+                      <tr>
+                        <ResizableWorkJournalHeader
+                          label="근무 날짜"
+                          width={columnWidths.date}
+                          onResize={(width) => resizeColumn("date", width)}
+                          editable={columnEditing}
+                        />
+                        <ResizableWorkJournalHeader
+                          label="근무자 이름"
+                          width={columnWidths.worker}
+                          onResize={(width) => resizeColumn("worker", width)}
+                          editable={columnEditing}
+                        />
+                        <ResizableWorkJournalHeader
+                          label="근무 상태"
+                          width={columnWidths.status}
+                          onResize={(width) => resizeColumn("status", width)}
+                          editable={columnEditing}
+                        />
+                        {isAdmin && (
+                          <>
+                            <ResizableWorkJournalHeader
+                              label="출근 처리"
+                              width={columnWidths.checkIn}
+                              onResize={(width) =>
+                                resizeColumn("checkIn", width)
+                              }
+                              editable={columnEditing}
+                            />
+                            <ResizableWorkJournalHeader
+                              label="퇴근 처리"
+                              width={columnWidths.checkOut}
+                              onResize={(width) =>
+                                resizeColumn("checkOut", width)
+                              }
+                              editable={columnEditing}
+                            />
+                            <ResizableWorkJournalHeader
+                              label="실제 근무시간"
+                              width={columnWidths.actualHours}
+                              onResize={(width) =>
+                                resizeColumn("actualHours", width)
+                              }
+                              editable={columnEditing}
+                              align="right"
+                            />
+                          </>
+                        )}
+                        <ResizableWorkJournalHeader
+                          label="입력 출근"
+                          width={columnWidths.inputStart}
+                          onResize={(width) =>
+                            resizeColumn("inputStart", width)
+                          }
+                          editable={columnEditing}
+                        />
+                        <ResizableWorkJournalHeader
+                          label="입력 퇴근"
+                          width={columnWidths.expectedEnd}
+                          onResize={(width) =>
+                            resizeColumn("expectedEnd", width)
+                          }
+                          editable={columnEditing}
+                        />
+                        <ResizableWorkJournalHeader
+                          label="입력 근무시간"
+                          width={columnWidths.inputHours}
+                          onResize={(width) =>
+                            resizeColumn("inputHours", width)
+                          }
+                          editable={columnEditing}
+                          align="right"
+                        />
+                        <ResizableWorkJournalHeader
+                          label="특이사항"
+                          width={columnWidths.note}
+                          onResize={(width) => resizeColumn("note", width)}
+                          editable={columnEditing}
+                        />
+                        <ResizableWorkJournalHeader
+                          label="작업"
+                          width={columnWidths.actions}
+                          onResize={(width) => resizeColumn("actions", width)}
+                          editable={columnEditing}
+                          align="center"
+                        />
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                      {journalsQuery.data.map((journal) => (
+                        <tr key={journal.id} className="hover:bg-gray-50">
+                          <td className="px-3 py-2.5 whitespace-nowrap">
+                            {formatKoreanDate(journal.work_date)}
+                          </td>
+                          <td className="px-3 py-2.5 font-medium text-gray-900">
+                            {journal.worker_name}
+                          </td>
+                          <td className="px-3 py-2.5 whitespace-nowrap">
+                            <span
+                              className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${
+                                journal.status === "handover_pending"
+                                  ? "bg-amber-100 text-amber-700"
+                                  : journal.status === "shift_completed"
+                                    ? "bg-blue-100 text-blue-700"
+                                    : journal.status === "closed"
+                                      ? "bg-emerald-100 text-emerald-700"
+                                      : "bg-brand-100 text-brand-700"
+                              }`}
+                            >
+                              {getWorkStatusLabel(journal.status)}
+                            </span>
+                          </td>
+                          {isAdmin && (
+                            <>
+                              <td className="px-3 py-2.5">
+                                {new Intl.DateTimeFormat("en-GB", {
+                                  timeZone: "Asia/Seoul",
+                                  hour: "2-digit",
+                                  minute: "2-digit",
+                                  hour12: false,
+                                }).format(new Date(journal.created_at))}
+                              </td>
+                              <td className="px-3 py-2.5">
+                                {isWorkEnded(journal.status)
+                                  ? journal.end_time.slice(0, 5)
+                                  : "-"}
+                              </td>
+                              <td className="px-3 py-2.5 text-right font-medium">
+                                {isWorkEnded(journal.status)
+                                  ? formatHours(Number(journal.work_hours))
+                                  : "-"}
+                              </td>
+                            </>
+                          )}
+                          <td className="px-3 py-2.5">
+                            {journal.start_time.slice(0, 5)}
+                          </td>
+                          <td className="px-3 py-2.5">
+                            {isWorkEnded(journal.status)
+                              ? journal.expected_end_time?.slice(0, 5) ||
+                                journal.end_time.slice(0, 5)
+                              : "-"}
+                          </td>
+                          <td className="px-3 py-2.5 text-right font-semibold text-brand-700">
+                            {Number(journal.input_work_hours ?? 0) > 0
+                              ? formatHours(Number(journal.input_work_hours))
+                              : "-"}
+                          </td>
+                          <td className="max-w-xs px-3 py-2.5">
+                            <p className="truncate" title={journal.note ?? ""}>
+                              {journal.note || "-"}
+                            </p>
+                          </td>
+                          <td className="px-3 py-2.5 text-center">
+                            <div className="flex justify-center gap-1">
+                              {isAdmin &&
+                                journal.status === "handover_pending" && (
+                                  <Button
+                                    size="xs"
+                                    variant="secondary"
+                                    disabled={closeHandoverMutation.isPending}
+                                    onClick={() => {
+                                      const reason = window.prompt(
+                                        "교대 없이 종료하는 사유를 입력해 주세요.",
+                                      );
+                                      if (!reason?.trim()) return;
+                                      closeHandoverMutation.mutate({
+                                        id: journal.id,
+                                        reason,
+                                      });
+                                    }}
+                                  >
+                                    교대 없이 종료
+                                  </Button>
+                                )}
                               <Button
                                 size="xs"
-                                variant="secondary"
-                                disabled={closeHandoverMutation.isPending}
-                                onClick={() => {
-                                  const reason = window.prompt(
-                                    "교대 없이 종료하는 사유를 입력해 주세요.",
-                                  );
-                                  if (!reason?.trim()) return;
-                                  closeHandoverMutation.mutate({
-                                    id: journal.id,
-                                    reason,
-                                  });
-                                }}
+                                variant="gray"
+                                onClick={() => handleStartEditing(journal)}
                               >
-                                교대 없이 종료
+                                수정
                               </Button>
-                            )}
-                          <Button
-                            size="xs"
-                            variant="gray"
-                            onClick={() => handleStartEditing(journal)}
-                          >
-                            수정
-                          </Button>
-                          {isAdmin && (
-                            <Button
-                              size="xs"
-                              variant="danger"
-                              disabled={deleteMutation.isPending}
-                              onClick={() => {
-                                if (
-                                  window.confirm(
-                                    "이 근무 기록을 삭제하시겠습니까?",
-                                  )
-                                ) {
-                                  deleteMutation.mutate(journal.id);
-                                }
-                              }}
-                            >
-                              삭제
-                            </Button>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <p className="py-10 text-center text-sm text-gray-500">
-              선택한 조건의 근무 기록이 없습니다.
-            </p>
-          )}
+                              {isAdmin && (
+                                <Button
+                                  size="xs"
+                                  variant="danger"
+                                  disabled={deleteMutation.isPending}
+                                  onClick={() => {
+                                    if (
+                                      window.confirm(
+                                        "이 근무 기록을 삭제하시겠습니까?",
+                                      )
+                                    ) {
+                                      deleteMutation.mutate(journal.id);
+                                    }
+                                  }}
+                                >
+                                  삭제
+                                </Button>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <p className="py-10 text-center text-sm text-gray-500">
+                  선택한 조건의 근무 기록이 없습니다.
+                </p>
+              )}
             </>
           )}
         </section>
@@ -1105,195 +1437,202 @@ export default function WorkJournalPage() {
             </select>
           </div>
 
-        <section className="space-y-5 rounded-xl border border-brand-100 bg-white p-5 shadow-sm">
-          {paymentQuery.isPending ? (
-            <Loading size="sm" text="급여 지급 현황을 불러오는 중..." />
-          ) : paymentGroups.length ? (
-            <>
-              <div className="grid gap-3 lg:grid-cols-2">
-                {paymentGroups.map((group) => {
-                  const totalHours = group.journals.reduce(
-                    (sum, journal) => sum + getPayableHours(journal),
-                    0,
-                  );
-                  const totalActualHours = group.journals.reduce(
-                    (sum, journal) => sum + Number(journal.work_hours),
-                    0,
-                  );
-                  const unpaidHours = group.unpaid.reduce(
-                    (sum, journal) => sum + getPayableHours(journal),
-                    0,
-                  );
-                  const advanceHours = group.advance.reduce(
-                    (sum, journal) => sum + getPayableHours(journal),
-                    0,
-                  );
-                  const salaryHours = group.salary.reduce(
-                    (sum, journal) => sum + getPayableHours(journal),
-                    0,
-                  );
-                  return (
-                    <div
-                      key={group.workerName}
-                      className="rounded-xl border border-gray-200 bg-gray-50 p-4"
-                    >
-                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                        <div>
-                          <p className="font-semibold text-gray-900">
-                            {group.workerName}
-                          </p>
-                          <p className="mt-1 text-xs text-gray-500">
-                            총 근무 {group.journals.length}회 ·{" "}
-                            입력 {formatHours(totalHours)} · 실제{" "}
-                            {formatHours(totalActualHours)}
-                          </p>
-                          <p className="mt-1 text-xs font-semibold text-brand-700">
-                            잔여 지급 {group.unpaid.length}회 ·{" "}
-                            {formatHours(unpaidHours)}
-                          </p>
-                        </div>
-                        <div className="flex flex-wrap gap-2">
-                          <Button
-                            size="sm"
-                            disabled={
-                              paymentMutation.isPending || !group.unpaid.length
-                            }
-                            onClick={() => handleWorkerSalaryPayment(group)}
-                          >
-                            {group.unpaid.length
-                              ? `월급 지급 (${group.unpaid.length}건)`
-                              : "지급 처리 완료"}
-                          </Button>
-                          {group.salary.length > 0 && (
+          <section className="space-y-5 rounded-xl border border-brand-100 bg-white p-5 shadow-sm">
+            {paymentQuery.isPending ? (
+              <Loading size="sm" text="급여 지급 현황을 불러오는 중..." />
+            ) : paymentGroups.length ? (
+              <>
+                <div className="grid gap-3 lg:grid-cols-2">
+                  {paymentGroups.map((group) => {
+                    const totalHours = group.journals.reduce(
+                      (sum, journal) => sum + getPayableHours(journal),
+                      0,
+                    );
+                    const totalActualHours = group.journals.reduce(
+                      (sum, journal) => sum + Number(journal.work_hours),
+                      0,
+                    );
+                    const unpaidHours = group.unpaid.reduce(
+                      (sum, journal) => sum + getPayableHours(journal),
+                      0,
+                    );
+                    const advanceHours = group.advance.reduce(
+                      (sum, journal) => sum + getPayableHours(journal),
+                      0,
+                    );
+                    const salaryHours = group.salary.reduce(
+                      (sum, journal) => sum + getPayableHours(journal),
+                      0,
+                    );
+                    return (
+                      <div
+                        key={group.workerName}
+                        className="rounded-xl border border-gray-200 bg-gray-50 p-4"
+                      >
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div>
+                            <p className="font-semibold text-gray-900">
+                              {group.workerName}
+                            </p>
+                            <p className="mt-1 text-xs text-gray-500">
+                              총 근무 {group.journals.length}회 · 입력{" "}
+                              {formatHours(totalHours)} · 실제{" "}
+                              {formatHours(totalActualHours)}
+                            </p>
+                            <p className="mt-1 text-xs font-semibold text-brand-700">
+                              잔여 지급 {group.unpaid.length}회 ·{" "}
+                              {formatHours(unpaidHours)}
+                            </p>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
                             <Button
                               size="sm"
-                              variant="gray"
-                              disabled={paymentMutation.isPending}
-                              onClick={() => handleWorkerSalaryCancel(group)}
+                              disabled={
+                                paymentMutation.isPending ||
+                                !group.unpaid.length
+                              }
+                              onClick={() => handleWorkerSalaryPayment(group)}
                             >
-                              월급 지급 취소
+                              {group.unpaid.length
+                                ? `월급 지급 (${group.unpaid.length}건)`
+                                : "지급 처리 완료"}
                             </Button>
-                          )}
-                        </div>
-                      </div>
-                      <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
-                        <div className="rounded-lg bg-white px-2 py-2 text-gray-600">
-                          <span className="block">미지급</span>
-                          <strong className="mt-1 block text-gray-900">
-                            {group.unpaid.length}회 · {formatHours(unpaidHours)}
-                          </strong>
-                        </div>
-                        <div className="rounded-lg bg-amber-50 px-2 py-2 text-amber-700">
-                          <span className="block">선지급</span>
-                          <strong className="mt-1 block">
-                            {group.advance.length}회 ·{" "}
-                            {formatHours(advanceHours)}
-                          </strong>
-                        </div>
-                        <div className="rounded-lg bg-emerald-50 px-2 py-2 text-emerald-700">
-                          <span className="block">월급 지급 완료</span>
-                          <strong className="mt-1 block">
-                            {group.salary.length}회 · {formatHours(salaryHours)}
-                          </strong>
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-
-              <div className="overflow-x-auto rounded-lg border border-gray-100">
-                <table className="w-full min-w-[900px] border-collapse text-sm [&_td]:border [&_td]:border-gray-200 [&_th]:border [&_th]:border-brand-200">
-                  <thead className="bg-brand-50 text-left text-xs text-brand-700">
-                    <tr>
-                      <th className="px-3 py-2.5">근무 날짜</th>
-                      <th className="px-3 py-2.5">근무자</th>
-                      <th className="px-3 py-2.5 text-right">실제 근무시간</th>
-                      <th className="px-3 py-2.5 text-right">입력 근무시간</th>
-                      <th className="px-3 py-2.5 text-center">지급 상태</th>
-                      <th className="px-3 py-2.5">처리 시간</th>
-                      <th className="px-3 py-2.5 text-center">선지급</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-100">
-                    {paymentQuery.data?.map((journal) => {
-                      const status = journal.payment_status ?? "unpaid";
-                      return (
-                        <tr key={journal.id} className="hover:bg-gray-50">
-                          <td className="whitespace-nowrap px-3 py-2.5">
-                            {formatKoreanDate(journal.work_date)}
-                          </td>
-                          <td className="px-3 py-2.5 font-medium text-gray-900">
-                            {journal.worker_name}
-                          </td>
-                          <td className="px-3 py-2.5 text-right">
-                            {formatHours(Number(journal.work_hours))}
-                          </td>
-                          <td className="px-3 py-2.5 text-right font-semibold text-brand-700">
-                            {formatHours(getPayableHours(journal))}
-                            {journal.input_work_hours == null && (
-                              <span className="ml-1 block text-[10px] font-normal text-amber-600">
-                                실제시간 대체
-                              </span>
-                            )}
-                          </td>
-                          <td className="px-3 py-2.5 text-center">
-                            <span
-                              className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${
-                                status === "advance"
-                                  ? "bg-amber-100 text-amber-700"
-                                  : status === "salary"
-                                    ? "bg-emerald-100 text-emerald-700"
-                                    : "bg-gray-100 text-gray-600"
-                              }`}
-                            >
-                              {status === "advance"
-                                ? "선지급"
-                                : status === "salary"
-                                  ? "월급 지급"
-                                  : "미지급"}
-                            </span>
-                          </td>
-                          <td className="whitespace-nowrap px-3 py-2.5 text-xs text-gray-500">
-                            {journal.paid_at
-                              ? new Date(journal.paid_at).toLocaleString(
-                                  "ko-KR",
-                                )
-                              : "-"}
-                          </td>
-                          <td className="px-3 py-2.5 text-center">
-                            {status === "salary" ? (
-                              <span className="text-xs text-gray-400">
-                                월급 지급 완료
-                              </span>
-                            ) : (
+                            {group.salary.length > 0 && (
                               <Button
-                                size="xs"
-                                variant={
-                                  status === "advance" ? "gray" : undefined
-                                }
+                                size="sm"
+                                variant="gray"
                                 disabled={paymentMutation.isPending}
-                                onClick={() => handleAdvanceToggle(journal)}
+                                onClick={() => handleWorkerSalaryCancel(group)}
                               >
-                                {status === "advance"
-                                  ? "선지급 취소"
-                                  : "선지급 처리"}
+                                월급 지급 취소
                               </Button>
                             )}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            </>
-          ) : (
-            <p className="py-10 text-center text-sm text-gray-500">
-              선택한 월의 근무 기록이 없습니다.
-            </p>
-          )}
-        </section>
+                          </div>
+                        </div>
+                        <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+                          <div className="rounded-lg bg-white px-2 py-2 text-gray-600">
+                            <span className="block">미지급</span>
+                            <strong className="mt-1 block text-gray-900">
+                              {group.unpaid.length}회 ·{" "}
+                              {formatHours(unpaidHours)}
+                            </strong>
+                          </div>
+                          <div className="rounded-lg bg-amber-50 px-2 py-2 text-amber-700">
+                            <span className="block">선지급</span>
+                            <strong className="mt-1 block">
+                              {group.advance.length}회 ·{" "}
+                              {formatHours(advanceHours)}
+                            </strong>
+                          </div>
+                          <div className="rounded-lg bg-emerald-50 px-2 py-2 text-emerald-700">
+                            <span className="block">월급 지급 완료</span>
+                            <strong className="mt-1 block">
+                              {group.salary.length}회 ·{" "}
+                              {formatHours(salaryHours)}
+                            </strong>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="overflow-x-auto rounded-lg border border-gray-100">
+                  <table className="w-full min-w-[900px] border-collapse text-sm [&_td]:border [&_td]:border-gray-200 [&_th]:border [&_th]:border-brand-200">
+                    <thead className="bg-brand-50 text-left text-xs text-brand-700">
+                      <tr>
+                        <th className="px-3 py-2.5">근무 날짜</th>
+                        <th className="px-3 py-2.5">근무자</th>
+                        <th className="px-3 py-2.5 text-right">
+                          실제 근무시간
+                        </th>
+                        <th className="px-3 py-2.5 text-right">
+                          입력 근무시간
+                        </th>
+                        <th className="px-3 py-2.5 text-center">지급 상태</th>
+                        <th className="px-3 py-2.5">처리 시간</th>
+                        <th className="px-3 py-2.5 text-center">선지급</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                      {paymentQuery.data?.map((journal) => {
+                        const status = journal.payment_status ?? "unpaid";
+                        return (
+                          <tr key={journal.id} className="hover:bg-gray-50">
+                            <td className="whitespace-nowrap px-3 py-2.5">
+                              {formatKoreanDate(journal.work_date)}
+                            </td>
+                            <td className="px-3 py-2.5 font-medium text-gray-900">
+                              {journal.worker_name}
+                            </td>
+                            <td className="px-3 py-2.5 text-right">
+                              {formatHours(Number(journal.work_hours))}
+                            </td>
+                            <td className="px-3 py-2.5 text-right font-semibold text-brand-700">
+                              {formatHours(getPayableHours(journal))}
+                              {journal.input_work_hours == null && (
+                                <span className="ml-1 block text-[10px] font-normal text-amber-600">
+                                  실제시간 대체
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-3 py-2.5 text-center">
+                              <span
+                                className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${
+                                  status === "advance"
+                                    ? "bg-amber-100 text-amber-700"
+                                    : status === "salary"
+                                      ? "bg-emerald-100 text-emerald-700"
+                                      : "bg-gray-100 text-gray-600"
+                                }`}
+                              >
+                                {status === "advance"
+                                  ? "선지급"
+                                  : status === "salary"
+                                    ? "월급 지급"
+                                    : "미지급"}
+                              </span>
+                            </td>
+                            <td className="whitespace-nowrap px-3 py-2.5 text-xs text-gray-500">
+                              {journal.paid_at
+                                ? new Date(journal.paid_at).toLocaleString(
+                                    "ko-KR",
+                                  )
+                                : "-"}
+                            </td>
+                            <td className="px-3 py-2.5 text-center">
+                              {status === "salary" ? (
+                                <span className="text-xs text-gray-400">
+                                  월급 지급 완료
+                                </span>
+                              ) : (
+                                <Button
+                                  size="xs"
+                                  variant={
+                                    status === "advance" ? "gray" : undefined
+                                  }
+                                  disabled={paymentMutation.isPending}
+                                  onClick={() => handleAdvanceToggle(journal)}
+                                >
+                                  {status === "advance"
+                                    ? "선지급 취소"
+                                    : "선지급 처리"}
+                                </Button>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            ) : (
+              <p className="py-10 text-center text-sm text-gray-500">
+                선택한 월의 근무 기록이 없습니다.
+              </p>
+            )}
+          </section>
         </>
       )}
     </main>

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -81,13 +81,13 @@ export default function LoginPage() {
           <div className="absolute bottom-20 right-20 w-96 h-96 bg-brand-300 rounded-full blur-3xl" />
         </div>
         <div className="relative z-10 text-center">
-          <div className="inline-flex items-center justify-center w-28 h-28 bg-white/15 backdrop-blur-sm rounded-3xl mb-8 ring-1 ring-white/20">
+          <div className="relative mb-8 inline-flex h-28 w-28 items-center justify-center rounded-3xl bg-white/15 ring-1 ring-white/20 backdrop-blur-sm">
             <Image
               src="/logo.PNG"
               alt="OSS Logo"
-              width={80}
-              height={80}
-              className="object-contain"
+              fill
+              sizes="112px"
+              className="object-contain p-4"
             />
           </div>
           <h1 className="text-3xl font-bold text-white mb-3">
@@ -105,13 +105,13 @@ export default function LoginPage() {
         <div className="w-full max-w-sm">
           {/* 모바일 로고 */}
           <div className="flex justify-center mb-8 lg:hidden">
-            <div className="w-24 h-24 bg-gradient-to-br from-brand-500 to-brand-600 rounded-2xl flex items-center justify-center shadow-lg shadow-brand-500/25">
+            <div className="relative flex h-24 w-24 items-center justify-center rounded-2xl bg-gradient-to-br from-brand-500 to-brand-600 shadow-lg shadow-brand-500/25">
               <Image
                 src="/logo.PNG"
                 alt="OSS Logo"
-                width={68}
-                height={68}
-                className="object-contain"
+                fill
+                sizes="96px"
+                className="object-contain p-3.5"
               />
             </div>
           </div>

--- a/src/app/_domains/_cashManagement/_services/cashManagementService.ts
+++ b/src/app/_domains/_cashManagement/_services/cashManagementService.ts
@@ -1,33 +1,33 @@
-import supabase from '@/libs/supabaseClient';
+import supabase from "@/libs/supabaseClient";
 import {
   CashClosingType,
   CashCounts,
   DailyCashSales,
   DailyPaymentSales,
   WorkShift,
-} from '../_types/cashManagement.types';
+} from "../_types/cashManagement.types";
 
 const CASH_PAYMENT_TYPES = new Set([
-  'cash',
-  'cash_receipt',
-  'egu_cash',
-  'egu_cash_receipt',
+  "cash",
+  "cash_receipt",
+  "egu_cash",
+  "egu_cash_receipt",
 ]);
 
-const NON_PAYMENT_TYPES = new Set(['remark', 'shipment_remark']);
+const NON_PAYMENT_TYPES = new Set(["remark", "shipment_remark"]);
 const OVAPE_PAYMENT_TYPES = [
-  { paymentType: 'card', label: '카드' },
-  { paymentType: 'transfer', label: '이체' },
-  { paymentType: 'cash', label: '현금' },
-  { paymentType: 'cash_receipt', label: '현금영수증' },
-  { paymentType: 'transfer_cash_receipt', label: '이체현금영수증' },
-  { paymentType: 'kakaotalk', label: '카카오톡' },
+  { paymentType: "card", label: "카드" },
+  { paymentType: "transfer", label: "이체" },
+  { paymentType: "cash", label: "현금" },
+  { paymentType: "cash_receipt", label: "현금영수증" },
+  { paymentType: "transfer_cash_receipt", label: "이체현금영수증" },
+  { paymentType: "kakaotalk", label: "카카오톡" },
 ] as const;
 const EGU_PAYMENT_TYPES = [
-  { paymentType: 'egu_card', label: '카드' },
-  { paymentType: 'egu_transfer', label: '이체' },
-  { paymentType: 'egu_cash', label: '현금' },
-  { paymentType: 'egu_cash_receipt', label: '현금영수증' },
+  { paymentType: "egu_card", label: "카드" },
+  { paymentType: "egu_transfer", label: "이체" },
+  { paymentType: "egu_cash", label: "현금" },
+  { paymentType: "egu_cash_receipt", label: "현금영수증" },
 ] as const;
 
 const getKoreaDateRange = (date: string) => {
@@ -41,11 +41,11 @@ export const getDailyCashSales = async (
 ): Promise<DailyCashSales> => {
   const { start, end } = getKoreaDateRange(date);
   const { data, error } = await supabase
-    .from('logs')
-    .select('jsonb')
-    .eq('category', 'stamp')
-    .gte('created_at', start)
-    .lt('created_at', end);
+    .from("logs")
+    .select("jsonb")
+    .eq("category", "stamp")
+    .gte("created_at", start)
+    .lt("created_at", end);
 
   if (error) throw error;
 
@@ -62,25 +62,22 @@ export const getDailyCashSales = async (
       : [];
     if (splitPayments.length) {
       for (const payment of splitPayments) {
-        const splitType = String(payment.paymentType ?? '');
+        const splitType = String(payment.paymentType ?? "");
         const splitAmount = Number(payment.amount ?? 0);
-        if (
-          !CASH_PAYMENT_TYPES.has(splitType) ||
-          !Number.isFinite(splitAmount)
-        )
+        if (!CASH_PAYMENT_TYPES.has(splitType) || !Number.isFinite(splitAmount))
           continue;
-        if (splitType.startsWith('egu_')) eguVape += splitAmount;
+        if (splitType.startsWith("egu_")) eguVape += splitAmount;
         else ovape += splitAmount;
       }
       continue;
     }
-    const paymentType = String(jsonb.paymentType ?? '');
+    const paymentType = String(jsonb.paymentType ?? "");
     if (!CASH_PAYMENT_TYPES.has(paymentType)) continue;
 
     const amount = Number(jsonb.totalAmount ?? 0);
     if (!Number.isFinite(amount)) continue;
 
-    if (paymentType.startsWith('egu_')) {
+    if (paymentType.startsWith("egu_")) {
       eguVape += amount;
     } else {
       ovape += amount;
@@ -93,16 +90,27 @@ export const getDailyCashSales = async (
 export const getDailyPaymentSales = async (
   date: string,
 ): Promise<DailyPaymentSales> => {
-  const usesSeparatedOutboundSummary = date >= '2026-07-31';
+  const usesSeparatedOutboundSummary = date >= "2026-07-31";
   const { start, end } = getKoreaDateRange(date);
-  const { data, error } = await supabase
-    .from('logs')
-    .select('jsonb')
-    .eq('category', 'stamp')
-    .gte('created_at', start)
-    .lt('created_at', end);
+  const [logsResult, receiptsResult] = await Promise.all([
+    supabase
+      .from("logs")
+      .select("jsonb")
+      .eq("category", "stamp")
+      .gte("created_at", start)
+      .lt("created_at", end),
+    supabase
+      .from("inventory_purchase_receipts")
+      .select(
+        "id, inventory_purchase_orders(inventory_suppliers(name)), inventory_purchase_receipt_lines(quantity)",
+      )
+      .eq("arrived_on", date)
+      .is("reversed_at", null),
+  ]);
 
-  if (error) throw error;
+  if (logsResult.error) throw logsResult.error;
+  if (receiptsResult.error) throw receiptsResult.error;
+  const data = logsResult.data;
 
   const amountByPaymentType = new Map<string, number>();
   const quantityByCategory = new Map<string, number>();
@@ -110,8 +118,16 @@ export const getDailyPaymentSales = async (
     string,
     { type: string; label: string; quantity: number }
   >();
+  const quantityByInboundType = new Map<
+    string,
+    {
+      type: "purchase" | "adjustment_in" | "exchange_in";
+      label: string;
+      quantity: number;
+    }
+  >();
   const deliveryByMethod = new Map<
-    'store_visit' | 'parcel' | 'delivery',
+    "store_visit" | "parcel" | "delivery",
     { orderCount: number; quantity: number; fee: number }
   >();
 
@@ -125,7 +141,7 @@ export const getDailyPaymentSales = async (
       : [];
     if (splitPayments.length) {
       for (const payment of splitPayments) {
-        const splitType = String(payment.paymentType ?? '').trim();
+        const splitType = String(payment.paymentType ?? "").trim();
         const splitAmount = Number(payment.amount ?? 0);
         if (
           !splitType ||
@@ -139,7 +155,7 @@ export const getDailyPaymentSales = async (
         );
       }
     }
-    const paymentType = String(jsonb.paymentType ?? '').trim();
+    const paymentType = String(jsonb.paymentType ?? "").trim();
     const amount = Number(jsonb.totalAmount ?? 0);
     if (!splitPayments.length) {
       if (
@@ -155,9 +171,9 @@ export const getDailyPaymentSales = async (
     }
 
     const deliveryMethod =
-      jsonb.deliveryMethod === 'store_visit' ||
-      jsonb.deliveryMethod === 'parcel' ||
-      jsonb.deliveryMethod === 'delivery'
+      jsonb.deliveryMethod === "store_visit" ||
+      jsonb.deliveryMethod === "parcel" ||
+      jsonb.deliveryMethod === "delivery"
         ? jsonb.deliveryMethod
         : null;
     const items = Array.isArray(jsonb.items)
@@ -175,34 +191,46 @@ export const getDailyPaymentSales = async (
       const quantity = Number(item.quantity ?? 0);
       if (!Number.isFinite(quantity) || quantity <= 0) continue;
 
-      const categoryName =
-        String(item.itemCategoryName ?? '').trim() || '기타';
-      const inventoryAction = String(item.inventoryAction ?? '').trim();
+      const categoryName = String(item.itemCategoryName ?? "").trim() || "기타";
+      const inventoryAction = String(item.inventoryAction ?? "").trim();
+      if (
+        inventoryAction === "exchange_in" ||
+        inventoryAction === "adjustment_in"
+      ) {
+        const type = inventoryAction;
+        const label =
+          inventoryAction === "exchange_in" ? "교환입고" : "재고조정-입고";
+        const current = quantityByInboundType.get(type);
+        quantityByInboundType.set(type, {
+          type,
+          label,
+          quantity: (current?.quantity ?? 0) + quantity,
+        });
+      }
       if (
         usesSeparatedOutboundSummary &&
-        (inventoryAction === 'exchange_in' ||
-          inventoryAction === 'adjustment_in')
+        (inventoryAction === "exchange_in" ||
+          inventoryAction === "adjustment_in")
       ) {
         continue;
       }
       hasOutboundItem = true;
-      const remark = String(item.remark ?? '').trim();
+      const remark = String(item.remark ?? "").trim();
       const outboundType =
-        inventoryAction === 'exchange_in'
-          ? '교환입고'
-          : inventoryAction === 'exchange_out'
-            ? '교환출고'
+        inventoryAction === "exchange_out"
+          ? "교환출고"
+          : inventoryAction === "adjustment_out"
+            ? "재고조정-출고"
             : item.adjustedUnitPrice != null
-              ? '가격조정'
-              : remark.startsWith('서비스')
-                ? '서비스'
-                : remark.startsWith('시연용')
-                  ? '시연용'
-                  : remark.startsWith('입고처리')
-                    ? '입고처리'
-                    : remark.startsWith('출고처리')
-                      ? '출고처리'
-                      : remark || null;
+              ? "가격조정"
+              : remark.startsWith("서비스")
+                ? "서비스"
+                : remark.startsWith("시연용")
+                  ? "시연용"
+                  : remark.startsWith("재고조정-출고") ||
+                      remark.startsWith("출고처리")
+                    ? "재고조정-출고"
+                    : null;
 
       if (usesSeparatedOutboundSummary && outboundType) {
         const key = `${categoryName}\u0000${outboundType}`;
@@ -232,18 +260,41 @@ export const getDailyPaymentSales = async (
         quantity: current.quantity + deliveryItemQuantity,
         fee:
           current.fee +
-          (deliveryMethod === 'store_visit'
+          (deliveryMethod === "store_visit"
             ? 0
             : Number(jsonb.deliveryFee ?? 0) || 0),
       });
     }
   }
 
+  for (const receipt of receiptsResult.data ?? []) {
+    const order = Array.isArray(receipt.inventory_purchase_orders)
+      ? receipt.inventory_purchase_orders[0]
+      : receipt.inventory_purchase_orders;
+    const supplier = Array.isArray(order?.inventory_suppliers)
+      ? order.inventory_suppliers[0]
+      : order?.inventory_suppliers;
+    const supplierName = String(supplier?.name ?? "").trim();
+    if (!supplierName) continue;
+    const quantity = (receipt.inventory_purchase_receipt_lines ?? []).reduce(
+      (sum, line) => sum + Number(line.quantity ?? 0),
+      0,
+    );
+    if (quantity <= 0) continue;
+    const key = `purchase:${supplierName}`;
+    const current = quantityByInboundType.get(key);
+    quantityByInboundType.set(key, {
+      type: "purchase",
+      label: supplierName,
+      quantity: (current?.quantity ?? 0) + 1,
+    });
+  }
+
   if (!usesSeparatedOutboundSummary) {
-    const parcelCount = deliveryByMethod.get('parcel')?.orderCount ?? 0;
-    const deliveryCount = deliveryByMethod.get('delivery')?.orderCount ?? 0;
-    if (parcelCount > 0) quantityByCategory.set('택배', parcelCount);
-    if (deliveryCount > 0) quantityByCategory.set('배달', deliveryCount);
+    const parcelCount = deliveryByMethod.get("parcel")?.orderCount ?? 0;
+    const deliveryCount = deliveryByMethod.get("delivery")?.orderCount ?? 0;
+    if (parcelCount > 0) quantityByCategory.set("택배", parcelCount);
+    if (deliveryCount > 0) quantityByCategory.set("배달", deliveryCount);
   }
 
   const ovapeBreakdown = OVAPE_PAYMENT_TYPES.map((item) => ({
@@ -265,20 +316,24 @@ export const getDailyPaymentSales = async (
       .sort((a, b) => b.quantity - a.quantity),
     outboundTypeSummary: [...quantityByOtherOutboundType.values()].sort(
       (a, b) =>
-        b.quantity - a.quantity || a.label.localeCompare(b.label, 'ko-KR'),
+        b.quantity - a.quantity || a.label.localeCompare(b.label, "ko-KR"),
+    ),
+    inboundSummary: [...quantityByInboundType.values()].sort(
+      (a, b) =>
+        b.quantity - a.quantity || a.label.localeCompare(b.label, "ko-KR"),
     ),
     deliverySummary: [
-      ['store_visit', '매장방문'],
-      ['parcel', '택배'],
-      ['delivery', '배달'],
+      ["store_visit", "매장방문"],
+      ["parcel", "택배"],
+      ["delivery", "배달"],
     ].flatMap(([method, label]) => {
       const summary = deliveryByMethod.get(
-        method as 'store_visit' | 'parcel' | 'delivery',
+        method as "store_visit" | "parcel" | "delivery",
       );
       return summary
         ? [
             {
-              method: method as 'store_visit' | 'parcel' | 'delivery',
+              method: method as "store_visit" | "parcel" | "delivery",
               label,
               ...summary,
             },
@@ -293,9 +348,9 @@ export const getCashClosing = async (
   date: string,
 ): Promise<CashClosingType | null> => {
   const { data, error } = await supabase
-    .from('cash_register_closings')
-    .select('*')
-    .eq('business_date', date)
+    .from("cash_register_closings")
+    .select("*")
+    .eq("business_date", date)
     .maybeSingle();
 
   if (error) throw error;
@@ -306,10 +361,10 @@ export const getPreviousClosing = async (
   date: string,
 ): Promise<CashClosingType | null> => {
   const { data, error } = await supabase
-    .from('cash_register_closings')
-    .select('*')
-    .lt('business_date', date)
-    .order('business_date', { ascending: false })
+    .from("cash_register_closings")
+    .select("*")
+    .lt("business_date", date)
+    .order("business_date", { ascending: false })
     .limit(1)
     .maybeSingle();
 
@@ -322,11 +377,11 @@ export const getCashClosingHistory = async (
   endDate: string,
 ): Promise<CashClosingType[]> => {
   const { data, error } = await supabase
-    .from('cash_register_closings')
-    .select('*')
-    .gte('business_date', startDate)
-    .lte('business_date', endDate)
-    .order('business_date', { ascending: false })
+    .from("cash_register_closings")
+    .select("*")
+    .gte("business_date", startDate)
+    .lte("business_date", endDate)
+    .order("business_date", { ascending: false })
     .limit(366);
 
   if (error) throw error;
@@ -352,9 +407,9 @@ export const saveCashClosing = async (values: {
     error: sessionError,
   } = await supabase.auth.getSession();
 
-  if (sessionError || !session) throw new Error('세션을 찾을 수 없습니다.');
+  if (sessionError || !session) throw new Error("세션을 찾을 수 없습니다.");
 
-  const { error } = await supabase.from('cash_register_closings').upsert(
+  const { error } = await supabase.from("cash_register_closings").upsert(
     {
       business_date: values.businessDate,
       opening_cash: values.openingCash,
@@ -371,7 +426,7 @@ export const saveCashClosing = async (values: {
       created_by: session.user.id,
       updated_at: new Date().toISOString(),
     },
-    { onConflict: 'business_date' },
+    { onConflict: "business_date" },
   );
 
   if (error) throw error;

--- a/src/app/_domains/_cashManagement/_types/cashManagement.types.ts
+++ b/src/app/_domains/_cashManagement/_types/cashManagement.types.ts
@@ -1,4 +1,6 @@
-export const CASH_DENOMINATIONS = [50000, 10000, 5000, 1000, 500, 100, 50, 10] as const;
+export const CASH_DENOMINATIONS = [
+  50000, 10000, 5000, 1000, 500, 100, 50, 10,
+] as const;
 
 export type CashCounts = Record<string, number>;
 
@@ -59,8 +61,13 @@ export type DailyPaymentSales = {
     label: string;
     quantity: number;
   }[];
+  inboundSummary: {
+    type: "purchase" | "adjustment_in" | "exchange_in";
+    label: string;
+    quantity: number;
+  }[];
   deliverySummary: {
-    method: 'store_visit' | 'parcel' | 'delivery';
+    method: "store_visit" | "parcel" | "delivery";
     label: string;
     orderCount: number;
     quantity: number;

--- a/src/app/_domains/_dailyClosing/_types/dailyClosing.types.ts
+++ b/src/app/_domains/_dailyClosing/_types/dailyClosing.types.ts
@@ -1,6 +1,6 @@
 export type DailyClosingChecklist = Record<string, boolean>;
 
-export type DailyClosingChecklistPhase = 'opening' | 'closing';
+export type DailyClosingChecklistPhase = "opening" | "closing";
 
 export type DailyClosingChecklistItem = {
   id: string;
@@ -36,8 +36,14 @@ export type DailyClosingReportSnapshot = {
     label: string;
     quantity: number;
   }>;
+  inboundSummary?: Array<{
+    type: "purchase" | "adjustment_in" | "exchange_in";
+    label: string;
+    quantity: number;
+    aggregationUnit?: "quantity" | "count";
+  }>;
   deliverySummary?: Array<{
-    method: 'store_visit' | 'parcel' | 'delivery';
+    method: "store_visit" | "parcel" | "delivery";
     label: string;
     orderCount: number;
     quantity: number;

--- a/src/app/_domains/_inventory/_services/inventoryService.ts
+++ b/src/app/_domains/_inventory/_services/inventoryService.ts
@@ -144,8 +144,7 @@ export const getInventoryMovements = async (
       movements
         .filter(
           (movement) =>
-            movement.reference_type === "outbound_log" &&
-            movement.reference_id,
+            movement.reference_type === "outbound_log" && movement.reference_id,
         )
         .map((movement) => movement.reference_id as string),
     ),
@@ -167,13 +166,15 @@ export const getInventoryMovements = async (
     outboundLogIds.length
       ? supabase
           .from("logs")
-          .select("id, customer_id, customers(name)")
+          .select("id, customer_id, jsonb, customers(name)")
           .in("id", outboundLogIds)
       : Promise.resolve({ data: [], error: null }),
     purchaseReceiptIds.length
       ? supabase
           .from("inventory_purchase_receipts")
-          .select("id, order_id, inventory_purchase_orders(inventory_suppliers(name))")
+          .select(
+            "id, order_id, inventory_purchase_orders(inventory_suppliers(name))",
+          )
           .in("id", purchaseReceiptIds)
       : Promise.resolve({ data: [], error: null }),
   ]);
@@ -182,6 +183,10 @@ export const getInventoryMovements = async (
   // 전체 이력 조회 실패로 처리하지 않고 기존 메모를 대체 정보로 사용한다.
   const outboundNames = new Map<string, string>();
   const outboundCustomerIds = new Map<string, string>();
+  const outboundItemDetails = new Map<
+    string,
+    { inventoryAction: InventoryMovement["inventory_action"]; remark: string }
+  >();
   if (!outboundResult.error) {
     for (const row of outboundResult.data ?? []) {
       const customers = Array.isArray(row.customers)
@@ -190,6 +195,36 @@ export const getInventoryMovements = async (
       if (customers?.name) outboundNames.set(String(row.id), customers.name);
       if (row.customer_id) {
         outboundCustomerIds.set(String(row.id), String(row.customer_id));
+      }
+      const jsonb = row.jsonb as {
+        items?: Array<{
+          itemName?: unknown;
+          inventoryAction?: unknown;
+          remark?: unknown;
+        }>;
+      } | null;
+      for (const item of Array.isArray(jsonb?.items) ? jsonb.items : []) {
+        const itemName = normalizeInventoryItemName(
+          String(item.itemName ?? ""),
+        );
+        if (!itemName) continue;
+        const action = String(item.inventoryAction ?? "");
+        const inventoryAction = [
+          "out",
+          "exchange_in",
+          "exchange_out",
+          "adjustment_in",
+          "adjustment_out",
+        ].includes(action)
+          ? (action as InventoryMovement["inventory_action"])
+          : null;
+        const direction = ["exchange_in", "adjustment_in"].includes(action)
+          ? "in"
+          : "out";
+        outboundItemDetails.set(`${row.id}\u0000${itemName}\u0000${direction}`, {
+          inventoryAction,
+          remark: String(item.remark ?? ""),
+        });
       }
     }
   }
@@ -211,27 +246,34 @@ export const getInventoryMovements = async (
     }
   }
 
-  return movements.map((movement) => ({
-    ...movement,
-    counterparty_name:
-      movement.reference_type === "outbound_log"
-        ? outboundNames.get(movement.reference_id ?? "") ?? null
-        : ["purchase_receipt", "purchase_receipt_reversal"].includes(
-              movement.reference_type ?? "",
-            )
-          ? supplierNames.get(movement.reference_id ?? "") ?? null
+  return movements.map((movement) => {
+    const itemDetail = outboundItemDetails.get(
+      `${movement.reference_id ?? ""}\u0000${normalizeInventoryItemName(movement.item_name)}\u0000${movement.quantity_delta > 0 ? "in" : "out"}`,
+    );
+    return {
+      ...movement,
+      counterparty_name:
+        movement.reference_type === "outbound_log"
+          ? (outboundNames.get(movement.reference_id ?? "") ?? null)
+          : ["purchase_receipt", "purchase_receipt_reversal"].includes(
+                movement.reference_type ?? "",
+              )
+            ? (supplierNames.get(movement.reference_id ?? "") ?? null)
+            : null,
+      counterparty_id:
+        movement.reference_type === "outbound_log"
+          ? (outboundCustomerIds.get(movement.reference_id ?? "") ?? null)
           : null,
-    counterparty_id:
-      movement.reference_type === "outbound_log"
-        ? outboundCustomerIds.get(movement.reference_id ?? "") ?? null
+      purchase_order_id: [
+        "purchase_receipt",
+        "purchase_receipt_reversal",
+      ].includes(movement.reference_type ?? "")
+        ? (receiptOrderIds.get(movement.reference_id ?? "") ?? null)
         : null,
-    purchase_order_id: [
-      "purchase_receipt",
-      "purchase_receipt_reversal",
-    ].includes(movement.reference_type ?? "")
-      ? receiptOrderIds.get(movement.reference_id ?? "") ?? null
-      : null,
-  }));
+      inventory_action: itemDetail?.inventoryAction ?? null,
+      item_remark: itemDetail?.remark ?? null,
+    };
+  });
 };
 
 export const initializeInventory = async (entries: InventoryEntry[]) => {
@@ -274,19 +316,6 @@ export const receiveInventory = async (
   if (error) throw error;
 };
 
-export const adjustInventory = async (
-  itemName: string,
-  quantity: number,
-  note: string,
-) => {
-  const { error } = await supabase.rpc("adjust_inventory", {
-    p_item_name: normalizeInventoryItemName(itemName),
-    p_quantity: quantity,
-    p_note: note.trim(),
-  });
-  if (error) throw error;
-};
-
 export const reverseInventoryMovement = async (movementId: string) => {
   const { error } = await supabase.rpc("reverse_inventory_movement", {
     p_movement_id: movementId,
@@ -312,8 +341,8 @@ export const saveInventorySupplier = async (
   const { data: savedId, error } = await supabase.rpc(
     "save_inventory_supplier",
     {
-    p_id: id,
-    p_data: data,
+      p_id: id,
+      p_data: data,
     },
   );
   if (error) throw error;
@@ -450,14 +479,17 @@ export const updatePurchaseOrderDetails = async (values: {
     note: string;
   }>;
 }): Promise<void> => {
-  const { error } = await supabase.rpc("update_inventory_purchase_order_details", {
-    p_order_id: values.orderId,
-    p_supplier_id: values.supplierId,
-    p_ordered_on: values.orderedOn,
-    p_note: values.note || null,
-    p_lines: values.lines,
-    p_receipts: values.receipts,
-  });
+  const { error } = await supabase.rpc(
+    "update_inventory_purchase_order_details",
+    {
+      p_order_id: values.orderId,
+      p_supplier_id: values.supplierId,
+      p_ordered_on: values.orderedOn,
+      p_note: values.note || null,
+      p_lines: values.lines,
+      p_receipts: values.receipts,
+    },
+  );
   if (error) throw error;
 };
 export const createPurchaseOrder = async (

--- a/src/app/_domains/_inventory/_types/inventory.types.ts
+++ b/src/app/_domains/_inventory/_types/inventory.types.ts
@@ -39,6 +39,14 @@ export type InventoryMovement = {
   counterparty_name?: string | null;
   counterparty_id?: string | null;
   purchase_order_id?: string | null;
+  inventory_action?:
+    | "out"
+    | "exchange_in"
+    | "exchange_out"
+    | "adjustment_in"
+    | "adjustment_out"
+    | null;
+  item_remark?: string | null;
   users?: { name: string | null } | null;
 };
 

--- a/src/app/_domains/_log/_services/logService.ts
+++ b/src/app/_domains/_log/_services/logService.ts
@@ -3,34 +3,46 @@ import {
   LogCategoryEnumType,
   PaymentTypeEnumType,
   StoreTypeEnumType,
-} from '@/app/_enums/enums';
-import type { StampLogMeta } from '@/app/_domains/_stamp/_services/stampService';
-import { confirmOutboundInventory } from '@/app/_domains/_inventory/_services/outboundInventoryService';
+} from "@/app/_enums/enums";
+import type { StampLogMeta } from "@/app/_domains/_stamp/_services/stampService";
+import { confirmOutboundInventory } from "@/app/_domains/_inventory/_services/outboundInventoryService";
 import {
   AfterServiceLogsResType,
   CustomersLogsResType,
   LogsResType,
-} from '@/app/_domains/_log/_types/log.types';
-import supabase from '@/libs/supabaseClient';
-import { getCurrentWorkerName } from '@/app/_domains/_workJournal/_utils/currentWorker';
+} from "@/app/_domains/_log/_types/log.types";
+import supabase from "@/libs/supabaseClient";
+import { getCurrentWorkerName } from "@/app/_domains/_workJournal/_utils/currentWorker";
 
 const resolveCurrentWorkerName = async () => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (session) {
+    const { data: currentUser } = await supabase
+      .from("users")
+      .select("oss_role")
+      .eq("id", session.user.id)
+      .maybeSingle();
+    if (currentUser?.oss_role === "admin") return "관리자";
+  }
+
   const storedWorkerName = getCurrentWorkerName();
   if (storedWorkerName) return storedWorkerName;
 
-  const today = new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'Asia/Seoul',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
+  const today = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
   }).format(new Date());
   const { data } = await supabase
-    .from('work_journals')
-    .select('worker_name')
-    .eq('work_date', today)
-    .eq('status', 'working')
+    .from("work_journals")
+    .select("worker_name")
+    .eq("work_date", today)
+    .eq("status", "working")
     .limit(2);
-  return data?.length === 1 ? data[0].worker_name : '';
+  return data?.length === 1 ? data[0].worker_name : "";
 };
 
 export const withCreatedWorker = async (
@@ -54,16 +66,16 @@ const withModifiedWorker = async (jsonb: Record<string, unknown>) => {
           workerName: string;
           modifiedAt: string;
         } =>
-          typeof item === 'object' &&
+          typeof item === "object" &&
           item !== null &&
-          typeof (item as Record<string, unknown>).workerName === 'string' &&
-          typeof (item as Record<string, unknown>).modifiedAt === 'string',
+          typeof (item as Record<string, unknown>).workerName === "string" &&
+          typeof (item as Record<string, unknown>).modifiedAt === "string",
       )
     : [];
   const legacyHistory =
     storedHistory.length === 0 &&
-    typeof jsonb.modifiedWorkerName === 'string' &&
-    typeof jsonb.modifiedAt === 'string'
+    typeof jsonb.modifiedWorkerName === "string" &&
+    typeof jsonb.modifiedAt === "string"
       ? [
           {
             workerName: jsonb.modifiedWorkerName,
@@ -71,7 +83,7 @@ const withModifiedWorker = async (jsonb: Record<string, unknown>) => {
           },
         ]
       : [];
-  const nextWorkerName = workerName || '알 수 없음';
+  const nextWorkerName = workerName || "알 수 없음";
 
   return {
     ...jsonb,
@@ -89,10 +101,10 @@ const withModifiedWorker = async (jsonb: Record<string, unknown>) => {
  * 로그 추가
  */
 export const createLog = async (
-  category: LogCategoryEnumType['value'],
+  category: LogCategoryEnumType["value"],
   customerId: string,
   action: string,
-  note: string = '',
+  note: string = "",
   jsonb: Record<string, unknown> | null = null,
 ) => {
   // 현재 세션에서 user id 가져오기
@@ -102,13 +114,13 @@ export const createLog = async (
   } = await supabase.auth.getSession();
 
   if (sessionError || !session) {
-    throw new Error('세션을 찾을 수 없습니다');
+    throw new Error("세션을 찾을 수 없습니다");
   }
 
   const adminId = session.user.id;
 
   const { data, error } = await supabase
-    .from('logs')
+    .from("logs")
     .insert({
       admin_id: adminId,
       customer_id: customerId,
@@ -129,7 +141,7 @@ export const createLog = async (
  * 특정 고객의 로그 조회 (최신순)
  */
 export const getLogsByCustomer = async (
-  category: LogCategoryEnumType['value'] = 'stamp',
+  category: LogCategoryEnumType["value"] = "stamp",
   customerId: string,
   limit = 10,
   offset = 0,
@@ -137,16 +149,16 @@ export const getLogsByCustomer = async (
   const from = offset;
   const to = offset + limit - 1;
   const { data, error } = await supabase
-    .from('logs')
+    .from("logs")
     .select(
       `
       *,
-      users!admin_id(name, email)
+      users!admin_id(name, email, oss_role)
     `,
     )
-    .eq('customer_id', customerId)
-    .eq('category', category)
-    .order('created_at', { ascending: false })
+    .eq("customer_id", customerId)
+    .eq("category", category)
+    .order("created_at", { ascending: false })
     .range(from, to);
 
   if (error) throw error;
@@ -158,7 +170,7 @@ export const createAfterServiceLog = async (
   customerId: string | null,
   afterServiceId: number,
   action: string,
-  note: string = '',
+  note: string = "",
   jsonb: Record<string, unknown> | null = null,
 ) => {
   // 현재 세션에서 user id 가져오기
@@ -168,13 +180,13 @@ export const createAfterServiceLog = async (
   } = await supabase.auth.getSession();
 
   if (sessionError || !session) {
-    throw new Error('세션을 찾을 수 없습니다');
+    throw new Error("세션을 찾을 수 없습니다");
   }
 
   const adminId = session.user.id;
 
   const { data, error } = await supabase
-    .from('logs')
+    .from("logs")
     .insert({
       admin_id: adminId,
       customer_id: customerId ? String(customerId) : null,
@@ -203,14 +215,14 @@ export const getLogsByAfterServiceId = async (
   const from = offset;
   const to = offset + limit - 1;
   const { data, error } = await supabase
-    .from('logs')
+    .from("logs")
     .select(
       `*,
-      users!admin_id(name, email)`,
+      users!admin_id(name, email, oss_role)`,
     )
-    .eq('after_service_id', afterServiceId)
-    .eq('category', 'after_service')
-    .order('created_at', { ascending: false })
+    .eq("after_service_id", afterServiceId)
+    .eq("category", "after_service")
+    .order("created_at", { ascending: false })
     .range(from, to);
 
   if (error) throw error;
@@ -223,7 +235,7 @@ export const getLogsByAfterServiceId = async (
 export const getLogs = async (
   limit = 10,
   offset = 0,
-  category: LogCategoryEnumType['value'] = 'stamp',
+  category: LogCategoryEnumType["value"] = "stamp",
   dateRange?: { start: string; end: string },
   paymentMethod?: string,
   searchKeyword?: string,
@@ -231,37 +243,35 @@ export const getLogs = async (
   const from = offset;
   const to = offset + limit - 1;
   let query = supabase
-    .from('logs')
+    .from("logs")
     .select(
       `
       *,
-      users!admin_id(name, email),
+      users!admin_id(name, email, oss_role),
       customers(name, phone, address, note, gender)
     `,
     )
-    .eq('category', category);
+    .eq("category", category);
 
   if (dateRange) {
     query = query
-      .gte('created_at', dateRange.start)
-      .lte('created_at', `${dateRange.end}T23:59:59.999Z`);
+      .gte("created_at", dateRange.start)
+      .lte("created_at", `${dateRange.end}T23:59:59.999Z`);
   }
 
   if (paymentMethod) {
-    const splitPaymentFilter = JSON.stringify([
-      { paymentType: paymentMethod },
-    ]);
+    const splitPaymentFilter = JSON.stringify([{ paymentType: paymentMethod }]);
     query = query.or(
       `jsonb->>paymentType.eq.${paymentMethod},jsonb->payments.cs.${splitPaymentFilter}`,
     );
   }
 
   if (searchKeyword) {
-    query = query.ilike('note', `%${searchKeyword}%`);
+    query = query.ilike("note", `%${searchKeyword}%`);
   }
 
   const { data, error } = await query
-    .order('created_at', { ascending: !!dateRange })
+    .order("created_at", { ascending: !!dateRange })
     .range(from, to);
 
   if (error) throw error;
@@ -272,7 +282,7 @@ export const getLogs = async (
  * 로그 삭제
  */
 export const deleteLog = async (logId: string) => {
-  const { error } = await supabase.rpc('cancel_or_delete_log_operation', {
+  const { error } = await supabase.rpc("cancel_or_delete_log_operation", {
     p_log_id: String(logId),
   });
   if (error) throw error;
@@ -284,15 +294,15 @@ export const deleteLog = async (logId: string) => {
 export const updateLogNote = async (
   logId: string,
   note: string,
-  paymentType?: PaymentTypeEnumType['value'],
-  storeName?: StoreTypeEnumType['value'],
+  paymentType?: PaymentTypeEnumType["value"],
+  storeName?: StoreTypeEnumType["value"],
   logMeta?: StampLogMeta,
   action?: string,
 ) => {
   const { data: existing, error: fetchError } = await supabase
-    .from('logs')
-    .select('jsonb, category')
-    .eq('id', logId)
+    .from("logs")
+    .select("jsonb, category")
+    .eq("id", logId)
     .single();
 
   if (fetchError) throw fetchError;
@@ -302,7 +312,7 @@ export const updateLogNote = async (
     existing?.category === LogCategoryEnum.STAMP.value &&
     !(await confirmOutboundInventory(logMeta.items, logId))
   ) {
-    throw new Error('사용자가 출고 수정을 취소했습니다.');
+    throw new Error("사용자가 출고 수정을 취소했습니다.");
   }
 
   const currentJsonb =
@@ -323,7 +333,7 @@ export const updateLogNote = async (
     } else {
       delete nextJsonb.extraNote;
     }
-    nextJsonb.deliveryMethod = logMeta.deliveryMethod ?? 'store_visit';
+    nextJsonb.deliveryMethod = logMeta.deliveryMethod ?? "store_visit";
     if (logMeta.deliveryAddressSource) {
       nextJsonb.deliveryAddressSource = logMeta.deliveryAddressSource;
     } else {
@@ -353,9 +363,9 @@ export const updateLogNote = async (
   if (action !== undefined) updatePayload.action = action;
 
   const { data, error } = await supabase
-    .from('logs')
+    .from("logs")
     .update(updatePayload)
-    .eq('id', logId)
+    .eq("id", logId)
     .select()
     .single();
 

--- a/src/app/_domains/_log/_types/log.types.ts
+++ b/src/app/_domains/_log/_types/log.types.ts
@@ -1,8 +1,9 @@
-import { LogCategoryEnumType } from '@/app/_enums/enums';
+import { LogCategoryEnumType } from "@/app/_enums/enums";
 
 export type LogActorUserInfo = {
   name: string;
   email: string;
+  oss_role?: "staff" | "admin";
 };
 
 export type LogBaseType = {
@@ -13,7 +14,7 @@ export type LogBaseType = {
   note: string;
   created_at: string;
   updated_at: string;
-  category: LogCategoryEnumType['value'];
+  category: LogCategoryEnumType["value"];
   users?: LogActorUserInfo;
   jsonb: Record<string, unknown>;
 };
@@ -37,7 +38,7 @@ export type LogCustomerInfo = {
   phone: string;
   address?: string | null;
   note?: string | null;
-  gender?: 'male' | 'female' | null;
+  gender?: "male" | "female" | null;
 };
 
 // 고객 상세 페이지의 로그

--- a/src/app/_domains/_workJournal/_services/workJournalService.ts
+++ b/src/app/_domains/_workJournal/_services/workJournalService.ts
@@ -1,31 +1,31 @@
-import supabase from '@/libs/supabaseClient';
+import supabase from "@/libs/supabaseClient";
 import {
   WorkJournalType,
   WorkPaymentStatus,
   WorkerDetailType,
-} from '../_types/workJournal.types';
+} from "../_types/workJournal.types";
 
 const getNextMonth = (month: string) => {
-  const [year, monthNumber] = month.split('-').map(Number);
+  const [year, monthNumber] = month.split("-").map(Number);
   const next = new Date(Date.UTC(year, monthNumber, 1));
-  return `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}`;
+  return `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, "0")}`;
 };
 
 export const getWorkJournals = async (
   month: string,
-  workerName = '',
+  workerName = "",
 ): Promise<WorkJournalType[]> => {
   let query = supabase
-    .from('work_journals')
-    .select('*')
-    .gte('work_date', `${month}-01`)
-    .lt('work_date', `${getNextMonth(month)}-01`);
+    .from("work_journals")
+    .select("*")
+    .gte("work_date", `${month}-01`)
+    .lt("work_date", `${getNextMonth(month)}-01`);
 
-  if (workerName) query = query.eq('worker_name', workerName);
+  if (workerName) query = query.eq("worker_name", workerName);
 
   const { data, error } = await query
-    .order('work_date', { ascending: false })
-    .order('start_time', { ascending: true });
+    .order("work_date", { ascending: false })
+    .order("start_time", { ascending: true });
 
   if (error) throw error;
   return (data ?? []) as WorkJournalType[];
@@ -34,19 +34,19 @@ export const getWorkJournals = async (
 export const getWorkJournalsByRange = async (
   startDate: string,
   endDate: string,
-  workerName = '',
+  workerName = "",
 ): Promise<WorkJournalType[]> => {
   let query = supabase
-    .from('work_journals')
-    .select('*')
-    .gte('work_date', startDate)
-    .lte('work_date', endDate);
+    .from("work_journals")
+    .select("*")
+    .gte("work_date", startDate)
+    .lte("work_date", endDate);
 
-  if (workerName) query = query.eq('worker_name', workerName);
+  if (workerName) query = query.eq("worker_name", workerName);
 
   const { data, error } = await query
-    .order('work_date', { ascending: false })
-    .order('start_time', { ascending: true });
+    .order("work_date", { ascending: false })
+    .order("start_time", { ascending: true });
 
   if (error) throw error;
   return (data ?? []) as WorkJournalType[];
@@ -56,10 +56,10 @@ export const getWorkJournalsByDate = async (
   date: string,
 ): Promise<WorkJournalType[]> => {
   const { data, error } = await supabase
-    .from('work_journals')
-    .select('*')
-    .eq('work_date', date)
-    .order('start_time', { ascending: true });
+    .from("work_journals")
+    .select("*")
+    .eq("work_date", date)
+    .order("start_time", { ascending: true });
 
   if (error) throw error;
   return (data ?? []) as WorkJournalType[];
@@ -67,10 +67,10 @@ export const getWorkJournalsByDate = async (
 
 export const getWorkerNames = async (): Promise<string[]> => {
   const { data, error } = await supabase
-    .from('work_journal_workers')
-    .select('name')
-    .eq('is_active', true)
-    .order('name', { ascending: true });
+    .from("work_journal_workers")
+    .select("name")
+    .eq("is_active", true)
+    .order("name", { ascending: true });
 
   if (error) throw error;
   return (data ?? []).map((row) => row.name);
@@ -78,15 +78,17 @@ export const getWorkerNames = async (): Promise<string[]> => {
 
 export const getWorkerDetails = async (): Promise<WorkerDetailType[]> => {
   const { data: workers, error: workersError } = await supabase
-    .from('work_journal_workers')
-    .select('id, name, is_active')
-    .order('name', { ascending: true });
+    .from("work_journal_workers")
+    .select("id, name, is_active")
+    .order("name", { ascending: true });
 
   if (workersError) throw workersError;
 
   const { data: privateDetails, error: detailsError } = await supabase
-    .from('work_journal_worker_private')
-    .select('worker_id, phone_number, bank_account, first_work_date, note, pin_hash, pin_code');
+    .from("work_journal_worker_private")
+    .select(
+      "worker_id, phone_number, bank_account, first_work_date, note, pin_hash, pin_code",
+    );
 
   if (detailsError) throw detailsError;
   const detailByWorkerId = new Map(
@@ -97,12 +99,12 @@ export const getWorkerDetails = async (): Promise<WorkerDetailType[]> => {
     const detail = detailByWorkerId.get(worker.id);
     return {
       ...worker,
-      phone_number: detail?.phone_number ?? '',
-      bank_account: detail?.bank_account ?? '',
-      first_work_date: detail?.first_work_date ?? '',
+      phone_number: detail?.phone_number ?? "",
+      bank_account: detail?.bank_account ?? "",
+      first_work_date: detail?.first_work_date ?? "",
       note: detail?.note ?? null,
       has_pin: Boolean(detail?.pin_hash),
-      pin_code: detail?.pin_code ?? '',
+      pin_code: detail?.pin_code ?? "",
     };
   });
 };
@@ -121,22 +123,22 @@ export const createWorker = async (values: {
     error: sessionError,
   } = await supabase.auth.getSession();
 
-  if (sessionError || !session) throw new Error('세션을 찾을 수 없습니다.');
+  if (sessionError || !session) throw new Error("세션을 찾을 수 없습니다.");
 
   const { data: worker, error } = await supabase
-    .from('work_journal_workers')
+    .from("work_journal_workers")
     .insert({
       name: values.name.trim(),
       is_active: values.isActive,
       created_by: session.user.id,
     })
-    .select('id')
+    .select("id")
     .single();
 
   if (error) throw error;
 
   const { error: privateError } = await supabase
-    .from('work_journal_worker_private')
+    .from("work_journal_worker_private")
     .insert({
       worker_id: worker.id,
       phone_number: values.phoneNumber.trim(),
@@ -148,7 +150,7 @@ export const createWorker = async (values: {
     });
 
   if (privateError) {
-    await supabase.from('work_journal_workers').delete().eq('id', worker.id);
+    await supabase.from("work_journal_workers").delete().eq("id", worker.id);
     throw privateError;
   }
 };
@@ -165,41 +167,39 @@ export const updateWorkerDetails = async (
   },
 ): Promise<void> => {
   const { error: workerError } = await supabase
-    .from('work_journal_workers')
+    .from("work_journal_workers")
     .update({
       is_active: values.isActive,
       updated_at: new Date().toISOString(),
     })
-    .eq('id', workerId);
+    .eq("id", workerId);
 
   if (workerError) throw workerError;
 
-  const { error } = await supabase
-    .from('work_journal_worker_private')
-    .upsert(
-      {
-        worker_id: workerId,
-        phone_number: values.phoneNumber.trim(),
-        bank_account: values.bankAccount.trim(),
-        first_work_date: values.firstWorkDate,
-        note: values.note.trim() || null,
-        ...(values.pin ? { pin_hash: values.pin, pin_code: values.pin } : {}),
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: 'worker_id' },
-    );
+  const { error } = await supabase.from("work_journal_worker_private").upsert(
+    {
+      worker_id: workerId,
+      phone_number: values.phoneNumber.trim(),
+      bank_account: values.bankAccount.trim(),
+      first_work_date: values.firstWorkDate,
+      note: values.note.trim() || null,
+      ...(values.pin ? { pin_hash: values.pin, pin_code: values.pin } : {}),
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "worker_id" },
+  );
 
   if (error) throw error;
 };
 
 export const deactivateWorker = async (name: string): Promise<void> => {
   const { error } = await supabase
-    .from('work_journal_workers')
+    .from("work_journal_workers")
     .update({
       is_active: false,
       updated_at: new Date().toISOString(),
     })
-    .eq('name', name);
+    .eq("name", name);
 
   if (error) throw error;
 };
@@ -211,7 +211,7 @@ export const createWorkJournal = async (values: {
   endTime: string;
   workHours: number;
   note: string;
-  workType: 'solo' | 'shift';
+  workType: "solo" | "shift";
   pin: string;
 }): Promise<void> => {
   const {
@@ -219,30 +219,30 @@ export const createWorkJournal = async (values: {
     error: sessionError,
   } = await supabase.auth.getSession();
 
-  if (sessionError || !session) throw new Error('세션을 찾을 수 없습니다.');
+  if (sessionError || !session) throw new Error("세션을 찾을 수 없습니다.");
 
   const { data: verified, error: verifyError } = await supabase.rpc(
-    'verify_work_journal_worker_pin',
+    "verify_work_journal_worker_pin",
     { p_worker_name: values.workerName.trim(), p_pin: values.pin },
   );
   if (verifyError) throw verifyError;
-  if (!verified) throw new Error('INVALID_WORKER_PIN');
+  if (!verified) throw new Error("INVALID_WORKER_PIN");
 
   const normalizedWorkerName = values.workerName.trim();
   const { data: pendingHandover, error: pendingError } = await supabase
-    .from('work_journals')
-    .select('id')
-    .eq('work_date', values.workDate)
-    .eq('status', 'handover_pending')
-    .neq('worker_name', normalizedWorkerName)
-    .order('updated_at', { ascending: false })
+    .from("work_journals")
+    .select("id")
+    .eq("work_date", values.workDate)
+    .eq("status", "handover_pending")
+    .neq("worker_name", normalizedWorkerName)
+    .order("updated_at", { ascending: false })
     .limit(1)
     .maybeSingle();
 
   if (pendingError) throw pendingError;
 
   const { data: createdJournal, error } = await supabase
-    .from('work_journals')
+    .from("work_journals")
     .insert({
       work_date: values.workDate,
       worker_name: normalizedWorkerName,
@@ -252,35 +252,35 @@ export const createWorkJournal = async (values: {
       work_hours: values.workHours,
       note: values.note.trim() || null,
       work_type: values.workType,
-      status: 'working',
+      status: "working",
       created_by: session.user.id,
     })
-    .select('id')
+    .select("id")
     .single();
 
   if (error) throw error;
 
   if (pendingHandover) {
     const { error: handoverError } = await supabase
-      .from('work_journals')
+      .from("work_journals")
       .update({
-        status: 'shift_completed',
+        status: "shift_completed",
         updated_at: new Date().toISOString(),
       })
-      .eq('id', pendingHandover.id)
-      .eq('status', 'handover_pending');
+      .eq("id", pendingHandover.id)
+      .eq("status", "handover_pending");
 
     if (handoverError) {
-      await supabase.from('work_journals').delete().eq('id', createdJournal.id);
+      await supabase.from("work_journals").delete().eq("id", createdJournal.id);
       throw handoverError;
     }
   }
 
   window.localStorage.setItem(
-    'current-work-worker',
+    "current-work-worker",
     JSON.stringify({ name: normalizedWorkerName, workDate: values.workDate }),
   );
-  window.dispatchEvent(new Event('staff-opening-changed'));
+  window.dispatchEvent(new Event("staff-opening-changed"));
 };
 
 export const completeWorkJournal = async (values: {
@@ -288,33 +288,63 @@ export const completeWorkJournal = async (values: {
   workerName: string;
   pin: string;
   actualEndTime: string;
+  inputEndTime: string;
   workHours: number;
   inputWorkHours: number;
   note: string;
-  workType: 'solo' | 'shift';
-}): Promise<void> => {
+  workType: "solo" | "shift";
+}): Promise<"handover_pending" | "shift_completed" | "closed"> => {
   const { data: verified, error: verifyError } = await supabase.rpc(
-    'verify_work_journal_worker_pin',
+    "verify_work_journal_worker_pin",
     { p_worker_name: values.workerName.trim(), p_pin: values.pin },
   );
   if (verifyError) throw verifyError;
-  if (!verified) throw new Error('INVALID_WORKER_PIN');
+  if (!verified) throw new Error("INVALID_WORKER_PIN");
+
+  let completionStatus: "handover_pending" | "shift_completed" | "closed" =
+    "closed";
+
+  if (values.workType === "shift") {
+    const { data: currentJournal, error: currentJournalError } = await supabase
+      .from("work_journals")
+      .select("work_date, created_at")
+      .eq("id", values.journalId)
+      .eq("worker_name", values.workerName.trim())
+      .single();
+
+    if (currentJournalError) throw currentJournalError;
+
+    const { data: successor, error: successorError } = await supabase
+      .from("work_journals")
+      .select("id")
+      .eq("work_date", currentJournal.work_date)
+      .neq("worker_name", values.workerName.trim())
+      .gt("created_at", currentJournal.created_at)
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (successorError) throw successorError;
+    completionStatus = successor ? "shift_completed" : "handover_pending";
+  }
 
   const { error } = await supabase
-    .from('work_journals')
+    .from("work_journals")
     .update({
       end_time: values.actualEndTime,
+      expected_end_time: values.inputEndTime,
       work_hours: values.workHours,
       input_work_hours: values.inputWorkHours,
       note: values.note.trim() || null,
-      status: values.workType === 'shift' ? 'handover_pending' : 'closed',
+      status: completionStatus,
       updated_at: new Date().toISOString(),
     })
-    .eq('id', values.journalId)
-    .eq('worker_name', values.workerName.trim());
+    .eq("id", values.journalId)
+    .eq("worker_name", values.workerName.trim());
 
   if (error) throw error;
-  window.localStorage.removeItem('current-work-worker');
+  window.localStorage.removeItem("current-work-worker");
+  return completionStatus;
 };
 
 export const closeHandoverWithoutSuccessor = async (
@@ -322,27 +352,27 @@ export const closeHandoverWithoutSuccessor = async (
   reason: string,
 ): Promise<void> => {
   const normalizedReason = reason.trim();
-  if (!normalizedReason) throw new Error('HANDOVER_CLOSE_REASON_REQUIRED');
+  if (!normalizedReason) throw new Error("HANDOVER_CLOSE_REASON_REQUIRED");
 
   const { data: journal, error: findError } = await supabase
-    .from('work_journals')
-    .select('note')
-    .eq('id', journalId)
-    .eq('status', 'handover_pending')
+    .from("work_journals")
+    .select("note")
+    .eq("id", journalId)
+    .eq("status", "handover_pending")
     .single();
 
   if (findError) throw findError;
 
   const closeNote = `[교대 없이 종료] ${normalizedReason}`;
   const { error } = await supabase
-    .from('work_journals')
+    .from("work_journals")
     .update({
-      status: 'closed',
-      note: [journal.note, closeNote].filter(Boolean).join('\n'),
+      status: "closed",
+      note: [journal.note, closeNote].filter(Boolean).join("\n"),
       updated_at: new Date().toISOString(),
     })
-    .eq('id', journalId)
-    .eq('status', 'handover_pending');
+    .eq("id", journalId)
+    .eq("status", "handover_pending");
 
   if (error) throw error;
 };
@@ -358,20 +388,20 @@ export const updateAttendanceJournal = async (
     workHours: number;
     inputWorkHours: number | null;
     note: string;
-    workType: 'solo' | 'shift';
-    status: 'working' | 'handover_pending' | 'shift_completed' | 'closed';
+    workType: "solo" | "shift";
+    status: "working" | "handover_pending" | "shift_completed" | "closed";
     actualStartTime?: string;
   },
 ): Promise<void> => {
   const { error } = await supabase
-    .from('work_journals')
+    .from("work_journals")
     .update({
       work_date: values.workDate,
       worker_name: values.workerName.trim(),
       start_time: values.startTime,
       expected_end_time: values.expectedEndTime,
       end_time:
-        values.status !== 'working'
+        values.status !== "working"
           ? values.actualEndTime
           : values.expectedEndTime,
       work_hours: values.workHours,
@@ -388,7 +418,7 @@ export const updateAttendanceJournal = async (
         : {}),
       updated_at: new Date().toISOString(),
     })
-    .eq('id', journalId);
+    .eq("id", journalId);
 
   if (error) throw error;
 };
@@ -397,7 +427,7 @@ export const verifyWorkerPin = async (
   workerName: string,
   pin: string,
 ): Promise<boolean> => {
-  const { data, error } = await supabase.rpc('verify_work_journal_worker_pin', {
+  const { data, error } = await supabase.rpc("verify_work_journal_worker_pin", {
     p_worker_name: workerName.trim(),
     p_pin: pin,
   });
@@ -414,11 +444,11 @@ export const updateWorkJournal = async (
     endTime: string;
     workHours: number;
     note: string;
-    workType: 'solo' | 'shift';
+    workType: "solo" | "shift";
   },
 ): Promise<void> => {
   const { error } = await supabase
-    .from('work_journals')
+    .from("work_journals")
     .update({
       work_date: values.workDate,
       worker_name: values.workerName.trim(),
@@ -430,13 +460,13 @@ export const updateWorkJournal = async (
       work_type: values.workType,
       updated_at: new Date().toISOString(),
     })
-    .eq('id', id);
+    .eq("id", id);
 
   if (error) throw error;
 };
 
 export const deleteWorkJournal = async (id: string): Promise<void> => {
-  const { error } = await supabase.from('work_journals').delete().eq('id', id);
+  const { error } = await supabase.from("work_journals").delete().eq("id", id);
   if (error) throw error;
 };
 
@@ -452,20 +482,20 @@ export const updateWorkJournalPaymentStatus = async (
     error: sessionError,
   } = await supabase.auth.getSession();
 
-  if (sessionError || !session) throw new Error('세션을 찾을 수 없습니다.');
+  if (sessionError || !session) throw new Error("세션을 찾을 수 없습니다.");
 
-  const isPaid = status !== 'unpaid';
+  const isPaid = status !== "unpaid";
   let query = supabase
-    .from('work_journals')
+    .from("work_journals")
     .update({
       payment_status: status,
       paid_at: isPaid ? new Date().toISOString() : null,
       paid_by: isPaid ? session.user.id : null,
       updated_at: new Date().toISOString(),
     })
-    .in('id', journalIds);
+    .in("id", journalIds);
 
-  if (fromStatus) query = query.eq('payment_status', fromStatus);
+  if (fromStatus) query = query.eq("payment_status", fromStatus);
 
   const { error } = await query;
 


### PR DESCRIPTION
## 작업 내용

### 재고 및 출고 관리

- 재고조정 입고·출고 유형을 각각 `재고조정-입고`, `재고조정-출고`로 구분
- 시연용, 재고조정, 교환 입출고의 재고변동 종류와 이동경로 개선
- 동일 품목의 교환입고·교환출고를 입출고 방향별로 구분
- 재고변동 종류 명칭 변경
  - 출고 수정 → 출고/수정
  - 출고 취소 → 출고/취소
  - 입고 취소 → 입고/취소
- 직접 재고조정 기능 제거
- 특수계정 처리메모 제목 및 입력 문구 정리

### 근무기록

- 출근·퇴근 관련 항목 명칭과 표시 방식 정리
- 출근 유형을 혼자 근무, 교대 첫 근무, 교대 마지막 근무로 구분
- 출근 유형별 기본 출근시간 설정
- 퇴근 기록 입력 화면 간소화
- 입력 퇴근시간 기본값을 오후 10시로 설정
- 급여 및 근무시간 합계를 입력 근무시간 기준으로 통일
- 입력 근무시간이 없으면 급여 집계에서 0시간 처리
- admin과 staff의 근무기록표 열 너비를 각각 저장하도록 개선
- staff 표에서 처리시각과 실제 근무시간 숨김

### 마감보고서

- 일반 출고, 나머지 출고, 수령 방식, 입고 영역 구성 개선
- 입고 영역에 거래처별 입고전표 건수 표시
- 제품 수량이 아닌 입고 처리 횟수를 `N건`으로 집계
- 신규 마감보고서에 입고 건수를 스냅샷으로 고정
- 기존 보고서의 제품 수량 오표시 보정
- 마감보고서 표 너비와 표시 순서 조정
- 근무자 표시 영역과 보고서 상단 레이아웃 간소화

### 계정 및 권한

- 사용자 정보 클릭 시 staff/admin 계정 전환 기능 추가
- 전환 대상 계정 선택 후 비밀번호 확인
- 윤동호, 이대양 계정은 전환 목록에서 제외
- 관리자 작업 이력을 근무자 이름 대신 `관리자`로 표시
- staff에서 입고의 거래처 관리 탭 숨김
- staff 일반 고객 메뉴 복원
- 로그아웃 위치 유지

### UI 및 기타

- 로그인, 헤더, 기기 비교 워터마크 로고 비율 경고 제거
- 로고의 화면 크기를 유지하면서 원본 비율 보존
- 표와 모달의 잘림 및 반응형 표시 개선

## 검증

- ESLint 통과
- TypeScript 검사 통과
- Next.js 프로덕션 빌드 통과
- 전체 20개 페이지 생성 확인
- `git diff --check` 통과
- 로컬 서버 주요 경로 HTTP 200 확인
- 브라우저 콘솔 로고 비율 경고 제거 확인

## 참고

- 실제 재고변동 생성, 출퇴근 확정, 마감 확정처럼 운영 데이터를 변경하는 테스트는 수행하지 않았습니다.