### PR TITLE
출고 배송 방식 및 마감보고서·이력 UI 개선

### DIFF
--- a/src/app/(auth)/_components/HistoriesComponents/CustomerInfo.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/CustomerInfo.tsx
@@ -1,4 +1,4 @@
-import { formatPhoneNumber } from '@/app/_utils/utils';
+import { formatPhoneNumber } from "@/app/_utils/utils";
 
 const CustomerInfo = ({
   name,
@@ -15,7 +15,7 @@ const CustomerInfo = ({
       onClick={onClick}
     >
       <p className="text-base font-semibold text-gray-900">
-        {name || '이름 없음'}
+        {name || "이름 없음"}
       </p>
       <p className="text-sm text-gray-600">{formatPhoneNumber(phone)}</p>
     </div>

--- a/src/app/(auth)/_components/StampLogEditModal.tsx
+++ b/src/app/(auth)/_components/StampLogEditModal.tsx
@@ -1,72 +1,72 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, useState } from 'react';
-import Button from '@/app/_components/Button';
+import { useEffect, useMemo, useState } from "react";
+import Button from "@/app/_components/Button";
 import {
   PaymentTypeEnumType,
   StoreTypeEnum,
   StoreTypeEnumType,
-} from '@/app/_enums/enums';
+} from "@/app/_enums/enums";
 import StampLogForm, {
   StampLogValue,
-} from '@/app/(auth)/customers/_components/StampLogForm';
-import TargetCustomerCard from '@/app/(auth)/customers/_components/TargetCustomerCard';
-import type { StampLogMeta } from '@/app/_domains/_stamp/_services/stampService';
-import { useModal } from '@/app/_contexts/ModalContext';
-import { getCustomerMode } from '@/app/_domains/_customer/_utils/specialCustomer';
+} from "@/app/(auth)/customers/_components/StampLogForm";
+import TargetCustomerCard from "@/app/(auth)/customers/_components/TargetCustomerCard";
+import type { StampLogMeta } from "@/app/_domains/_stamp/_services/stampService";
+import { useModal } from "@/app/_contexts/ModalContext";
+import { getCustomerMode } from "@/app/_domains/_customer/_utils/specialCustomer";
 
 const getStampAmountFromAction = (action: string) => {
-  if (action === 'no-stamp') return 0;
-  if (action.startsWith('add-')) {
-    const amount = Number(action.replace('add-', ''));
+  if (action === "no-stamp") return 0;
+  if (action.startsWith("add-")) {
+    const amount = Number(action.replace("add-", ""));
     return Number.isFinite(amount) ? amount : 0;
   }
   return 0;
 };
 
-const formatAmount = (value: number) => value.toLocaleString('ko-KR');
+const formatAmount = (value: number) => value.toLocaleString("ko-KR");
 
 const getShipmentTypeLabel = (
-  item: NonNullable<StampLogMeta['items']>[number],
+  item: NonNullable<StampLogMeta["items"]>[number],
 ) => {
-  if (item.inventoryAction === 'adjustment_in') return '재고조정-입고';
-  if (item.inventoryAction === 'adjustment_out') return '재고조정-출고';
-  if (item.inventoryAction === 'exchange_in') return '교환입고';
-  if (item.inventoryAction === 'exchange_out') return '교환출고';
-  if (item.remark?.startsWith('시연용')) return '시연용';
-  if (typeof item.adjustedUnitPrice === 'number') return '가격조정';
-  if (item.remark?.startsWith('서비스')) return '서비스';
-  return '일반판매';
+  if (item.inventoryAction === "adjustment_in") return "재고조정-입고";
+  if (item.inventoryAction === "adjustment_out") return "재고조정-출고";
+  if (item.inventoryAction === "exchange_in") return "교환입고";
+  if (item.inventoryAction === "exchange_out") return "교환출고";
+  if (item.remark?.startsWith("시연용")) return "시연용";
+  if (typeof item.adjustedUnitPrice === "number") return "가격조정";
+  if (item.remark?.startsWith("서비스")) return "서비스";
+  return "일반판매";
 };
 
 const getShipmentTypeClassName = (
-  item: NonNullable<StampLogMeta['items']>[number],
+  item: NonNullable<StampLogMeta["items"]>[number],
 ) => {
   const type = getShipmentTypeLabel(item);
-  if (type === '서비스') return 'bg-sky-50 text-sky-700';
-  if (type === '교환입고') return 'bg-emerald-50 text-emerald-700';
-  if (type === '교환출고') return 'bg-amber-50 text-amber-700';
-  if (type === '가격조정') return 'bg-violet-50 text-violet-700';
-  return 'bg-gray-100 text-gray-600';
+  if (type === "서비스") return "bg-sky-50 text-sky-700";
+  if (type === "교환입고") return "bg-emerald-50 text-emerald-700";
+  if (type === "교환출고") return "bg-amber-50 text-amber-700";
+  if (type === "가격조정") return "bg-violet-50 text-violet-700";
+  return "bg-gray-100 text-gray-600";
 };
 
 const getItemDisplayMemo = (
-  item: NonNullable<StampLogMeta['items']>[number],
+  item: NonNullable<StampLogMeta["items"]>[number],
 ) => {
   const remark = item.remark?.trim();
-  if (!remark) return '';
+  if (!remark) return "";
   const wrappedMemo = remark.match(
     /^(?:서비스|교환입고|교환출고)\((.*)\)$/,
   )?.[1];
   if (wrappedMemo) return wrappedMemo.trim();
   if (
-    remark === '서비스' ||
-    remark === '교환입고' ||
-    remark === '교환출고' ||
-    remark === '가격 조정' ||
-    remark === '가격조정'
+    remark === "서비스" ||
+    remark === "교환입고" ||
+    remark === "교환출고" ||
+    remark === "가격 조정" ||
+    remark === "가격조정"
   ) {
-    return '';
+    return "";
   }
   return remark;
 };
@@ -79,15 +79,15 @@ interface StampLogEditModalProps {
     note?: string | null;
   };
   initialAction: string;
-  initialPaymentType?: PaymentTypeEnumType['value'];
-  initialStoreName?: StoreTypeEnumType['value'];
+  initialPaymentType?: PaymentTypeEnumType["value"];
+  initialStoreName?: StoreTypeEnumType["value"];
   initialLogMeta?: StampLogMeta | null;
   isStampAmountEditable?: boolean;
   title?: string;
   onSubmit: (values: {
     note: string;
-    paymentType?: PaymentTypeEnumType['value'];
-    storeName: StoreTypeEnumType['value'];
+    paymentType?: PaymentTypeEnumType["value"];
+    storeName: StoreTypeEnumType["value"];
     logMeta: StampLogMeta;
     amount: number;
   }) => Promise<void>;
@@ -101,7 +101,7 @@ const StampLogEditModal = ({
   initialStoreName,
   initialLogMeta,
   isStampAmountEditable = false,
-  title = '출고 이력 수정',
+  title = "출고 이력 수정",
   onSubmit,
   onCancel,
 }: StampLogEditModalProps) => {
@@ -135,7 +135,7 @@ const StampLogEditModal = ({
       ) === stampLog.finalAmount);
 
   useEffect(() => {
-    setSize(step >= 2 ? 'max-w-6xl' : 'max-w-2xl');
+    setSize(step >= 2 ? "max-w-6xl" : "max-w-2xl");
   }, [setSize, step]);
 
   const handleSubmit = async () => {
@@ -172,7 +172,7 @@ const StampLogEditModal = ({
       </h2>
 
       <div className="mb-5 flex shrink-0 items-start justify-center">
-        {(['기본 정보', '품목 · 금액', '최종 확인'] as const).map(
+        {(["기본 정보", "품목 · 금액", "최종 확인"] as const).map(
           (label, index) => {
             const stepNumber = (index + 1) as 1 | 2 | 3;
             const isActive = step === stepNumber;
@@ -184,19 +184,17 @@ const StampLogEditModal = ({
                   <div
                     className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition-colors ${
                       isDone
-                        ? 'bg-gradient-to-r from-brand-500 to-brand-600 text-white shadow-sm'
+                        ? "bg-gradient-to-r from-brand-500 to-brand-600 text-white shadow-sm"
                         : isActive
-                          ? 'bg-brand-100 text-brand-600 ring-2 ring-brand-400'
-                          : 'bg-gray-100 text-gray-400'
+                          ? "bg-brand-100 text-brand-600 ring-2 ring-brand-400"
+                          : "bg-gray-100 text-gray-400"
                     }`}
                   >
-                    {isDone ? '✓' : stepNumber}
+                    {isDone ? "✓" : stepNumber}
                   </div>
                   <span
                     className={`whitespace-nowrap text-[11px] font-medium ${
-                      isActive || isDone
-                        ? 'text-brand-700'
-                        : 'text-gray-400'
+                      isActive || isDone ? "text-brand-700" : "text-gray-400"
                     }`}
                   >
                     {label}
@@ -205,7 +203,7 @@ const StampLogEditModal = ({
                 {index < 2 && (
                   <div
                     className={`mt-4 h-0.5 w-8 rounded-full transition-colors sm:w-12 ${
-                      isDone ? 'bg-brand-500' : 'bg-gray-200'
+                      isDone ? "bg-brand-500" : "bg-gray-200"
                     }`}
                   />
                 )}
@@ -226,9 +224,7 @@ const StampLogEditModal = ({
       <div className="min-h-0 flex-1 overflow-y-auto pr-1">
         <StampLogForm
           initialValue={initialValue}
-          isStampAmountEditable={
-            customerMode !== 'x' && isStampAmountEditable
-          }
+          isStampAmountEditable={customerMode !== "x" && isStampAmountEditable}
           layout="split"
           step={step}
           customerMode={customerMode}
@@ -241,43 +237,47 @@ const StampLogEditModal = ({
           <div className="space-y-4">
             <div
               className={`grid grid-cols-2 gap-2 ${
-                customerMode === 'x' ? 'md:grid-cols-4' : 'md:grid-cols-5'
+                customerMode === "x" ? "md:grid-cols-4" : "md:grid-cols-5"
               }`}
             >
               {[
                 {
-                  label: '출고 방식',
+                  label: "출고 방식",
                   value: stampLog.logMeta.reservationDate
                     ? `${stampLog.logMeta.reservationDate} 예약 출고`
-                    : '즉시 출고',
+                    : "즉시 출고",
                 },
-                { label: '출고 매장', value: stampLog.storeLabel },
+                { label: "출고 매장", value: stampLog.storeLabel },
                 {
-                  label: '수령 방식',
+                  label: "수령 방식",
                   value:
-                    stampLog.logMeta.deliveryMethod === 'parcel'
-                      ? '택배'
-                      : stampLog.logMeta.deliveryMethod === 'delivery'
-                        ? '배달'
-                        : '매장방문',
+                    stampLog.logMeta.deliveryMethod === "parcel"
+                      ? "택배"
+                      : stampLog.logMeta.deliveryMethod === "delivery"
+                        ? stampLog.logMeta.deliveryType === "self"
+                          ? "자체배달"
+                          : stampLog.logMeta.deliveryType === "customer_quick"
+                            ? "손님퀵"
+                            : "배달대행"
+                        : "매장방문",
                 },
-                ...(customerMode === 'x'
+                ...(customerMode === "x"
                   ? []
                   : [
                       {
-                        label: '스탬프 적립',
+                        label: "스탬프 적립",
                         value:
                           stampLog.amount === 0
-                            ? '미적립'
+                            ? "미적립"
                             : `${stampLog.amount}개`,
                       },
                     ]),
                 {
-                  label: '결제 정보',
+                  label: "결제 정보",
                   value: stampLog.logMeta.payments?.length
                     ? stampLog.logMeta.payments
                         .map((payment) => payment.paymentTypeName)
-                        .join(' · ')
+                        .join(" · ")
                     : stampLog.paymentTypeName,
                 },
               ].map((summary) => (
@@ -296,19 +296,21 @@ const StampLogEditModal = ({
             </div>
 
             <div className="grid grid-cols-1 gap-2 md:grid-cols-4">
-              {stampLog.logMeta.deliveryMethod !== 'store_visit' && (
+              {(stampLog.logMeta.deliveryMethod === "parcel" ||
+                (stampLog.logMeta.deliveryMethod === "delivery" &&
+                  stampLog.logMeta.deliveryType === "agency")) && (
                 <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
                   <p className="text-xs font-medium text-gray-500">
-                    {stampLog.logMeta.deliveryMethod === 'delivery'
-                      ? '배달비'
-                      : '택배비'}
+                    {stampLog.logMeta.deliveryMethod === "delivery"
+                      ? "배달대행비"
+                      : "택배비"}
                   </p>
                   <p className="mt-1 text-sm font-semibold text-gray-900">
                     {formatAmount(stampLog.logMeta.deliveryFee ?? 0)}원
                   </p>
                 </div>
               )}
-              {stampLog.logMeta.deliveryMethod !== 'store_visit' && (
+              {stampLog.logMeta.deliveryMethod !== "store_visit" && (
                 <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 md:col-span-2">
                   <p className="text-xs font-medium text-gray-500">배송 주소</p>
                   <p className="mt-1 break-words text-sm text-gray-800">
@@ -318,14 +320,14 @@ const StampLogEditModal = ({
               )}
               <div
                 className={`rounded-lg border border-gray-200 bg-white px-3 py-2.5 ${
-                  stampLog.logMeta.deliveryMethod === 'store_visit'
-                    ? 'md:col-span-4'
-                    : ''
+                  stampLog.logMeta.deliveryMethod === "store_visit"
+                    ? "md:col-span-4"
+                    : ""
                 }`}
               >
                 <p className="text-xs font-medium text-gray-500">출고 메모</p>
                 <p className="mt-1 whitespace-pre-wrap break-words text-sm text-gray-800">
-                  {stampLog.logMeta.extraNote || '없음'}
+                  {stampLog.logMeta.extraNote || "없음"}
                 </p>
               </div>
             </div>
@@ -341,7 +343,7 @@ const StampLogEditModal = ({
                       stampLog.logMeta.items?.map((item) => item.itemId) ?? [],
                     ).size
                   }
-                  종 · 총{' '}
+                  종 · 총{" "}
                   {stampLog.logMeta.items?.reduce(
                     (sum, item) => sum + item.quantity,
                     0,
@@ -355,8 +357,12 @@ const StampLogEditModal = ({
                     <tr className="border-b border-gray-200">
                       <th className="w-[6%] px-2 py-2 text-center">번호</th>
                       <th className="w-[33%] px-2 py-2 text-left">품목명</th>
-                      <th className="w-[13%] px-2 py-2 text-center">품목종류</th>
-                      <th className="w-[13%] px-2 py-2 text-center">출고 유형</th>
+                      <th className="w-[13%] px-2 py-2 text-center">
+                        품목종류
+                      </th>
+                      <th className="w-[13%] px-2 py-2 text-center">
+                        출고 유형
+                      </th>
                       <th className="w-[8%] px-2 py-2 text-center">수량</th>
                       <th className="w-[13%] px-2 py-2 text-right">단가</th>
                       <th className="w-[14%] px-3 py-2 text-right">소계</th>
@@ -377,7 +383,9 @@ const StampLogEditModal = ({
                           </td>
                           <td className="px-2 py-2 font-medium text-gray-900">
                             <div className="flex flex-wrap items-center gap-x-1.5">
-                              <span className="break-words">{item.itemName}</span>
+                              <span className="break-words">
+                                {item.itemName}
+                              </span>
                               {memo && (
                                 <span className="break-words text-xs font-normal text-gray-500">
                                   ({memo})
@@ -386,7 +394,7 @@ const StampLogEditModal = ({
                             </div>
                           </td>
                           <td className="px-2 py-2 text-center text-xs font-medium text-gray-600">
-                            {item.itemCategoryName ?? '미분류'}
+                            {item.itemCategoryName ?? "미분류"}
                           </td>
                           <td className="px-2 py-2 text-center">
                             <span
@@ -400,7 +408,7 @@ const StampLogEditModal = ({
                           </td>
                           <td className="px-2 py-2 text-right text-gray-700">
                             {formatAmount(
-                              typeof item.adjustedUnitPrice === 'number'
+                              typeof item.adjustedUnitPrice === "number"
                                 ? item.adjustedUnitPrice
                                 : item.unitPrice,
                             )}
@@ -426,13 +434,13 @@ const StampLogEditModal = ({
             <div>
               <p className="text-xs text-gray-500">품목 수량</p>
               <p className="mt-0.5 text-sm font-semibold text-gray-900">
-                총{' '}
+                총{" "}
                 {
                   new Set(
                     stampLog.logMeta.items?.map((item) => item.itemId) ?? [],
                   ).size
                 }
-                종 ·{' '}
+                종 ·{" "}
                 {stampLog.logMeta.items?.reduce(
                   (sum, item) => sum + item.quantity,
                   0,
@@ -446,7 +454,7 @@ const StampLogEditModal = ({
                 {stampLog.logMeta.payments?.length
                   ? stampLog.logMeta.payments
                       .map((payment) => payment.paymentTypeName)
-                      .join(' · ')
+                      .join(" · ")
                   : stampLog.paymentTypeName}
               </p>
               {stampLog.logMeta.payments?.length ? (
@@ -456,7 +464,7 @@ const StampLogEditModal = ({
                       (payment) =>
                         `${payment.paymentTypeName} ${formatAmount(payment.amount)}원`,
                     )
-                    .join(' · ')}
+                    .join(" · ")}
                 </p>
               ) : null}
             </div>
@@ -477,7 +485,7 @@ const StampLogEditModal = ({
               <p className="mt-0.5 text-base font-semibold text-gray-900">
                 {stampLog.logMeta.discount
                   ? `${stampLog.logMeta.discount.name} ${formatAmount(stampLog.logMeta.discount.amount)}원`
-                  : '0원'}
+                  : "0원"}
               </p>
             </div>
             <div className="border-l border-gray-200 pl-5">
@@ -503,15 +511,13 @@ const StampLogEditModal = ({
             }}
             disabled={isSubmitting}
           >
-            {step === 1 ? '취소' : '이전'}
+            {step === 1 ? "취소" : "이전"}
           </Button>
           {step < 3 ? (
             step === 1 && !formValidity.hasCompletedBasicSequence ? null : (
               <Button
                 size="sm"
-                onClick={() =>
-                  setStep((current) => (current === 1 ? 2 : 3))
-                }
+                onClick={() => setStep((current) => (current === 1 ? 2 : 3))}
                 disabled={
                   step === 1
                     ? !formValidity.hasCompletedBasicSequence
@@ -527,7 +533,7 @@ const StampLogEditModal = ({
               onClick={handleSubmit}
               disabled={isSubmitting || !stampLog}
             >
-              {isSubmitting ? '저장 중...' : '수정'}
+              {isSubmitting ? "저장 중..." : "수정"}
             </Button>
           )}
         </div>

--- a/src/app/(auth)/cash-management/_components/DailyClosingReport.tsx
+++ b/src/app/(auth)/cash-management/_components/DailyClosingReport.tsx
@@ -213,35 +213,48 @@ export default function DailyClosingReport({
         const parsed = JSON.parse(savedDraft) as {
           openingChecks?: Record<string, boolean>;
           closingChecks?: Record<string, boolean>;
+          cleaningNote?: string;
+          specialNote?: string;
         };
         setOpeningChecks(parsed.openingChecks ?? {});
         setClosingChecks(parsed.closingChecks ?? {});
+        setCleaningNote(parsed.cleaningNote ?? "");
+        setSpecialNote(parsed.specialNote ?? "");
       } catch {
         window.sessionStorage.removeItem(getChecklistDraftKey(businessDate));
         setOpeningChecks({});
         setClosingChecks({});
+        setCleaningNote("");
+        setSpecialNote("");
       }
     } else {
       setOpeningChecks({});
       setClosingChecks({});
+      setCleaningNote("");
+      setSpecialNote("");
     }
     setChecksDraftDate(businessDate);
-    setCleaningNote("");
-    setSpecialNote("");
   }, [businessDate]);
 
   useEffect(() => {
     if (checksDraftDate !== businessDate || reportQuery.data) return;
     window.sessionStorage.setItem(
       getChecklistDraftKey(businessDate),
-      JSON.stringify({ openingChecks, closingChecks }),
+      JSON.stringify({
+        openingChecks,
+        closingChecks,
+        cleaningNote,
+        specialNote,
+      }),
     );
   }, [
     businessDate,
     checksDraftDate,
+    cleaningNote,
     closingChecks,
     openingChecks,
     reportQuery.data,
+    specialNote,
   ]);
 
   useEffect(() => {
@@ -463,6 +476,29 @@ export default function DailyClosingReport({
   });
   const canCancelClosing =
     isClosed && (isAdmin || businessDate === getTodayInKorea());
+  const handleCompleteClosing = () => {
+    open({
+      content: (
+        <ConfirmModal
+          title="마감 전 확인"
+          description="매출 금액과 체크리스트를 모두 확인했나요?"
+          confirmLabel="마감 처리"
+          cancelLabel="다시 확인"
+          confirmingLabel="마감 처리 중..."
+          onCancel={close}
+          onConfirm={async () => {
+            try {
+              await closeMutation.mutateAsync();
+              close();
+            } catch {
+              // 오류 안내는 closeMutation에서 처리합니다.
+            }
+          }}
+        />
+      ),
+      options: { dismissOnBackdrop: false },
+    });
+  };
   const handleCancelClosing = () => {
     open({
       content: (
@@ -830,7 +866,7 @@ export default function DailyClosingReport({
           )}
         </div>
         <Button
-          onClick={() => closeMutation.mutate()}
+          onClick={handleCompleteClosing}
           disabled={
             isClosed ||
             closeMutation.isPending ||

--- a/src/app/(auth)/cash-management/_components/ReportSnapshotView.tsx
+++ b/src/app/(auth)/cash-management/_components/ReportSnapshotView.tsx
@@ -46,10 +46,9 @@ export default function ReportSnapshotView({
     queryFn: () => getDailyPaymentSales(snapshot!.businessDate),
     enabled: Boolean(
       snapshot?.businessDate &&
-        snapshot.inboundSummary?.some(
-          (item) =>
-            item.type === "purchase" && item.aggregationUnit !== "count",
-        ),
+      snapshot.inboundSummary?.some(
+        (item) => item.type === "purchase" && item.aggregationUnit !== "count",
+      ),
     ),
   });
   useEffect(() => {
@@ -424,8 +423,8 @@ export default function ReportSnapshotView({
                           ? item.aggregationUnit === "count"
                             ? `${item.quantity}건`
                             : receiptCount == null
-                            ? ""
-                            : `${receiptCount}건`
+                              ? ""
+                              : `${receiptCount}건`
                           : `${item.quantity}개`,
                     };
                   })}

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -16,7 +16,9 @@ import { getCustomerMode } from "@/app/_domains/_customer/_utils/specialCustomer
 
 const formatAmount = (value: number) => value.toLocaleString("ko-KR");
 
-const getShipmentTypeLabel = (item: NonNullable<StampLogMeta["items"]>[number]) => {
+const getShipmentTypeLabel = (
+  item: NonNullable<StampLogMeta["items"]>[number],
+) => {
   if (item.inventoryAction === "adjustment_in") return "재고조정-입고";
   if (item.inventoryAction === "adjustment_out") return "재고조정-출고";
   if (item.inventoryAction === "exchange_in") return "교환입고";
@@ -161,9 +163,16 @@ export default function StampConfirmModal({
   const labelTitle = "특이 사항";
   const labelText = " (조정 사유 입력)";
 
-  const isConfirmDisabled = mode === "use10" && breathType === "";
+  const hasRequiredAdjustmentNote = mode !== "adjust" || note.trim().length > 0;
+  const isConfirmDisabled =
+    (mode === "use10" && breathType === "") || !hasRequiredAdjustmentNote;
 
   const handleConfirm = async () => {
+    if (!hasRequiredAdjustmentNote) {
+      toast.error("특이사항을 입력해 주세요.");
+      return;
+    }
+
     try {
       setIsSubmitting(true);
       if (mode === "add") {
@@ -182,12 +191,25 @@ export default function StampConfirmModal({
         const deliveryFeeTag =
           (stampLog.logMeta.deliveryFee ?? 0) > 0
             ? `${
-                stampLog.logMeta.deliveryMethod === "delivery"
-                  ? "배달비"
-                  : "택배비"
+                stampLog.logMeta.deliveryMethod === "parcel" &&
+                stampLog.logMeta.parcelCarrier?.trim()
+                  ? `${stampLog.logMeta.parcelCarrier.trim()}택배`
+                  : stampLog.logMeta.deliveryMethod === "delivery"
+                    ? "배달대행비"
+                    : "택배비"
               }${stampLog.logMeta.deliveryFee}`
             : "";
-        const hasSavedTransactionTags = Boolean(discountTag || deliveryFeeTag);
+        const deliveryTypeTag =
+          stampLog.logMeta.deliveryMethod !== "delivery"
+            ? ""
+            : stampLog.logMeta.deliveryType === "self"
+              ? "자체배달"
+              : stampLog.logMeta.deliveryType === "customer_quick"
+                ? "손님이 퀵부르심"
+                : "";
+        const hasSavedTransactionTags = Boolean(
+          discountTag || deliveryFeeTag || deliveryTypeTag,
+        );
         const transactionCloseIndex = hasSavedTransactionTags
           ? stampLog.note.indexOf(")")
           : -1;
@@ -199,6 +221,7 @@ export default function StampConfirmModal({
           discountTag,
           reservationTag,
           deliveryFeeTag,
+          deliveryTypeTag,
         ].filter(Boolean);
         const nextNote =
           transactionTags.length > 0
@@ -303,11 +326,7 @@ export default function StampConfirmModal({
                       : "bg-gray-100 text-gray-400"
                 }`}
               >
-                {isDone
-                  ? "✓"
-                  : usesStandardSalesFlow
-                    ? stepNumber
-                    : idx + 1}
+                {isDone ? "✓" : usesStandardSalesFlow ? stepNumber : idx + 1}
               </div>
               <span
                 className={`text-[11px] font-medium whitespace-nowrap ${
@@ -378,9 +397,7 @@ export default function StampConfirmModal({
               <>
                 <div
                   className={`grid grid-cols-2 gap-2 ${
-                    customerMode === "x"
-                      ? "md:grid-cols-4"
-                      : "md:grid-cols-5"
+                    customerMode === "x" ? "md:grid-cols-4" : "md:grid-cols-5"
                   }`}
                 >
                   {[
@@ -397,7 +414,12 @@ export default function StampConfirmModal({
                         stampLog.logMeta.deliveryMethod === "parcel"
                           ? "택배"
                           : stampLog.logMeta.deliveryMethod === "delivery"
-                            ? "배달"
+                            ? stampLog.logMeta.deliveryType === "self"
+                              ? "자체배달"
+                              : stampLog.logMeta.deliveryType ===
+                                  "customer_quick"
+                                ? "손님퀵"
+                                : "배달대행"
                             : "매장방문",
                     },
                     ...(customerMode === "x"
@@ -435,11 +457,13 @@ export default function StampConfirmModal({
                 </div>
 
                 <div className="grid grid-cols-1 gap-2 md:grid-cols-4">
-                  {stampLog.logMeta.deliveryMethod !== "store_visit" && (
+                  {(stampLog.logMeta.deliveryMethod === "parcel" ||
+                    (stampLog.logMeta.deliveryMethod === "delivery" &&
+                      stampLog.logMeta.deliveryType === "agency")) && (
                     <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
                       <p className="text-xs font-medium text-gray-500">
                         {stampLog.logMeta.deliveryMethod === "delivery"
-                          ? "배달비"
+                          ? "배달대행비"
                           : "택배비"}
                       </p>
                       <p className="mt-1 text-sm font-semibold text-gray-900">
@@ -567,7 +591,6 @@ export default function StampConfirmModal({
                 </table>
               </div>
             </div>
-
           </div>
         )}
       </div>
@@ -1021,6 +1044,7 @@ export default function StampConfirmModal({
             <div className="mb-6">
               <label className="block text-sm font-medium text-gray-700 mb-2">
                 {labelTitle}
+                <span className="ml-1 text-rose-600">*</span>
                 <span className="text-xs text-gray-500 whitespace-pre-line">
                   {labelText}
                 </span>

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -66,6 +66,7 @@ const discountOptions = [
 
 type DiscountOptionValue = (typeof discountOptions)[number]["value"];
 type DeliveryMethod = "store_visit" | "parcel" | "delivery";
+type DeliveryType = "agency" | "self" | "customer_quick";
 
 type DraftStampLogLine = StampLogItem & {
   id: string;
@@ -182,6 +183,13 @@ export default function StampLogForm({
   const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethod>(
     initialValue?.logMeta?.deliveryMethod ?? "store_visit",
   );
+  const [deliveryType, setDeliveryType] = useState<DeliveryType | "">(
+    initialValue?.logMeta?.deliveryType ??
+      (initialValue?.logMeta?.deliveryMethod === "delivery" ? "agency" : ""),
+  );
+  const [parcelCarrier, setParcelCarrier] = useState(
+    initialValue?.logMeta?.parcelCarrier ?? "",
+  );
   const [hasConfirmedStore, setHasConfirmedStore] = useState(true);
   const [hasConfirmedDeliveryMethod, setHasConfirmedDeliveryMethod] = useState(
     Boolean(initialValue),
@@ -192,12 +200,40 @@ export default function StampLogForm({
   const [deliveryAddress, setDeliveryAddress] = useState(
     initialValue?.logMeta?.deliveryAddress ?? "",
   );
-  const [deliveryFeeInput, setDeliveryFeeInput] = useState(
-    initialValue?.logMeta?.deliveryFee === undefined
-      ? ""
-      : String(initialValue.logMeta.deliveryFee),
+  const [parcelFeeInput, setParcelFeeInput] = useState(
+    initialValue?.logMeta?.deliveryMethod === "parcel" &&
+      initialValue.logMeta.deliveryFee !== undefined
+      ? String(initialValue.logMeta.deliveryFee)
+      : "",
   );
+  const [agencyFeeInput, setAgencyFeeInput] = useState(
+    initialValue?.logMeta?.deliveryMethod === "delivery" &&
+      (initialValue.logMeta.deliveryBaseFee !== undefined ||
+        initialValue.logMeta.deliveryFee !== undefined)
+      ? String(
+          initialValue.logMeta.deliveryBaseFee ??
+            initialValue.logMeta.deliveryFee,
+        )
+      : "",
+  );
+  const deliveryFeeInput =
+    deliveryMethod === "parcel"
+      ? parcelFeeInput
+      : deliveryMethod === "delivery"
+        ? agencyFeeInput
+        : "";
+  const setDeliveryFeeInput = (value: string) => {
+    if (deliveryMethod === "parcel") {
+      setParcelFeeInput(value);
+    } else if (deliveryMethod === "delivery") {
+      setAgencyFeeInput(value);
+    }
+  };
   const deliveryFee = deliveryFeeInput === "" ? 0 : Number(deliveryFeeInput);
+  const usesLegacyDeliveryFee =
+    initialValue?.logMeta?.deliveryMethod === "delivery" &&
+    initialValue.logMeta.deliveryBaseFee === undefined &&
+    initialValue.logMeta.deliveryFee !== undefined;
   const [itemSearch, setItemSearch] = useState("");
   const [selectedItem, setSelectedItem] = useState<ItemType | null>(null);
   const [showItemResults, setShowItemResults] = useState(false);
@@ -332,7 +368,17 @@ export default function StampLogForm({
     (option) => option.value === discountType,
   )?.name;
   const activeDiscountAmount = discountLabel ? discountAmount : 0;
-  const activeDeliveryFee = deliveryMethod === "store_visit" ? 0 : deliveryFee;
+  const activeDeliveryFee =
+    deliveryMethod === "store_visit"
+      ? 0
+      : deliveryMethod === "delivery" &&
+          deliveryType === "agency" &&
+          deliveryFee > 0 &&
+          !usesLegacyDeliveryFee
+        ? deliveryFee + Math.round(deliveryFee * 0.1) + 200
+        : deliveryMethod === "delivery" && deliveryType !== "agency"
+          ? 0
+          : deliveryFee;
   const discountTag =
     discountLabel && activeDiscountAmount > 0
       ? `${discountLabel}할인${activeDiscountAmount}`
@@ -340,20 +386,36 @@ export default function StampLogForm({
   const discountLine = discountTag ? `${discountTag})` : "";
   const deliveryFeeLabel =
     deliveryMethod === "parcel"
-      ? "택배비"
+      ? "택배"
       : deliveryMethod === "delivery"
-        ? "배달비"
+        ? deliveryType === "agency"
+          ? "배달대행비"
+          : ""
         : "";
   const deliveryFeeTag =
     deliveryFeeLabel && activeDeliveryFee > 0
-      ? `${deliveryFeeLabel}${activeDeliveryFee}`
+      ? `${
+          deliveryMethod === "parcel" && parcelCarrier.trim()
+            ? parcelCarrier.trim()
+            : ""
+        }${deliveryFeeLabel}${activeDeliveryFee}`
       : "";
-  const transactionTags = [discountTag, deliveryFeeTag].filter(Boolean);
+  const deliveryTypeTag =
+    deliveryMethod !== "delivery"
+      ? ""
+      : deliveryType === "self"
+        ? "자체배달"
+        : deliveryType === "customer_quick"
+          ? "손님이 퀵부르심"
+          : "";
+  const transactionTags = [discountTag, deliveryFeeTag, deliveryTypeTag].filter(
+    Boolean,
+  );
   const transactionNote =
     transactionTags.length > 0 ? `${transactionTags.join(",")})` : "";
   const itemNote = draftLines.map((line) => line.lineText).join(", ");
   const generatedNote = [transactionNote, itemNote].filter(Boolean).join(" ");
-  const finalAmount = totalAmount - activeDiscountAmount;
+  const finalAmount = totalAmount + activeDeliveryFee - activeDiscountAmount;
   const splitPaymentTotal = splitPayments.reduce(
     (sum, payment) => sum + payment.amount,
     0,
@@ -369,6 +431,7 @@ export default function StampLogForm({
     .join(" + ");
   const finalAmountExpression = [
     amountExpression || "0",
+    activeDeliveryFee > 0 ? `+ ${formatAmount(activeDeliveryFee)}` : "",
     activeDiscountAmount > 0 ? `- ${formatAmount(activeDiscountAmount)}` : "",
   ]
     .filter(Boolean)
@@ -382,7 +445,11 @@ export default function StampLogForm({
         : paymentType !== "";
   const hasValidDeliveryInfo =
     deliveryMethod === "store_visit" ||
-    (deliveryAddress.trim().length > 0 && deliveryFeeInput !== "");
+    (deliveryAddress.trim().length > 0 &&
+      (deliveryMethod === "parcel"
+        ? deliveryFeeInput !== "" && parcelCarrier.trim().length > 0
+        : deliveryType !== "" &&
+          (deliveryType !== "agency" || deliveryFeeInput !== "")));
 
   useEffect(() => {
     if (!isNonSalesSpecialCustomer) return;
@@ -453,6 +520,12 @@ export default function StampLogForm({
       totalAmount: finalAmount,
       extraNote: extraNote.trim() || undefined,
       deliveryMethod,
+      deliveryType:
+        deliveryMethod === "delivery" ? deliveryType || undefined : undefined,
+      parcelCarrier:
+        deliveryMethod === "parcel"
+          ? parcelCarrier.trim() || undefined
+          : undefined,
       deliveryAddressSource:
         deliveryMethod === "store_visit" ? undefined : deliveryAddressSource,
       deliveryAddress:
@@ -460,7 +533,16 @@ export default function StampLogForm({
           ? undefined
           : deliveryAddress.trim() || undefined,
       deliveryFee:
-        deliveryMethod === "store_visit" ? undefined : activeDeliveryFee,
+        deliveryMethod === "parcel" ||
+        (deliveryMethod === "delivery" && deliveryType === "agency")
+          ? activeDeliveryFee
+          : undefined,
+      deliveryBaseFee:
+        deliveryMethod === "delivery" &&
+        deliveryType === "agency" &&
+        !usesLegacyDeliveryFee
+          ? deliveryFee
+          : undefined,
       payments:
         paymentMode === "split" && hasSelectedSplitPayments
           ? splitPayments
@@ -518,6 +600,8 @@ export default function StampLogForm({
     draftLines,
     storeName,
     deliveryMethod,
+    deliveryType,
+    parcelCarrier,
     deliveryAddressSource,
     deliveryAddress,
     deliveryFee,
@@ -1137,6 +1221,8 @@ export default function StampLogForm({
                 setPaymentType("");
                 setSplitPayments([]);
                 if (option.value === "store_visit") {
+                  setDeliveryType("");
+                  setParcelCarrier("");
                   setDeliveryAddress("");
                   setDeliveryFeeInput("");
                 }
@@ -1146,115 +1232,206 @@ export default function StampLogForm({
             </Button>
           ))}
         </div>
-        {deliveryMethod !== "store_visit" && (
-          <div className="mt-3 grid grid-cols-[72px_minmax(0,1fr)_88px] items-start gap-2 pt-2">
-            <div>
-              <label className="mb-1 block h-4 text-xs font-semibold leading-4 text-gray-600">
-                {deliveryMethod === "parcel" ? "택배비" : "배달비"}
-              </label>
-              <div className="relative">
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  maxLength={5}
-                  value={deliveryFeeInput}
-                  onChange={(event) => {
-                    const value = event.target.value;
-                    if (
-                      value === "" ||
-                      (/^[0-9]+$/.test(value) && value.length <= 5)
-                    ) {
-                      setDeliveryFeeInput(value);
+        {deliveryMethod === "delivery" && (
+          <div className="mt-3 border-t border-gray-200 pt-3">
+            <div className="grid grid-cols-3 gap-2">
+              {(
+                [
+                  { value: "agency", label: "배달대행" },
+                  { value: "self", label: "자체배달" },
+                  { value: "customer_quick", label: "손님퀵" },
+                ] as const
+              ).map((option) => (
+                <Button
+                  key={option.value}
+                  type="button"
+                  size="sm"
+                  variant={deliveryType === option.value ? "primary" : "gray"}
+                  onClick={() => {
+                    setDeliveryType(option.value);
+                    if (option.value !== "agency") {
+                      setDeliveryFeeInput("");
                     }
                   }}
-                  placeholder="금액"
-                  className="h-20 w-full rounded-lg border border-gray-300 bg-white pl-1.5 pr-6 text-right text-sm outline-none transition placeholder:text-gray-400 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
-                />
-                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-500">
-                  원
-                </span>
-              </div>
-            </div>
-            <div className="min-w-0">
-              <label className="mb-1 block h-4 text-xs font-semibold leading-4 text-gray-600">
-                배송 주소
-              </label>
-              <textarea
-                value={deliveryAddress}
-                onChange={(event) => setDeliveryAddress(event.target.value)}
-                placeholder={
-                  customerAddress?.trim()
-                    ? "배송 주소를 확인하세요."
-                    : "배송 주소를 입력하세요."
-                }
-                rows={3}
-                className="h-20 w-full resize-none rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm leading-5 outline-none transition placeholder:text-gray-400 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
-              />
-            </div>
-            <div>
-              <div aria-hidden="true" className="mb-1 h-4" />
-              <div className="grid h-20 grid-rows-2 gap-2">
-                <Button
-                  type="button"
-                  size="xs"
-                  variant={
-                    deliveryAddressSource === "registered" ? "primary" : "gray"
-                  }
-                  disabled={!customerAddress?.trim()}
-                  onClick={() => {
-                    setDeliveryAddressSource("registered");
-                    setDeliveryAddress(customerAddress?.trim() ?? "");
-                  }}
-                  className="h-9 w-full"
+                  className="w-full"
                 >
-                  불러오기
+                  {option.label}
                 </Button>
-                <Button
-                  type="button"
-                  size="xs"
-                  variant={deliveryAddressSource === "new" ? "primary" : "gray"}
-                  onClick={() => {
-                    setDeliveryAddressSource("new");
-                    setDeliveryAddress("");
-                  }}
-                  className="h-9 w-full"
-                >
-                  새로작성
-                </Button>
-              </div>
+              ))}
             </div>
           </div>
         )}
+        {deliveryMethod !== "store_visit" &&
+          (deliveryMethod !== "delivery" || deliveryType !== "") && (
+            <div
+              className={`mt-3 grid items-start gap-2 pt-2 ${
+                deliveryMethod === "parcel"
+                  ? "grid-cols-1 sm:grid-cols-[150px_minmax(0,1fr)_88px]"
+                  : deliveryType === "agency"
+                    ? "grid-cols-1 sm:grid-cols-[150px_minmax(0,1fr)_88px]"
+                    : "grid-cols-1 sm:grid-cols-[minmax(0,1fr)_88px]"
+              }`}
+            >
+              {deliveryMethod === "parcel" && (
+                <div>
+                  <label className="mb-1 block h-4 text-xs font-semibold leading-4 text-gray-600">
+                    택배사 이름
+                  </label>
+                  <input
+                    type="text"
+                    maxLength={30}
+                    value={parcelCarrier}
+                    onChange={(event) => setParcelCarrier(event.target.value)}
+                    placeholder="ex) 우체국,GS편의점"
+                    className="h-9 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none transition placeholder:text-gray-400 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                  />
+                  <div className="relative mt-2">
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      maxLength={5}
+                      value={deliveryFeeInput}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        if (
+                          value === "" ||
+                          (/^[0-9]+$/.test(value) && value.length <= 5)
+                        ) {
+                          setDeliveryFeeInput(value);
+                        }
+                      }}
+                      placeholder="택배비"
+                      aria-label="택배비"
+                      className="h-9 w-full rounded-lg border border-gray-300 bg-white pl-3 pr-7 text-right text-sm outline-none transition placeholder:text-left placeholder:text-gray-400 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                    />
+                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-500">
+                      원
+                    </span>
+                  </div>
+                </div>
+              )}
+              {deliveryMethod === "delivery" && deliveryType === "agency" && (
+                <div>
+                  <label className="mb-1 block h-4 text-xs font-semibold leading-4 text-gray-600">
+                    배달대행비
+                  </label>
+                  <div className="relative">
+                    <textarea
+                      inputMode="numeric"
+                      maxLength={5}
+                      rows={3}
+                      value={deliveryFeeInput}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        if (
+                          value === "" ||
+                          (/^[0-9]+$/.test(value) && value.length <= 5)
+                        ) {
+                          setDeliveryFeeInput(value);
+                        }
+                      }}
+                      placeholder={"대행료 입력시\n자동계산 됩니다."}
+                      className={`h-20 w-full resize-none overflow-hidden rounded-lg border border-gray-300 bg-white px-2 pr-7 text-[13px] leading-5 outline-none transition placeholder:text-center placeholder:text-gray-400 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100 ${
+                        deliveryFeeInput
+                          ? "py-[18px] text-right"
+                          : "py-[18px] text-center"
+                      }`}
+                    />
+                    <span className="pointer-events-none absolute right-2 top-[28px] -translate-y-1/2 text-xs text-gray-500">
+                      원
+                    </span>
+                    {deliveryFeeInput && (
+                      <span className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-brand-50 px-2.5 py-0.5 text-center text-[11px] font-semibold text-brand-600">
+                        최종 {formatAmount(activeDeliveryFee)}원
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+              <div className="min-w-0">
+                <label className="mb-1 block h-4 text-xs font-semibold leading-4 text-gray-600">
+                  배송 주소
+                </label>
+                <textarea
+                  value={deliveryAddress}
+                  onChange={(event) => setDeliveryAddress(event.target.value)}
+                  placeholder={
+                    customerAddress?.trim()
+                      ? "배송 주소를 확인하세요."
+                      : "배송 주소를 입력하세요."
+                  }
+                  rows={3}
+                  className="h-20 w-full resize-none rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm leading-5 outline-none transition placeholder:text-gray-400 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                />
+              </div>
+              <div>
+                <div aria-hidden="true" className="mb-1 h-4" />
+                <div className="grid h-20 grid-rows-2 gap-2">
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant={
+                      deliveryAddressSource === "registered"
+                        ? "primary"
+                        : "gray"
+                    }
+                    disabled={!customerAddress?.trim()}
+                    onClick={() => {
+                      setDeliveryAddressSource("registered");
+                      setDeliveryAddress(customerAddress?.trim() ?? "");
+                    }}
+                    className="h-9 w-full"
+                  >
+                    불러오기
+                  </Button>
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant={
+                      deliveryAddressSource === "new" ? "primary" : "gray"
+                    }
+                    onClick={() => {
+                      setDeliveryAddressSource("new");
+                      setDeliveryAddress("");
+                    }}
+                    className="h-9 w-full"
+                  >
+                    새로작성
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
       </div>
     </div>
   );
 
   const stepOneStampField = (
     <div className="grid grid-cols-[140px_minmax(0,1fr)]">
-      <div className="flex items-start border-r border-gray-200 px-4 py-5 text-sm font-bold text-gray-800">
+      <div className="flex items-center border-r border-gray-200 px-4 py-2 text-sm font-bold text-gray-800">
         <span className="mr-2 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-500 text-[11px] font-bold leading-none text-white">
           4
         </span>
         스탬프 적립
       </div>
-      <div className="min-w-0 p-4">
+      <div className="min-w-0 p-1">
         <div className="grid grid-cols-3 items-stretch gap-2">
-          <div className="min-w-0 rounded-lg border border-gray-200 bg-gray-50 p-2">
+          <div className="min-w-0 rounded-lg border border-gray-200 bg-gray-50 p-1">
             {stampCountField}
           </div>
-          <div className="flex min-w-0 flex-col items-center justify-center rounded-lg border border-gray-200 bg-gray-50 px-2 py-3 text-center">
+          <div className="flex min-w-0 flex-col items-center justify-center rounded-lg border border-gray-200 bg-gray-50 px-2 py-1 text-center">
             <p className="whitespace-nowrap text-[10px] text-gray-500">
               현재 스탬프 잔여량
             </p>
-            <strong className="text-lg text-gray-900">
+            <strong className="text-base text-gray-900">
               {currentStampCount}개
             </strong>
           </div>
-          <div className="flex min-w-0 flex-col items-center justify-center rounded-lg border border-gray-200 bg-gray-50 px-2 py-3 text-center">
+          <div className="flex min-w-0 flex-col items-center justify-center rounded-lg border border-gray-200 bg-gray-50 px-2 py-1 text-center">
             <p className="whitespace-nowrap text-[10px] text-gray-500">
               적립 후 잔여량
             </p>
-            <strong className="text-lg text-brand-600">
+            <strong className="text-base text-brand-600">
               {currentStampCount + amount}개
             </strong>
           </div>

--- a/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
@@ -1,16 +1,17 @@
-'use client';
+"use client";
 
-import Button from '@/app/_components/Button';
-import { LogsResType } from '@/app/_domains/_log/_types/log.types';
+import Button from "@/app/_components/Button";
+import { LogsResType } from "@/app/_domains/_log/_types/log.types";
 import {
   ActionInfoLabel,
   CustomerInfo,
   LogActorInfo,
   PaymentTypeLabel,
   StoreLabel,
-} from '@/app/(auth)/_components/HistoriesComponents';
-import useCopy from '@/app/_domains/_log/_hooks/useCopy';
-import { isSpecialCustomer } from '@/app/_domains/_customer/_utils/specialCustomer';
+} from "@/app/(auth)/_components/HistoriesComponents";
+import useCopy from "@/app/_domains/_log/_hooks/useCopy";
+import { isSpecialCustomer } from "@/app/_domains/_customer/_utils/specialCustomer";
+import { PaymentTypeEnum } from "@/app/_enums/enums";
 
 interface StampHistoryItemProps {
   log: LogsResType;
@@ -37,19 +38,43 @@ const StampHistoryItem = ({
   const hasSpecialCustomer =
     Boolean(log.customers?.name) &&
     isSpecialCustomer(log.customers.name, log.customers.phone);
+  const isCustomerRemark =
+    log.jsonb?.paymentType === PaymentTypeEnum.REMARK.value;
+  const isCouponUse = log.action === "coupon-10";
+  const isStampAdjustment =
+    !isCustomerRemark &&
+    !isCouponUse &&
+    (log.action.startsWith("add-") || log.action.startsWith("remove-")) &&
+    !Array.isArray(log.jsonb?.items) &&
+    !log.jsonb?.paymentType;
+  const customerBadge = isCustomerRemark ? (
+    <span className="inline-flex whitespace-nowrap rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-500">
+      고객 특이사항
+    </span>
+  ) : isCouponUse ? (
+    <span className="inline-flex whitespace-nowrap rounded-full bg-blue-100 px-2 py-1 text-xs font-semibold text-blue-700">
+      쿠폰 사용
+    </span>
+  ) : isStampAdjustment ? (
+    <span className="inline-flex whitespace-nowrap rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">
+      스탬프 조정
+    </span>
+  ) : null;
 
   return (
     <div className="grid grid-cols-[125px_88px_minmax(260px,1fr)_115px_auto] items-center gap-2 whitespace-nowrap rounded-lg border border-brand-50 p-2.5 text-xs transition-colors hover:bg-brand-50/30 sm:px-2 sm:py-4 sm:text-sm">
-      <div className="flex min-w-0 self-start flex-col items-center text-center">
-        <div>
-          {hasSpecialCustomer ? (
-            <span className="inline-flex whitespace-nowrap rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">
-              특수계정
-            </span>
-          ) : (
-            <ActionInfoLabel action={log.action} />
-          )}
-        </div>
+      <div className="flex min-w-0 self-center flex-col items-center text-center">
+        {!isCustomerRemark && !isCouponUse && (
+          <div>
+            {hasSpecialCustomer ? (
+              <span className="inline-flex whitespace-nowrap rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">
+                특수계정
+              </span>
+            ) : (
+              <ActionInfoLabel action={log.action} />
+            )}
+          </div>
+        )}
         <CustomerInfo
           name={log.customers?.name}
           phone={log.customers?.phone}
@@ -57,17 +82,18 @@ const StampHistoryItem = ({
         />
       </div>
 
-      <div className="ml-2 flex min-w-0 self-start flex-col items-start gap-1">
-        {log.jsonb && 'storeName' in log.jsonb && (
+      <div className="ml-2 flex min-w-0 self-center flex-col items-start gap-1">
+        {customerBadge}
+        {log.jsonb && "storeName" in log.jsonb && (
           <StoreLabel jsonb={log.jsonb} />
         )}
-        {log.jsonb && 'paymentType' in log.jsonb && (
+        {!isCustomerRemark && log.jsonb && "paymentType" in log.jsonb && (
           <PaymentTypeLabel jsonb={log.jsonb} />
         )}
-        {typeof log.jsonb?.totalAmount === 'number' &&
+        {typeof log.jsonb?.totalAmount === "number" &&
           log.jsonb.totalAmount > 0 && (
             <span className="inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 text-xs font-semibold px-2 py-1">
-              {log.jsonb.totalAmount.toLocaleString('ko-KR')}원
+              {log.jsonb.totalAmount.toLocaleString("ko-KR")}원
             </span>
           )}
       </div>
@@ -80,20 +106,20 @@ const StampHistoryItem = ({
           <div className="min-w-0 flex-1 break-words whitespace-normal text-xs text-gray-600 sm:text-sm">
             <p className="whitespace-pre-line">
               {log.note ? (
-                `${isSplitPayment ? '분할결제) ' : ''}${log.note}`
+                `${isSplitPayment ? "분할결제) " : ""}${log.note}`
               ) : (
                 <span className="text-gray-400"> - </span>
               )}
             </p>
-            {typeof log.jsonb?.extraNote === 'string' &&
+            {typeof log.jsonb?.extraNote === "string" &&
               log.jsonb.extraNote.trim() && (
                 <p className="mt-1 italic text-gray-400">
                   출고 특이사항: &quot;{log.jsonb.extraNote.trim()}&quot;
                 </p>
               )}
-            {(log.jsonb?.deliveryMethod === 'parcel' ||
-              log.jsonb?.deliveryMethod === 'delivery') &&
-              typeof log.jsonb?.deliveryAddress === 'string' &&
+            {(log.jsonb?.deliveryMethod === "parcel" ||
+              log.jsonb?.deliveryMethod === "delivery") &&
+              typeof log.jsonb?.deliveryAddress === "string" &&
               log.jsonb.deliveryAddress.trim() && (
                 <p className="mt-1 break-words italic text-gray-400">
                   주소: {log.jsonb.deliveryAddress.trim()}
@@ -136,7 +162,12 @@ const StampHistoryItem = ({
           </Button>
         )}
         {isAdmin && (
-          <Button variant="danger" size="sm" onClick={onDelete} aria-label="삭제">
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={onDelete}
+            aria-label="삭제"
+          >
             🗑️
           </Button>
         )}

--- a/src/app/_domains/_log/_services/logService.ts
+++ b/src/app/_domains/_log/_services/logService.ts
@@ -334,6 +334,16 @@ export const updateLogNote = async (
       delete nextJsonb.extraNote;
     }
     nextJsonb.deliveryMethod = logMeta.deliveryMethod ?? "store_visit";
+    if (logMeta.deliveryType) {
+      nextJsonb.deliveryType = logMeta.deliveryType;
+    } else {
+      delete nextJsonb.deliveryType;
+    }
+    if (logMeta.parcelCarrier) {
+      nextJsonb.parcelCarrier = logMeta.parcelCarrier;
+    } else {
+      delete nextJsonb.parcelCarrier;
+    }
     if (logMeta.deliveryAddressSource) {
       nextJsonb.deliveryAddressSource = logMeta.deliveryAddressSource;
     } else {
@@ -348,6 +358,11 @@ export const updateLogNote = async (
       nextJsonb.deliveryFee = logMeta.deliveryFee;
     } else {
       delete nextJsonb.deliveryFee;
+    }
+    if (logMeta.deliveryBaseFee !== undefined) {
+      nextJsonb.deliveryBaseFee = logMeta.deliveryBaseFee;
+    } else {
+      delete nextJsonb.deliveryBaseFee;
     }
     if (logMeta.payments?.length) {
       nextJsonb.payments = logMeta.payments;

--- a/src/app/_domains/_stamp/_services/stampService.ts
+++ b/src/app/_domains/_stamp/_services/stampService.ts
@@ -1,14 +1,14 @@
-import supabase from '@/libs/supabaseClient';
+import supabase from "@/libs/supabaseClient";
 import {
   createLog,
   withCreatedWorker,
-} from '@/app/_domains/_log/_services/logService';
+} from "@/app/_domains/_log/_services/logService";
 import {
   LogCategoryEnum,
   PaymentTypeEnumType,
   StoreTypeEnumType,
-} from '@/app/_enums/enums';
-import { confirmOutboundInventory } from '@/app/_domains/_inventory/_services/outboundInventoryService';
+} from "@/app/_enums/enums";
+import { confirmOutboundInventory } from "@/app/_domains/_inventory/_services/outboundInventoryService";
 
 export interface Stamp {
   id: string;
@@ -28,21 +28,24 @@ export type StampLogItem = {
   remark: string;
   lineText: string;
   inventoryAction?:
-    'out' | 'exchange_in' | 'exchange_out' | 'adjustment_in' | 'adjustment_out';
+    "out" | "exchange_in" | "exchange_out" | "adjustment_in" | "adjustment_out";
 };
 
 export type StampLogMeta = {
-  storeName?: StoreTypeEnumType['value'];
+  storeName?: StoreTypeEnumType["value"];
   totalAmount?: number;
   extraNote?: string;
   reservationDate?: string;
-  deliveryMethod?: 'store_visit' | 'parcel' | 'delivery';
-  deliveryAddressSource?: 'registered' | 'new';
+  deliveryMethod?: "store_visit" | "parcel" | "delivery";
+  deliveryType?: "agency" | "self" | "customer_quick";
+  parcelCarrier?: string;
+  deliveryAddressSource?: "registered" | "new";
   deliveryAddress?: string;
   deliveryMemo?: string;
+  deliveryBaseFee?: number;
   deliveryFee?: number;
   payments?: Array<{
-    paymentType: PaymentTypeEnumType['value'];
+    paymentType: PaymentTypeEnumType["value"];
     paymentTypeName: string;
     amount: number;
   }>;
@@ -61,17 +64,17 @@ export type StampLogMeta = {
 export const addStamp = async (
   customerId: string,
   amount: number = 1,
-  note: string = '',
-  paymentType?: PaymentTypeEnumType['value'],
+  note: string = "",
+  paymentType?: PaymentTypeEnumType["value"],
   logMeta?: StampLogMeta,
 ) => {
   if (!(await confirmOutboundInventory(logMeta?.items ?? []))) {
-    throw new Error('출고 처리를 취소했습니다.');
+    throw new Error("출고 처리를 취소했습니다.");
   }
-  const { error } = await supabase.rpc('apply_stamp_log_operation', {
+  const { error } = await supabase.rpc("apply_stamp_log_operation", {
     p_customer_id: customerId,
     p_stamp_delta: amount,
-    p_action: amount === 0 ? 'no-stamp' : `add-${amount}`,
+    p_action: amount === 0 ? "no-stamp" : `add-${amount}`,
     p_note: note,
     p_jsonb: await withCreatedWorker({ paymentType, ...logMeta }),
   });
@@ -84,14 +87,14 @@ export const addStamp = async (
 export const addReservationStamp = async (
   customerId: string,
   amount: number = 0,
-  note: string = '',
-  paymentType?: PaymentTypeEnumType['value'],
+  note: string = "",
+  paymentType?: PaymentTypeEnumType["value"],
   logMeta?: StampLogMeta,
 ) => {
   return createLog(
     LogCategoryEnum.RESERVATION.value,
     customerId,
-    amount === 0 ? 'no-stamp' : `add-${amount}`,
+    amount === 0 ? "no-stamp" : `add-${amount}`,
     note,
     { paymentType, ...logMeta },
   );
@@ -102,23 +105,23 @@ export const addReservationStamp = async (
  */
 export const confirmReservationStamp = async (logId: string) => {
   const { data: log, error } = await supabase
-    .from('logs')
-    .select('*')
-    .eq('id', logId)
+    .from("logs")
+    .select("*")
+    .eq("id", logId)
     .single();
 
   if (error) throw error;
-  if (!log) throw new Error('예약 이력을 찾을 수 없습니다');
+  if (!log) throw new Error("예약 이력을 찾을 수 없습니다");
 
   const reservationItems = Array.isArray(log.jsonb?.items)
     ? (log.jsonb.items as StampLogItem[])
     : [];
   if (!(await confirmOutboundInventory(reservationItems, logId))) {
-    throw new Error('출고 확정을 취소했습니다.');
+    throw new Error("출고 확정을 취소했습니다.");
   }
 
   const { error: updateError } = await supabase.rpc(
-    'confirm_reservation_stamp_operation',
+    "confirm_reservation_stamp_operation",
     { p_log_id: String(logId) },
   );
   if (updateError) throw updateError;
@@ -128,12 +131,12 @@ export const confirmReservationStamp = async (logId: string) => {
  * 스탬프 제거 (count 감소)
  */
 export const removeStamp = async (
-  mode: 'remove' | 'coupon',
+  mode: "remove" | "coupon",
   customerId: string,
   amount: number = 1,
-  note: string = '',
+  note: string = "",
 ) => {
-  const { error } = await supabase.rpc('apply_stamp_log_operation', {
+  const { error } = await supabase.rpc("apply_stamp_log_operation", {
     p_customer_id: customerId,
     p_stamp_delta: -amount,
     p_action: `${mode}-${amount}`,
@@ -148,10 +151,10 @@ export const removeStamp = async (
  */
 export const getStampsByCustomer = async (customerId: string) => {
   const { data, error } = await supabase
-    .from('stamps')
-    .select('*')
-    .eq('customer_id', customerId)
-    .order('created_at', { ascending: false });
+    .from("stamps")
+    .select("*")
+    .eq("customer_id", customerId)
+    .order("created_at", { ascending: false });
 
   if (error) throw error;
 
@@ -162,7 +165,7 @@ export const getStampsByCustomer = async (customerId: string) => {
  * 특정 스탬프 삭제
  */
 export const deleteStamp = async (stampId: string) => {
-  const { error } = await supabase.from('stamps').delete().eq('id', stampId);
+  const { error } = await supabase.from("stamps").delete().eq("id", stampId);
 
   if (error) throw error;
 };


### PR DESCRIPTION
- 택배사 및 택배비 입력·이력 표시 기능 추가
- 배달 유형을 배달대행, 자체배달, 손님퀵으로 구분
- 배달대행료 10% + 200원 자동 계산 적용
- 택배비와 배달대행료 입력 상태 분리
- 스탬프 조정 시 특이사항 필수 적용
- 출고 이력 스탬프 적립 영역 높이 축소
- 고객 특이사항, 스탬프 조정, 쿠폰 사용 이력 배지 위치 정리
- 수정 이력이 많아져도 고객 및 결제 정보가 세로 중앙에 유지되도록 개선
- 마감보고서 청소 현황과 특이사항 초안 유지
- 마감 처리 전 최종 확인 알림 추가