### PR TITLE
출고 결제금액 계산 및 staff 고객정보 수정 권한 개선

### DIFF
--- a/src/app/(auth)/customers/[id]/_components/CustomerInfo.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomerInfo.tsx
@@ -1,6 +1,5 @@
 import Button from '@/app/_components/Button';
 import { formatPhoneNumber } from '@/app/_utils/utils';
-import { useUser } from '@/app/_contexts/UserContext';
 
 interface CustomerInfoProps {
   customer: {
@@ -15,13 +14,11 @@ interface CustomerInfoProps {
 }
 
 const CustomerInfo = ({ customer, onEdit }: CustomerInfoProps) => {
-  const { isAdmin } = useUser();
-
   return (
     <section className="flex-1 h-full bg-white rounded-lg shadow-sm border border-brand-100 p-6">
       <div className="flex items-center justify-between mb-6 pb-3 border-b border-brand-100">
         <h2 className="text-xl font-semibold text-brand-700">고객 정보</h2>
-        {onEdit && isAdmin && (
+        {onEdit && (
           <Button
             onClick={onEdit}
             variant="secondary"

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -415,7 +415,7 @@ export default function StampLogForm({
     transactionTags.length > 0 ? `${transactionTags.join(",")})` : "";
   const itemNote = draftLines.map((line) => line.lineText).join(", ");
   const generatedNote = [transactionNote, itemNote].filter(Boolean).join(" ");
-  const finalAmount = totalAmount + activeDeliveryFee - activeDiscountAmount;
+  const finalAmount = totalAmount - activeDiscountAmount;
   const splitPaymentTotal = splitPayments.reduce(
     (sum, payment) => sum + payment.amount,
     0,
@@ -431,7 +431,6 @@ export default function StampLogForm({
     .join(" + ");
   const finalAmountExpression = [
     amountExpression || "0",
-    activeDeliveryFee > 0 ? `+ ${formatAmount(activeDeliveryFee)}` : "",
     activeDiscountAmount > 0 ? `- ${formatAmount(activeDiscountAmount)}` : "",
   ]
     .filter(Boolean)

--- a/supabase/migrations/20260803000000_allow_staff_customer_updates.sql
+++ b/supabase/migrations/20260803000000_allow_staff_customer_updates.sql
@@ -1,0 +1,25 @@
+alter table public.customers enable row level security;
+
+drop policy if exists "Enable update access for all users"
+on public.customers;
+
+create policy "authenticated staff and admins can update customers"
+on public.customers
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.users
+    where users.id = auth.uid()
+      and users.oss_role in ('staff', 'admin')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.users
+    where users.id = auth.uid()
+      and users.oss_role in ('staff', 'admin')
+  )
+);


### PR DESCRIPTION
## 작업 내용

### 출고 이력 결제금액 계산 수정
- 택배비와 배달대행비가 최종 결제금액에 합산되지 않도록 수정했습니다.
- 신규 출고 이력 추가와 기존 출고 이력 수정에 동일하게 적용됩니다.
- 택배비와 배달대행비는 기존처럼 출고 이력과 배송 정보에 기록됩니다.
- 할인 금액은 기존처럼 최종 결제금액에서 차감됩니다.
- 분할결제 검증 금액도 수정된 최종 결제금액을 기준으로 계산됩니다.

### 고객정보 수정 권한 개선
- staff 계정에서도 고객 상세의 고객정보 수정 버튼이 표시되도록 변경했습니다.
- staff와 admin 모두 고객정보를 수정할 수 있도록 Supabase RLS 마이그레이션을 추가했습니다.
- 고객 삭제 버튼과 삭제 권한은 기존처럼 admin 계정에만 제공됩니다.

## DB 적용 필요

아래 Supabase 마이그레이션을 원격 DB에 적용해야 staff 고객정보 수정이 실제로 동작합니다.

supabase/migrations/20260803000000_allow_staff_customer_updates.sql

## 검증

- 전체 ESLint 통과
- Next.js 프로덕션 빌드 통과
- git diff 검사 통과