### PR TITLE
고객 적립 설정 및 입고·오픈 업무 기능 개선

### DIFF
--- a/src/app/(auth)/_components/StampLogEditModal.tsx
+++ b/src/app/(auth)/_components/StampLogEditModal.tsx
@@ -77,6 +77,7 @@ interface StampLogEditModalProps {
     phone: string;
     address?: string | null;
     note?: string | null;
+    is_stamp_eligible?: boolean;
   };
   initialAction: string;
   initialPaymentType?: PaymentTypeEnumType["value"];
@@ -106,7 +107,11 @@ const StampLogEditModal = ({
   onCancel,
 }: StampLogEditModalProps) => {
   const { setSize } = useModal();
-  const customerMode = getCustomerMode(target.name, target.phone);
+  const customerMode = getCustomerMode(
+    target.name,
+    target.phone,
+    target.is_stamp_eligible ?? true,
+  );
   const [stampLog, setStampLog] = useState<StampLogValue | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [step, setStep] = useState<1 | 2 | 3>(2);

--- a/src/app/(auth)/cash-management/_components/ChecklistManagement.tsx
+++ b/src/app/(auth)/cash-management/_components/ChecklistManagement.tsx
@@ -7,7 +7,9 @@ import Button from "@/app/_components/Button";
 import Loading from "@/app/_components/Loading";
 import {
   getDailyClosingChecklistItems,
+  getOpeningCompletionNotice,
   saveDailyClosingChecklistItems,
+  saveOpeningCompletionNotice,
 } from "@/app/_domains/_dailyClosing/_services/dailyClosingService";
 import type {
   DailyClosingChecklistItem,
@@ -21,16 +23,31 @@ const phaseTitle: Record<DailyClosingChecklistPhase, string> = {
 
 export default function ChecklistManagement() {
   const [editing, setEditing] = useState(false);
+  const [noticeEditing, setNoticeEditing] = useState(false);
+  const [noticeTitle, setNoticeTitle] = useState("");
+  const [noticeContent, setNoticeContent] = useState("");
+  const [noticeActive, setNoticeActive] = useState(false);
   const [draft, setDraft] = useState<DailyClosingChecklistItem[]>([]);
   const checklistQuery = useQuery({
     queryKey: ["daily-closing-checklist-items"],
     queryFn: getDailyClosingChecklistItems,
+  });
+  const noticeQuery = useQuery({
+    queryKey: ["opening-completion-notice"],
+    queryFn: getOpeningCompletionNotice,
   });
   const items = useMemo(() => checklistQuery.data ?? [], [checklistQuery.data]);
 
   useEffect(() => {
     if (!editing) setDraft(items.map((item) => ({ ...item })));
   }, [editing, items]);
+
+  useEffect(() => {
+    if (noticeEditing) return;
+    setNoticeTitle(noticeQuery.data?.title ?? "오픈 처리가 완료되었습니다");
+    setNoticeContent(noticeQuery.data?.content ?? "");
+    setNoticeActive(noticeQuery.data?.is_active ?? false);
+  }, [noticeEditing, noticeQuery.data]);
 
   const saveMutation = useMutation({
     mutationFn: () =>
@@ -51,6 +68,22 @@ export default function ChecklistManagement() {
     },
     onError: () =>
       toast.error("체크리스트 저장에 실패했습니다. SQL을 확인해 주세요."),
+  });
+
+  const noticeSaveMutation = useMutation({
+    mutationFn: () =>
+      saveOpeningCompletionNotice({
+        title: noticeTitle,
+        content: noticeContent,
+        isActive: noticeActive,
+      }),
+    onSuccess: async () => {
+      toast.success("오픈 완료 알림을 저장했습니다.");
+      setNoticeEditing(false);
+      await noticeQuery.refetch();
+    },
+    onError: () =>
+      toast.error("알림 저장에 실패했습니다. 새 SQL 적용 여부를 확인해 주세요."),
   });
 
   if (checklistQuery.isPending) {
@@ -87,6 +120,95 @@ export default function ChecklistManagement() {
             />
           ))}
         </div>
+      </section>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="font-bold text-gray-900">오픈 완료 알림</h2>
+              <span
+                className={`rounded-full px-2 py-0.5 text-[11px] font-bold ${
+                  noticeActive
+                    ? "bg-emerald-100 text-emerald-700"
+                    : "bg-gray-100 text-gray-500"
+                }`}
+              >
+                {noticeActive ? "사용" : "미사용"}
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-gray-500">
+              오픈 대상 항목을 모두 체크한 직원에게 저장된 알림 버전별로 한 번 표시됩니다.
+            </p>
+          </div>
+          {!noticeEditing && (
+            <Button
+              size="sm"
+              variant="gray"
+              onClick={() => setNoticeEditing(true)}
+              disabled={noticeQuery.isPending || noticeQuery.isError}
+            >
+              수정
+            </Button>
+          )}
+        </div>
+
+        {noticeQuery.isError ? (
+          <p className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-700">
+            알림 설정을 불러올 수 없습니다. 오픈 완료 알림 SQL을 먼저 적용해 주세요.
+          </p>
+        ) : noticeEditing ? (
+          <div className="mt-4 space-y-4 rounded-xl border border-gray-200 bg-gray-50/70 p-4">
+            <label className="flex cursor-pointer items-center gap-2 text-sm font-semibold text-gray-700">
+              <input
+                type="checkbox"
+                checked={noticeActive}
+                onChange={(event) => setNoticeActive(event.target.checked)}
+                className="cursor-pointer accent-brand-500"
+              />
+              오픈 완료 알림 사용
+            </label>
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-semibold text-gray-700">제목</span>
+              <input
+                value={noticeTitle}
+                onChange={(event) => setNoticeTitle(event.target.value)}
+                maxLength={80}
+                className="h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                placeholder="알림 제목을 입력하세요"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-semibold text-gray-700">내용</span>
+              <textarea
+                value={noticeContent}
+                onChange={(event) => setNoticeContent(event.target.value)}
+                rows={5}
+                maxLength={1000}
+                className="w-full resize-y rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-900 outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                placeholder="직원에게 전달할 내용을 입력하세요"
+              />
+            </label>
+            <div className="flex justify-end gap-2">
+              <Button variant="gray" onClick={() => setNoticeEditing(false)}>
+                취소
+              </Button>
+              <Button
+                onClick={() => noticeSaveMutation.mutate()}
+                disabled={noticeSaveMutation.isPending || !noticeTitle.trim()}
+              >
+                {noticeSaveMutation.isPending ? "저장 중..." : "알림 저장"}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50/70 p-4">
+            <p className="font-semibold text-gray-900">{noticeTitle}</p>
+            <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-gray-600">
+              {noticeContent || "작성된 알림 내용이 없습니다."}
+            </p>
+          </div>
+        )}
       </section>
 
       {editing && (

--- a/src/app/(auth)/cash-management/page.tsx
+++ b/src/app/(auth)/cash-management/page.tsx
@@ -560,19 +560,16 @@ export default function CashManagementPage() {
             <div className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
               <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-5 py-4">
                 <div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h2 className="font-semibold text-gray-900">
-                      실제 현금 입력
-                    </h2>
-                    <Button
-                      size="xs"
-                      variant="gray"
+                  <h2 className="font-semibold text-gray-900">
+                    <button
+                      type="button"
                       onClick={loadPreviousCashCounts}
-                      className="border-gray-200 bg-white/80 text-[11px] text-gray-600 shadow-xs hover:border-brand-200 hover:text-brand-700"
+                      aria-label="전날 시재 불러오기"
+                      className="cursor-pointer appearance-none bg-transparent p-0 text-left font-inherit text-inherit outline-none focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-brand-200"
                     >
-                      전날 시재 불러오기
-                    </Button>
-                  </div>
+                      실제 현금 입력
+                    </button>
+                  </h2>
                   <p className="mt-1 text-xs text-gray-500">
                     지폐와 동전의 개수를 입력하세요.
                   </p>

--- a/src/app/(auth)/customers/[id]/_components/CustomerEditModal.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomerEditModal.tsx
@@ -1,15 +1,16 @@
-'use client';
+"use client";
 
-import { Resolver, useForm } from 'react-hook-form';
-import { z } from 'zod';
-import { useState } from 'react';
-import Button from '@/app/_components/Button';
-import { formatPhoneNumber } from '@/app/_utils/utils';
+import { Controller, Resolver, useForm } from "react-hook-form";
+import { z } from "zod";
+import { useState } from "react";
+import Button from "@/app/_components/Button";
+import { formatPhoneNumber } from "@/app/_utils/utils";
 
 type FormValues = {
   name: string;
   phone: string;
-  gender: 'male' | 'female';
+  gender: "male" | "female";
+  is_stamp_eligible: boolean;
   address?: string;
   note?: string;
 };
@@ -18,26 +19,27 @@ const schema = z.object({
   name: z.coerce
     .string()
     .trim()
-    .min(1, { message: '이름을 입력하세요.' })
-    .transform((v) => (v.toUpperCase() === 'X' ? 'X' : v)),
+    .min(1, { message: "이름을 입력하세요." })
+    .transform((v) => (v.toUpperCase() === "X" ? "X" : v)),
   phone: z.coerce
     .string()
     .trim()
-    .min(1, { message: '전화번호를 입력하세요.' })
-    .refine((v) => v.toUpperCase() === 'X' || /^[0-9]{10,11}$/.test(v), {
-      message: '10-11자리 숫자만 입력하세요. (정보 없을 경우 X 입력)',
+    .min(1, { message: "전화번호를 입력하세요." })
+    .refine((v) => v.toUpperCase() === "X" || /^[0-9]{10,11}$/.test(v), {
+      message: "10-11자리 숫자만 입력하세요. (정보 없을 경우 X 입력)",
     })
-    .transform((v) => (v.toUpperCase() === 'X' ? 'X' : v)),
-  gender: z.enum(['male', 'female']),
+    .transform((v) => (v.toUpperCase() === "X" ? "X" : v)),
+  gender: z.enum(["male", "female"]),
+  is_stamp_eligible: z.boolean(),
   address: z.coerce
     .string()
     .trim()
-    .max(200, { message: '주소지는 200자 이하로 입력해주세요.' })
+    .max(200, { message: "주소지는 200자 이하로 입력해주세요." })
     .optional(),
   note: z.coerce
     .string()
     .trim()
-    .max(500, { message: '특이사항은 500자 이하로 입력해주세요.' })
+    .max(500, { message: "특이사항은 500자 이하로 입력해주세요." })
     .optional(),
 });
 
@@ -52,9 +54,9 @@ const safeResolver = (schema: z.ZodTypeAny) => async (data: unknown) => {
     const errors: Record<string, { type: string; message: string }> = {};
 
     Object.keys(formattedErrors).forEach((key) => {
-      if (key !== '_errors' && formattedErrors[key]?._errors?.length > 0) {
+      if (key !== "_errors" && formattedErrors[key]?._errors?.length > 0) {
         errors[key] = {
-          type: 'validation',
+          type: "validation",
           message: formattedErrors[key]._errors[0],
         };
       }
@@ -62,7 +64,7 @@ const safeResolver = (schema: z.ZodTypeAny) => async (data: unknown) => {
 
     return { values: {}, errors };
   } catch (err) {
-    console.error('[safeResolver Error]', err);
+    console.error("[safeResolver Error]", err);
     return { values: {}, errors: {} };
   }
 };
@@ -78,7 +80,8 @@ export default function CustomerEditModal({
   customer: {
     name: string;
     phone: string;
-    gender?: 'male' | 'female';
+    gender?: "male" | "female";
+    is_stamp_eligible?: boolean;
     address?: string | null;
     note?: string | null;
   };
@@ -93,17 +96,19 @@ export default function CustomerEditModal({
 
   const {
     register,
+    control,
     handleSubmit,
     formState: { errors, isSubmitting, isValid },
   } = useForm<FormValues>({
-    mode: 'onChange',
+    mode: "onChange",
     resolver: safeResolver(schema) as Resolver<FormValues, unknown>,
     defaultValues: {
       name: customer.name,
       phone: customer.phone,
-      gender: customer.gender || 'male',
-      address: customer.address || '',
-      note: customer.note || '',
+      gender: customer.gender || "male",
+      is_stamp_eligible: customer.is_stamp_eligible ?? true,
+      address: customer.address || "",
+      note: customer.note || "",
     },
   });
 
@@ -182,7 +187,7 @@ export default function CustomerEditModal({
               }
             }}
           >
-            {isDeleting ? '삭제 중...' : '삭제'}
+            {isDeleting ? "삭제 중..." : "삭제"}
           </Button>
         </div>
       </div>
@@ -207,13 +212,23 @@ export default function CustomerEditModal({
                 전화번호:
               </span>
               <p className="text-base font-semibold text-gray-900">
-                {formData.phone === 'X' ? 'X' : formatPhoneNumber(formData.phone)}
+                {formData.phone === "X"
+                  ? "X"
+                  : formatPhoneNumber(formData.phone)}
               </p>
             </div>
             <div>
               <span className="text-sm font-medium text-gray-600">성별:</span>
               <p className="text-base font-semibold text-gray-900">
-                {formData.gender === 'male' ? '남자' : '여자'}
+                {formData.gender === "male" ? "남자" : "여자"}
+              </p>
+            </div>
+            <div>
+              <span className="text-sm font-medium text-gray-600">
+                적립 대상:
+              </span>
+              <p className="text-base font-semibold text-gray-900">
+                {formData.is_stamp_eligible ? "적립" : "미적립"}
               </p>
             </div>
             {formData.note && (
@@ -256,7 +271,7 @@ export default function CustomerEditModal({
             onClick={handleConfirm}
             size="sm"
           >
-            {isSubmitting ? '수정 중...' : '수정'}
+            {isSubmitting ? "수정 중..." : "수정"}
           </Button>
         </div>
       </div>
@@ -280,7 +295,7 @@ export default function CustomerEditModal({
             className="w-full rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
             placeholder="홍길동"
             aria-invalid={!!errors.name || undefined}
-            {...register('name')}
+            {...register("name")}
           />
           {errors.name && (
             <p className="mt-1 text-xs text-rose-600">{errors.name.message}</p>
@@ -296,7 +311,7 @@ export default function CustomerEditModal({
             className="w-full rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
             placeholder="'-' 없이 숫자만 (ex: 01012345678) / 정보 없을 경우 X"
             aria-invalid={!!errors.phone || undefined}
-            {...register('phone')}
+            {...register("phone")}
           />
           {errors.phone && (
             <p className="mt-1 text-xs text-rose-600">{errors.phone.message}</p>
@@ -309,11 +324,11 @@ export default function CustomerEditModal({
           </span>
           <div className="flex items-center gap-4">
             <label className="inline-flex items-center gap-2 text-sm">
-              <input type="radio" value="male" {...register('gender')} />
+              <input type="radio" value="male" {...register("gender")} />
               남자
             </label>
             <label className="inline-flex items-center gap-2 text-sm">
-              <input type="radio" value="female" {...register('gender')} />
+              <input type="radio" value="female" {...register("gender")} />
               여자
             </label>
           </div>
@@ -325,12 +340,40 @@ export default function CustomerEditModal({
         </div>
 
         <div>
+          <span className="block text-sm font-medium mb-1">적립 대상</span>
+          <Controller
+            name="is_stamp_eligible"
+            control={control}
+            render={({ field }) => (
+              <div className="flex items-center gap-4">
+                <label className="inline-flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    checked={field.value}
+                    onChange={() => field.onChange(true)}
+                  />
+                  적립
+                </label>
+                <label className="inline-flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    checked={!field.value}
+                    onChange={() => field.onChange(false)}
+                  />
+                  미적립
+                </label>
+              </div>
+            )}
+          />
+        </div>
+
+        <div>
           <label className="block text-sm font-medium mb-1">특이사항</label>
           <textarea
             className="w-full min-h-24 rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
             placeholder="고객,결제 관련 특이사항을 입력하세요. (선택)"
             aria-invalid={!!errors.note || undefined}
-            {...register('note')}
+            {...register("note")}
           />
           {errors.note && (
             <p className="mt-1 text-xs text-rose-600">{errors.note.message}</p>
@@ -342,9 +385,11 @@ export default function CustomerEditModal({
           <textarea
             rows={3}
             className="w-full min-h-20 resize-y rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
-            placeholder={"주소지를 입력하세요. (선택)\nex) OO구 도로명주소 OO건물 OO동 OO호 (공동현관 : 비밀번호 or X)"}
+            placeholder={
+              "주소지를 입력하세요. (선택)\nex) OO구 도로명주소 OO건물 OO동 OO호 (공동현관 : 비밀번호 or X)"
+            }
             aria-invalid={!!errors.address || undefined}
-            {...register('address')}
+            {...register("address")}
           />
           {errors.address && (
             <p className="mt-1 text-xs text-rose-600">
@@ -356,7 +401,7 @@ export default function CustomerEditModal({
 
       <div
         className={`pt-4 border-t border-gray-200 flex justify-between mt-4 ${
-          isAdmin ? 'justify-between' : 'justify-end'
+          isAdmin ? "justify-between" : "justify-end"
         }`}
       >
         {isAdmin && (
@@ -376,7 +421,7 @@ export default function CustomerEditModal({
             취소
           </Button>
           <Button type="submit" disabled={isSubmitting} size="sm">
-            {isSubmitting ? '수정 중...' : '수정'}
+            {isSubmitting ? "수정 중..." : "수정"}
           </Button>
         </div>
       </div>

--- a/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
@@ -3,29 +3,29 @@ import {
   LogActorInfo,
   PaymentTypeLabel,
   StoreLabel,
-} from '@/app/(auth)/_components/HistoriesComponents';
-import Button from '@/app/_components/Button';
-import Loading from '@/app/_components/Loading';
-import useCopy from '@/app/_domains/_log/_hooks/useCopy';
-import { CustomersLogsResType } from '@/app/_domains/_log/_types/log.types';
+} from "@/app/(auth)/_components/HistoriesComponents";
+import Button from "@/app/_components/Button";
+import Loading from "@/app/_components/Loading";
+import useCopy from "@/app/_domains/_log/_hooks/useCopy";
+import { CustomersLogsResType } from "@/app/_domains/_log/_types/log.types";
 import {
   updateLogNote,
   deleteLog,
-} from '@/app/_domains/_log/_services/logService';
-import { useCallback } from 'react';
+} from "@/app/_domains/_log/_services/logService";
+import { useCallback } from "react";
 import {
   PaymentTypeEnum,
   PaymentTypeEnumType,
   StoreTypeEnumType,
-} from '@/app/_enums/enums';
-import { groupLogsByDate, formatDateKey } from '@/app/_utils/utils';
-import { toast } from 'react-hot-toast';
-import { useModal } from '@/app/_contexts/ModalContext';
-import DeleteConfirmModal from '@/app/(auth)/_components/DeleteConfirmModal';
-import ConfirmModal from '@/app/(auth)/_components/ConfirmModal';
-import StampLogEditModal from '@/app/(auth)/_components/StampLogEditModal';
-import RemarkLogCreateModal from '../RemarkLogCreateModal';
-import type { StampLogMeta } from '@/app/_domains/_stamp/_services/stampService';
+} from "@/app/_enums/enums";
+import { groupLogsByDate, formatDateKey } from "@/app/_utils/utils";
+import { toast } from "react-hot-toast";
+import { useModal } from "@/app/_contexts/ModalContext";
+import DeleteConfirmModal from "@/app/(auth)/_components/DeleteConfirmModal";
+import ConfirmModal from "@/app/(auth)/_components/ConfirmModal";
+import StampLogEditModal from "@/app/(auth)/_components/StampLogEditModal";
+import RemarkLogCreateModal from "../RemarkLogCreateModal";
+import type { StampLogMeta } from "@/app/_domains/_stamp/_services/stampService";
 
 const CustomersDetailStampsHistories = ({
   targetUser,
@@ -41,9 +41,10 @@ const CustomersDetailStampsHistories = ({
   targetUser: {
     phone: string;
     name: string;
-    gender?: 'male' | 'female' | null;
+    gender?: "male" | "female" | null;
     address?: string | null;
     note?: string | null;
+    is_stamp_eligible?: boolean;
   };
   isLoading: boolean;
   error: string;
@@ -70,10 +71,10 @@ const CustomersDetailStampsHistories = ({
           await onConfirmReservation(log.id);
           onDeleteLog(log.id);
           close();
-          toast.success('출고 이력으로 확정되었습니다.');
+          toast.success("출고 이력으로 확정되었습니다.");
         } catch (e) {
           console.error(e);
-          toast.error('출고 확정에 실패했습니다. 다시 시도해 주세요.');
+          toast.error("출고 확정에 실패했습니다. 다시 시도해 주세요.");
           close();
         }
       };
@@ -82,7 +83,7 @@ const CustomersDetailStampsHistories = ({
           <ConfirmModal
             title="출고 확정"
             description={
-              '이 예약을 출고 이력으로 확정하시겠습니까?\n확정 시 스탬프가 적립되고 출고 이력으로 이동합니다.'
+              "이 예약을 출고 이력으로 확정하시겠습니까?\n확정 시 스탬프가 적립되고 출고 이력으로 이동합니다."
             }
             confirmLabel="출고 확정"
             confirmingLabel="확정 중..."
@@ -103,10 +104,10 @@ const CustomersDetailStampsHistories = ({
           await deleteLog(log.id);
           onDeleteLog(log.id);
           close();
-          toast.success('로그를 삭제했습니다.');
+          toast.success("로그를 삭제했습니다.");
         } catch (e) {
           console.error(e);
-          toast.error('로그 삭제에 실패했습니다. 다시 시도해 주세요.');
+          toast.error("로그 삭제에 실패했습니다. 다시 시도해 주세요.");
           close();
         }
       };
@@ -140,22 +141,22 @@ const CustomersDetailStampsHistories = ({
             }));
             close();
             toast.success(
-              isRemarkLog ? '특이사항을 저장했습니다.' : '메모를 저장했습니다.',
+              isRemarkLog ? "특이사항을 저장했습니다." : "메모를 저장했습니다.",
             );
           } catch (e) {
             console.error(e);
-            toast.error('저장에 실패했습니다. 다시 시도해 주세요.');
+            toast.error("저장에 실패했습니다. 다시 시도해 주세요.");
           }
         };
 
         open({
           content: (
             <RemarkLogCreateModal
-              initialNote={log.note ?? ''}
+              initialNote={log.note ?? ""}
               mode="edit"
-              title={isRemarkLog ? undefined : '메모 수정'}
-              label={isRemarkLog ? undefined : '메모'}
-              placeholder={isRemarkLog ? undefined : '메모를 입력하세요'}
+              title={isRemarkLog ? undefined : "메모 수정"}
+              label={isRemarkLog ? undefined : "메모"}
+              placeholder={isRemarkLog ? undefined : "메모를 입력하세요"}
               onSubmit={handleRemarkSubmit}
               onCancel={close}
             />
@@ -167,8 +168,8 @@ const CustomersDetailStampsHistories = ({
 
       const handleSubmit = async (values: {
         note: string;
-        paymentType?: PaymentTypeEnumType['value'];
-        storeName: StoreTypeEnumType['value'];
+        paymentType?: PaymentTypeEnumType["value"];
+        storeName: StoreTypeEnumType["value"];
         logMeta: StampLogMeta;
         amount: number;
       }) => {
@@ -176,7 +177,7 @@ const CustomersDetailStampsHistories = ({
           // 예약 이력은 아직 스탬프가 적립되지 않았으므로 개수 수정 허용
           const nextAction = isReservation
             ? values.amount === 0
-              ? 'no-stamp'
+              ? "no-stamp"
               : `add-${values.amount}`
             : undefined;
           const updated = await updateLogNote(
@@ -195,10 +196,10 @@ const CustomersDetailStampsHistories = ({
             updated_at: updated.updated_at,
           }));
           close();
-          toast.success('이력을 저장했습니다.');
+          toast.success("이력을 저장했습니다.");
         } catch (e) {
           console.error(e);
-          toast.error('저장에 실패했습니다. 다시 시도해 주세요.');
+          toast.error("저장에 실패했습니다. 다시 시도해 주세요.");
         }
       };
 
@@ -210,17 +211,18 @@ const CustomersDetailStampsHistories = ({
               phone: targetUser.phone,
               address: targetUser.address,
               note: targetUser.note,
+              is_stamp_eligible: targetUser.is_stamp_eligible,
             }}
             initialAction={log.action}
             initialPaymentType={
-              log.jsonb?.paymentType as PaymentTypeEnumType['value'] | undefined
+              log.jsonb?.paymentType as PaymentTypeEnumType["value"] | undefined
             }
             initialStoreName={
-              log.jsonb?.storeName as StoreTypeEnumType['value'] | undefined
+              log.jsonb?.storeName as StoreTypeEnumType["value"] | undefined
             }
             initialLogMeta={log.jsonb as StampLogMeta}
             isStampAmountEditable={isReservation}
-            title={isReservation ? '출고 예약 수정' : '출고 이력 수정'}
+            title={isReservation ? "출고 예약 수정" : "출고 이력 수정"}
             onSubmit={handleSubmit}
             onCancel={close}
           />
@@ -237,6 +239,7 @@ const CustomersDetailStampsHistories = ({
       targetUser.address,
       targetUser.note,
       targetUser.phone,
+      targetUser.is_stamp_eligible,
     ],
   );
 
@@ -284,8 +287,8 @@ const CustomersDetailStampsHistories = ({
                 >
                   <div className="flex items-center gap-4 sm:gap-6">
                     {!(
-                      targetUser.name.trim() === 'X' &&
-                      targetUser.phone.trim() === 'X'
+                      targetUser.name.trim() === "X" &&
+                      targetUser.phone.trim() === "X"
                     ) && <ActionInfoLabel action={log.action} />}
 
                     {log.users && (
@@ -300,16 +303,16 @@ const CustomersDetailStampsHistories = ({
                     )}
                   </div>
                   <div className="flex flex-col items-start gap-1 ml-4">
-                    {log.jsonb && 'storeName' in log.jsonb && (
+                    {log.jsonb && "storeName" in log.jsonb && (
                       <StoreLabel jsonb={log.jsonb} />
                     )}
-                    {log.jsonb && 'paymentType' in log.jsonb && (
+                    {log.jsonb && "paymentType" in log.jsonb && (
                       <PaymentTypeLabel jsonb={log.jsonb} />
                     )}
-                    {typeof log.jsonb?.totalAmount === 'number' &&
+                    {typeof log.jsonb?.totalAmount === "number" &&
                       log.jsonb.totalAmount > 0 && (
                         <span className="inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 text-xs font-semibold px-2 py-1">
-                          {log.jsonb.totalAmount.toLocaleString('ko-KR')}원
+                          {log.jsonb.totalAmount.toLocaleString("ko-KR")}원
                         </span>
                       )}
                   </div>
@@ -328,16 +331,16 @@ const CustomersDetailStampsHistories = ({
                             <span className="text-gray-400"> - </span>
                           )}
                         </p>
-                        {typeof log.jsonb?.extraNote === 'string' &&
+                        {typeof log.jsonb?.extraNote === "string" &&
                           log.jsonb.extraNote.trim() && (
                             <p className="mt-1 italic text-gray-400">
                               출고 특이사항: &quot;{log.jsonb.extraNote.trim()}
                               &quot;
                             </p>
                           )}
-                        {(log.jsonb?.deliveryMethod === 'parcel' ||
-                          log.jsonb?.deliveryMethod === 'delivery') &&
-                          typeof log.jsonb?.deliveryAddress === 'string' &&
+                        {(log.jsonb?.deliveryMethod === "parcel" ||
+                          log.jsonb?.deliveryMethod === "delivery") &&
+                          typeof log.jsonb?.deliveryAddress === "string" &&
                           log.jsonb.deliveryAddress.trim() && (
                             <p className="mt-1 break-words italic text-gray-400">
                               주소: {log.jsonb.deliveryAddress.trim()}

--- a/src/app/(auth)/customers/[id]/_components/StampSection.tsx
+++ b/src/app/(auth)/customers/[id]/_components/StampSection.tsx
@@ -26,6 +26,7 @@ interface StampSectionProps {
     phone: string;
     address?: string | null;
     gender?: "male" | "female" | null;
+    is_stamp_eligible?: boolean;
     note?: string | null;
   };
   onUpdate: () => void;
@@ -65,8 +66,16 @@ const StampSection = ({
   const openOutboundModalRef = useRef<() => void>(() => undefined);
   const { open, close } = useModal();
   const queryClient = useQueryClient();
-  const customerMode = getCustomerMode(target.name, target.phone);
+  const customerMode = getCustomerMode(
+    target.name,
+    target.phone,
+    target.is_stamp_eligible ?? true,
+  );
   const isSpecialCustomer = customerMode !== "normal";
+  const isRegularNonAccrualCustomer =
+    customerMode === "x" &&
+    target.is_stamp_eligible === false &&
+    !(target.name.trim() === "X" && target.phone.trim() === "X");
   const specialAccountLabel =
     customerMode === "demo"
       ? "시연용 처리"
@@ -83,6 +92,7 @@ const StampSection = ({
             phone: target.phone,
             address: target.address,
             note: target.note,
+            is_stamp_eligible: target.is_stamp_eligible,
           }}
           stampCount={stampCount}
           mode="add"
@@ -235,10 +245,18 @@ const StampSection = ({
 
           <div className="w-full border-t border-brand-200 pt-5">
             <p className="mb-5 text-center text-base leading-7 text-gray-600 sm:text-lg">
-              <strong className="font-semibold text-brand-700">
-                {specialAccountLabel}
-              </strong>
-              을 위한 특수 계정입니다.
+              {isRegularNonAccrualCustomer ? (
+                <strong className="font-semibold text-brand-700">
+                  {specialAccountLabel}입니다.
+                </strong>
+              ) : (
+                <>
+                  <strong className="font-semibold text-brand-700">
+                    {specialAccountLabel}
+                  </strong>
+                  을 위한 특수 계정입니다.
+                </>
+              )}
             </p>
           </div>
 
@@ -284,6 +302,7 @@ const StampSection = ({
                           phone: target.phone,
                           address: target.address,
                           note: target.note,
+                          is_stamp_eligible: target.is_stamp_eligible,
                         }}
                         mode="use10"
                         onCancel={close}
@@ -313,6 +332,7 @@ const StampSection = ({
                           phone: target.phone,
                           address: target.address,
                           note: target.note,
+                          is_stamp_eligible: target.is_stamp_eligible,
                         }}
                         mode="adjust"
                         onCancel={close}

--- a/src/app/(auth)/customers/[id]/page.tsx
+++ b/src/app/(auth)/customers/[id]/page.tsx
@@ -91,6 +91,7 @@ export default function CustomerDetailPage() {
     name: string;
     phone: string;
     gender: "male" | "female";
+    is_stamp_eligible: boolean;
     address?: string;
     note?: string;
   }) => {
@@ -169,6 +170,7 @@ export default function CustomerDetailPage() {
   const isSpecialCustomer = checkSpecialCustomer(
     customer.name,
     customer.phone,
+    customer.is_stamp_eligible ?? true,
   );
 
   return (
@@ -219,6 +221,7 @@ export default function CustomerDetailPage() {
               phone: customer.phone,
               address: customer.address,
               gender: customer.gender,
+              is_stamp_eligible: customer.is_stamp_eligible,
               note: customer.note,
             }}
             onUpdate={handleUpdate}
@@ -296,6 +299,7 @@ export default function CustomerDetailPage() {
                   phone: customer.phone,
                   name: customer.name,
                   gender: customer.gender,
+                  is_stamp_eligible: customer.is_stamp_eligible,
                   address: customer.address,
                   note: customer.note,
                 }}

--- a/src/app/(auth)/customers/_components/CustomerCreateModal.tsx
+++ b/src/app/(auth)/customers/_components/CustomerCreateModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 import { useState, useRef } from "react";
 import Button from "@/app/_components/Button";
@@ -26,6 +26,7 @@ const schema = z.object({
     })
     .transform((v) => (v.toUpperCase() === "X" ? "X" : v)),
   gender: z.enum(["male", "female"]),
+  is_stamp_eligible: z.boolean(),
   address: z
     .string()
     .trim()
@@ -71,6 +72,7 @@ export default function CustomerCreateModal({
   // ========================================================================
   const {
     register,
+    control,
     handleSubmit,
     formState: { errors, isValid },
   } = useForm<FormValues>({
@@ -80,6 +82,7 @@ export default function CustomerCreateModal({
       name: "",
       phone: "",
       gender: "male",
+      is_stamp_eligible: true,
       address: "",
       note: "",
     },
@@ -156,6 +159,14 @@ export default function CustomerCreateModal({
                 <span className="text-sm font-medium text-gray-600">성별:</span>
                 <p className="text-base font-semibold text-gray-900">
                   {formData.gender === "male" ? "남자" : "여자"}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-gray-600">
+                  적립 대상:
+                </span>
+                <p className="text-base font-semibold text-gray-900">
+                  {formData.is_stamp_eligible ? "적립" : "미적립"}
                 </p>
               </div>
               {formData.note && (
@@ -285,6 +296,34 @@ export default function CustomerCreateModal({
           </div>
 
           <div>
+            <span className="block text-sm font-medium mb-1">적립 대상</span>
+            <Controller
+              name="is_stamp_eligible"
+              control={control}
+              render={({ field }) => (
+                <div className="flex items-center gap-4">
+                  <label className="inline-flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      checked={field.value}
+                      onChange={() => field.onChange(true)}
+                    />
+                    적립
+                  </label>
+                  <label className="inline-flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      checked={!field.value}
+                      onChange={() => field.onChange(false)}
+                    />
+                    미적립
+                  </label>
+                </div>
+              )}
+            />
+          </div>
+
+          <div>
             <label className="block text-sm font-medium mb-1">특이사항</label>
             <textarea
               className="w-full min-h-24 rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
@@ -304,7 +343,9 @@ export default function CustomerCreateModal({
             <textarea
               rows={3}
               className="w-full min-h-20 resize-y rounded border border-brand-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-300"
-              placeholder={"주소지를 입력하세요. (선택)\nex) OO구 도로명주소 OO건물 OO동 OO호 (공동현관 : 비밀번호 or X)"}
+              placeholder={
+                "주소지를 입력하세요. (선택)\nex) OO구 도로명주소 OO건물 OO동 OO호 (공동현관 : 비밀번호 or X)"
+              }
               aria-invalid={!!errors.address || undefined}
               {...register("address")}
             />
@@ -314,7 +355,6 @@ export default function CustomerCreateModal({
               </p>
             )}
           </div>
-
         </div>
 
         <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 mt-6 shrink-0">

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -80,6 +80,7 @@ export default function StampConfirmModal({
     phone: string;
     address?: string | null;
     note?: string | null;
+    is_stamp_eligible?: boolean;
   };
   mode: "add" | "adjust" | "use10";
   amount?: number;
@@ -120,7 +121,11 @@ export default function StampConfirmModal({
         (sum, payment) => sum + payment.amount,
         0,
       ) === stampLog.finalAmount);
-  const customerMode = getCustomerMode(target.name, target.phone);
+  const customerMode = getCustomerMode(
+    target.name,
+    target.phone,
+    target.is_stamp_eligible ?? true,
+  );
   const usesStandardSalesFlow =
     customerMode === "normal" || customerMode === "x";
 

--- a/src/app/(auth)/customers/page.tsx
+++ b/src/app/(auth)/customers/page.tsx
@@ -121,6 +121,7 @@ export default function CustomersPage() {
         name: values.name,
         phone: values.phone,
         gender: values.gender,
+        is_stamp_eligible: values.is_stamp_eligible,
         address: values.address,
         note: values.note,
       });

--- a/src/app/(auth)/histories/_components/StampHistories/index.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/index.tsx
@@ -1,43 +1,43 @@
-'use client';
+"use client";
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback } from "react";
 import {
   LogCategoryEnum,
   LogCategoryEnumType,
   PaymentTypeEnum,
   PaymentTypeEnumType,
   StoreTypeEnumType,
-} from '@/app/_enums/enums';
+} from "@/app/_enums/enums";
 import {
   updateLogNote,
   deleteLog,
-} from '@/app/_domains/_log/_services/logService';
-import { confirmReservationStamp } from '@/app/_domains/_stamp/_services/stampService';
-import { useQueryClient } from '@tanstack/react-query';
-import { logKeys } from '@/app/_domains/_log/_queryKeys/logKeys';
-import { customerKeys } from '@/app/_domains/_customer/_queryKeys/customerKeys';
-import Loading from '@/app/_components/Loading';
-import Button from '@/app/_components/Button';
-import { Dropdown, DropdownOption } from '@/app/_components/Dropdown';
-import DateRangePicker from '@/app/_components/DateRangePicker';
-import toast from 'react-hot-toast';
-import { useRouter } from 'next/navigation';
-import { LogsResType } from '@/app/_domains/_log/_types/log.types';
-import useLogs from '@/app/_domains/_log/_hooks/useLogs';
-import { groupLogsByDate, formatDateKey } from '@/app/_utils/utils';
-import StampHistoryItem from './StampHistoryItem';
-import { useUser } from '@/app/_contexts/UserContext';
-import { useModal } from '@/app/_contexts/ModalContext';
-import DeleteConfirmModal from '@/app/(auth)/_components/DeleteConfirmModal';
-import StampLogEditModal from '@/app/(auth)/_components/StampLogEditModal';
-import ConfirmModal from '@/app/(auth)/_components/ConfirmModal';
-import RemarkLogCreateModal from '@/app/(auth)/customers/[id]/_components/RemarkLogCreateModal';
-import type { StampLogMeta } from '@/app/_domains/_stamp/_services/stampService';
+} from "@/app/_domains/_log/_services/logService";
+import { confirmReservationStamp } from "@/app/_domains/_stamp/_services/stampService";
+import { useQueryClient } from "@tanstack/react-query";
+import { logKeys } from "@/app/_domains/_log/_queryKeys/logKeys";
+import { customerKeys } from "@/app/_domains/_customer/_queryKeys/customerKeys";
+import Loading from "@/app/_components/Loading";
+import Button from "@/app/_components/Button";
+import { Dropdown, DropdownOption } from "@/app/_components/Dropdown";
+import DateRangePicker from "@/app/_components/DateRangePicker";
+import toast from "react-hot-toast";
+import { useRouter } from "next/navigation";
+import { LogsResType } from "@/app/_domains/_log/_types/log.types";
+import useLogs from "@/app/_domains/_log/_hooks/useLogs";
+import { groupLogsByDate, formatDateKey } from "@/app/_utils/utils";
+import StampHistoryItem from "./StampHistoryItem";
+import { useUser } from "@/app/_contexts/UserContext";
+import { useModal } from "@/app/_contexts/ModalContext";
+import DeleteConfirmModal from "@/app/(auth)/_components/DeleteConfirmModal";
+import StampLogEditModal from "@/app/(auth)/_components/StampLogEditModal";
+import ConfirmModal from "@/app/(auth)/_components/ConfirmModal";
+import RemarkLogCreateModal from "@/app/(auth)/customers/[id]/_components/RemarkLogCreateModal";
+import type { StampLogMeta } from "@/app/_domains/_stamp/_services/stampService";
 
 const PAGE_SIZE = 10;
 
 const paymentMethodOptions = [
-  { label: '전체', value: '' },
+  { label: "전체", value: "" },
   ...Object.values(PaymentTypeEnum).map((p) => ({
     label: p.name,
     value: p.value,
@@ -45,7 +45,7 @@ const paymentMethodOptions = [
 ];
 
 interface StampHistoriesProps {
-  category?: LogCategoryEnumType['value'];
+  category?: LogCategoryEnumType["value"];
   isReservation?: boolean;
 }
 
@@ -60,9 +60,9 @@ const StampHistories = ({
 
   const [startDate, setStartDate] = useState<string | null>(null);
   const [endDate, setEndDate] = useState<string | null>(null);
-  const [paymentMethod, setPaymentMethod] = useState('');
-  const [searchInput, setSearchInput] = useState('');
-  const [searchKeyword, setSearchKeyword] = useState('');
+  const [paymentMethod, setPaymentMethod] = useState("");
+  const [searchInput, setSearchInput] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("");
 
   const dateRange =
     startDate && endDate ? { start: startDate, end: endDate } : null;
@@ -82,7 +82,7 @@ const StampHistories = ({
 
   const handleSearchKeyDown = (e: React.KeyboardEvent) => {
     if (e.nativeEvent.isComposing) return;
-    if (e.key === 'Enter') handleSearch();
+    if (e.key === "Enter") handleSearch();
   };
 
   const startEdit = useCallback(
@@ -104,21 +104,23 @@ const StampHistories = ({
               updated_at: updated.updated_at,
             }));
             close();
-            toast.success(isRemarkLog ? '특이사항을 저장했습니다.' : '메모를 저장했습니다.');
+            toast.success(
+              isRemarkLog ? "특이사항을 저장했습니다." : "메모를 저장했습니다.",
+            );
           } catch (e) {
-            console.error('Failed to save note:', e);
-            toast.error('저장에 실패했습니다. 다시 시도해 주세요.');
+            console.error("Failed to save note:", e);
+            toast.error("저장에 실패했습니다. 다시 시도해 주세요.");
           }
         };
 
         open({
           content: (
             <RemarkLogCreateModal
-              initialNote={log.note ?? ''}
+              initialNote={log.note ?? ""}
               mode="edit"
-              title={isRemarkLog ? undefined : '메모 수정'}
-              label={isRemarkLog ? undefined : '메모'}
-              placeholder={isRemarkLog ? undefined : '메모를 입력하세요'}
+              title={isRemarkLog ? undefined : "메모 수정"}
+              label={isRemarkLog ? undefined : "메모"}
+              placeholder={isRemarkLog ? undefined : "메모를 입력하세요"}
               onSubmit={handleRemarkSubmit}
               onCancel={close}
             />
@@ -130,8 +132,8 @@ const StampHistories = ({
 
       const handleSubmit = async (values: {
         note: string;
-        paymentType?: PaymentTypeEnumType['value'];
-        storeName: StoreTypeEnumType['value'];
+        paymentType?: PaymentTypeEnumType["value"];
+        storeName: StoreTypeEnumType["value"];
         logMeta: StampLogMeta;
         amount: number;
       }) => {
@@ -139,7 +141,7 @@ const StampHistories = ({
           // 예약 이력은 아직 스탬프가 적립되지 않았으므로 개수 수정 허용
           const nextAction = isReservation
             ? values.amount === 0
-              ? 'no-stamp'
+              ? "no-stamp"
               : `add-${values.amount}`
             : undefined;
           const updated = await updateLogNote(
@@ -158,10 +160,10 @@ const StampHistories = ({
             updated_at: updated.updated_at,
           }));
           close();
-          toast.success('이력을 저장했습니다.');
+          toast.success("이력을 저장했습니다.");
         } catch (e) {
-          console.error('Failed to save note:', e);
-          toast.error('저장에 실패했습니다. 다시 시도해 주세요.');
+          console.error("Failed to save note:", e);
+          toast.error("저장에 실패했습니다. 다시 시도해 주세요.");
         }
       };
 
@@ -173,19 +175,18 @@ const StampHistories = ({
               phone: log.customers.phone,
               address: log.customers.address,
               note: log.customers.note,
+              is_stamp_eligible: log.customers.is_stamp_eligible,
             }}
             initialAction={log.action}
             initialPaymentType={
-              log.jsonb?.paymentType as
-                | PaymentTypeEnumType['value']
-                | undefined
+              log.jsonb?.paymentType as PaymentTypeEnumType["value"] | undefined
             }
             initialStoreName={
-              log.jsonb?.storeName as StoreTypeEnumType['value'] | undefined
+              log.jsonb?.storeName as StoreTypeEnumType["value"] | undefined
             }
             initialLogMeta={log.jsonb as StampLogMeta}
             isStampAmountEditable={isReservation}
-            title={isReservation ? '출고 예약 수정' : '출고 이력 수정'}
+            title={isReservation ? "출고 예약 수정" : "출고 이력 수정"}
             onSubmit={handleSubmit}
             onCancel={close}
           />
@@ -203,10 +204,10 @@ const StampHistories = ({
           await deleteLog(log.id);
           removeItem(log.id);
           close();
-          toast.success('로그를 삭제했습니다.');
+          toast.success("로그를 삭제했습니다.");
         } catch (e) {
-          console.error('Failed to delete log:', e);
-          toast.error('로그 삭제에 실패했습니다. 다시 시도해 주세요.');
+          console.error("Failed to delete log:", e);
+          toast.error("로그 삭제에 실패했습니다. 다시 시도해 주세요.");
           close();
         }
       };
@@ -238,10 +239,10 @@ const StampHistories = ({
             });
           }
           close();
-          toast.success('출고 이력으로 확정되었습니다.');
+          toast.success("출고 이력으로 확정되었습니다.");
         } catch (e) {
-          console.error('Failed to confirm reservation:', e);
-          toast.error('출고 확정에 실패했습니다. 다시 시도해 주세요.');
+          console.error("Failed to confirm reservation:", e);
+          toast.error("출고 확정에 실패했습니다. 다시 시도해 주세요.");
           close();
         }
       };
@@ -251,7 +252,7 @@ const StampHistories = ({
           <ConfirmModal
             title="출고 확정"
             description={
-              '이 예약을 출고 이력으로 확정하시겠습니까?\n확정 시 스탬프가 적립되고 출고 이력으로 이동합니다.'
+              "이 예약을 출고 이력으로 확정하시겠습니까?\n확정 시 스탬프가 적립되고 출고 이력으로 이동합니다."
             }
             confirmLabel="출고 확정"
             confirmingLabel="확정 중..."
@@ -291,7 +292,7 @@ const StampHistories = ({
               <Dropdown controlledValue={paymentMethod}>
                 <Dropdown.Trigger>
                   {paymentMethodOptions.find((o) => o.value === paymentMethod)
-                    ?.label ?? '전체'}
+                    ?.label ?? "전체"}
                 </Dropdown.Trigger>
                 <Dropdown.Content>
                   {paymentMethodOptions.map((option, i) => (

--- a/src/app/(auth)/inventory/InventoryPageContent.tsx
+++ b/src/app/(auth)/inventory/InventoryPageContent.tsx
@@ -298,43 +298,43 @@ export function InventoryPageContent({
             {receiveTabOrder
               .filter((item) => isAdmin || item === "receive")
               .map((item, index) => (
-              <div key={item} className="flex items-center">
-                {editingReceiveTabOrder && (
+                <div key={item} className="flex items-center">
+                  {editingReceiveTabOrder && (
+                    <button
+                      type="button"
+                      onClick={() => moveReceiveTab(index, -1)}
+                      disabled={index === 0}
+                      className="h-7 w-6 text-xs text-gray-400 hover:text-brand-600 disabled:opacity-20"
+                      aria-label={`${item === "receive" ? "입고" : "거래처 관리"} 왼쪽으로 이동`}
+                    >
+                      ‹
+                    </button>
+                  )}
                   <button
                     type="button"
-                    onClick={() => moveReceiveTab(index, -1)}
-                    disabled={index === 0}
-                    className="h-7 w-6 text-xs text-gray-400 hover:text-brand-600 disabled:opacity-20"
-                    aria-label={`${item === "receive" ? "입고" : "거래처 관리"} 왼쪽으로 이동`}
+                    role="tab"
+                    aria-selected={receiveView === item}
+                    onClick={() => setReceiveView(item)}
+                    className={`border-b-2 px-5 py-3 text-sm font-semibold transition-colors ${
+                      receiveView === item
+                        ? "border-brand-500 text-brand-700"
+                        : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
+                    }`}
                   >
-                    ‹
+                    {item === "receive" ? "입고" : "거래처 관리"}
                   </button>
-                )}
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={receiveView === item}
-                  onClick={() => setReceiveView(item)}
-                  className={`border-b-2 px-5 py-3 text-sm font-semibold transition-colors ${
-                    receiveView === item
-                      ? "border-brand-500 text-brand-700"
-                      : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
-                  }`}
-                >
-                  {item === "receive" ? "입고" : "거래처 관리"}
-                </button>
-                {editingReceiveTabOrder && (
-                  <button
-                    type="button"
-                    onClick={() => moveReceiveTab(index, 1)}
-                    disabled={index === receiveTabOrder.length - 1}
-                    className="h-7 w-6 text-xs text-gray-400 hover:text-brand-600 disabled:opacity-20"
-                    aria-label={`${item === "receive" ? "입고" : "거래처 관리"} 오른쪽으로 이동`}
-                  >
-                    ›
-                  </button>
-                )}
-              </div>
+                  {editingReceiveTabOrder && (
+                    <button
+                      type="button"
+                      onClick={() => moveReceiveTab(index, 1)}
+                      disabled={index === receiveTabOrder.length - 1}
+                      className="h-7 w-6 text-xs text-gray-400 hover:text-brand-600 disabled:opacity-20"
+                      aria-label={`${item === "receive" ? "입고" : "거래처 관리"} 오른쪽으로 이동`}
+                    >
+                      ›
+                    </button>
+                  )}
+                </div>
               ))}
           </div>
           {isAdmin && (
@@ -1472,6 +1472,24 @@ type TaxInvoiceStatus =
   | "이구베이프 현금영수증"
   | "X";
 
+const TAX_INVOICE_OPTIONS = [
+  "오베이프 세금계산서",
+  "이구베이프 세금계산서",
+  "오베이프 현금영수증",
+  "이구베이프 현금영수증",
+  "X",
+] as const satisfies readonly Exclude<TaxInvoiceStatus, "">[];
+
+const getSupplierDefaultTaxInvoiceStatus = (
+  note: string | null | undefined,
+): TaxInvoiceStatus => {
+  const match = (note ?? "").match(/\[\[default_tax_invoice:(.*?)\]\]/);
+  const value = match?.[1] as TaxInvoiceStatus | undefined;
+  return value && TAX_INVOICE_OPTIONS.some((option) => option === value)
+    ? value
+    : "";
+};
+
 const splitPurchaseOrderNote = (value: string | null | undefined) => {
   const note = value ?? "";
   const match = note.match(/^\[\[tax_invoice:(.*?)\]\]\r?\n?/);
@@ -1671,18 +1689,36 @@ function ReceiptManager({
         .toLocaleLowerCase("ko-KR")
         .includes(supplierSearch.trim().toLocaleLowerCase("ko-KR")),
     );
-  const taxInvoiceOptions = [
-    "오베이프 세금계산서",
-    "이구베이프 세금계산서",
-    "오베이프 현금영수증",
-    "이구베이프 현금영수증",
-    "X",
-  ] as const;
-  const taxInvoiceSuggestions = taxInvoiceOptions.filter((option) =>
+  const taxInvoiceSuggestions = TAX_INVOICE_OPTIONS.filter((option) =>
     option
       .toLocaleLowerCase("ko-KR")
       .includes(taxInvoiceSearch.trim().toLocaleLowerCase("ko-KR")),
   );
+
+  const selectSupplier = (supplier: InventorySupplier) => {
+    setSupplierId(supplier.id);
+    setSupplierSearch(supplier.name);
+    setSupplierPickerOpen(false);
+
+    const savedTaxInvoiceStatus = getSupplierDefaultTaxInvoiceStatus(
+      supplier.note,
+    );
+    if (!savedTaxInvoiceStatus) return;
+
+    const shouldLoad = window.confirm(
+      `저장된 발행 종류(${savedTaxInvoiceStatus})를 불러오시겠습니까?\n\nA/S 입고나 스티커 처리 시 아니오를 클릭하고 발행 종류를 X로 선택해 주세요.`,
+    );
+    if (shouldLoad) {
+      setTaxInvoiceStatus(savedTaxInvoiceStatus);
+      setTaxInvoiceSearch(savedTaxInvoiceStatus);
+      setTaxInvoicePickerOpen(false);
+      return;
+    }
+
+    setTaxInvoiceStatus("");
+    setTaxInvoiceSearch("");
+    setTaxInvoicePickerOpen(true);
+  };
 
   const commitDraftRow = () => {
     setRows((current) => [
@@ -1848,11 +1884,7 @@ function ReceiptManager({
                                 <button
                                   type="button"
                                   key={supplier.id}
-                                  onClick={() => {
-                                    setSupplierId(supplier.id);
-                                    setSupplierSearch(supplier.name);
-                                    setSupplierPickerOpen(false);
-                                  }}
+                                  onClick={() => selectSupplier(supplier)}
                                   className="flex min-h-11 w-full items-center justify-between gap-3 rounded-lg px-3 text-left text-sm hover:bg-brand-50"
                                 >
                                   <span className="font-semibold text-gray-900">
@@ -2616,12 +2648,6 @@ function PurchaseOrderList({
   onCreate?: () => void;
 }) {
   const [quantities, setQuantities] = useState<Record<string, string>>({});
-  const [orderedQuantities, setOrderedQuantities] = useState<
-    Record<string, string>
-  >({});
-  const [editingOrderedQuantities, setEditingOrderedQuantities] = useState<
-    Record<string, boolean>
-  >({});
   const [arrivalDates, setArrivalDates] = useState<Record<string, string>>({});
   const [arrivalNotes, setArrivalNotes] = useState<Record<string, string>>({});
   const [pending, setPending] = useState(false);
@@ -2640,9 +2666,7 @@ function PurchaseOrderList({
   >("waiting");
   useEffect(() => {
     setQuantities({});
-    setOrderedQuantities({});
     setEditingQuantities({});
-    setEditingOrderedQuantities({});
     setSavedQuantities({});
     setArrivalDates({});
     setArrivalNotes({});
@@ -2736,9 +2760,7 @@ function PurchaseOrderList({
   }, [listTab, orders]);
   const clearDraftState = () => {
     setQuantities({});
-    setOrderedQuantities({});
     setEditingQuantities({});
-    setEditingOrderedQuantities({});
     setSavedQuantities({});
     setArrivalDates({});
     setArrivalNotes({});
@@ -2836,6 +2858,50 @@ function PurchaseOrderList({
     }).format(new Date(`${value}T00:00:00+09:00`));
   const cleanQuantityMemo = (value: string | null | undefined) =>
     value?.replace(/\[자동 수량 확인\]\s*/g, "").trim() ?? "";
+  const copyOrderForExcel = async (order: PurchaseOrder) => {
+    const orderNote = splitPurchaseOrderNote(order.note);
+    const supplierName = order.inventory_suppliers?.name ?? "";
+    const commonColumns = [supplierName, formatKoreanDate(order.ordered_on)];
+    const itemRows = order.inventory_purchase_order_lines.map((line) =>
+      [
+        ...commonColumns,
+        line.item_name,
+        line.ordered_quantity,
+        "",
+        "=[@수량]*[@매입가]",
+        cleanQuantityMemo(line.note),
+        orderNote.note,
+        orderNote.taxInvoiceStatus,
+        "",
+      ].join("\t"),
+    );
+    const adjustmentRows = (
+      order.inventory_purchase_order_adjustments ?? []
+    ).map((adjustment) => {
+      const signedAmount =
+        adjustment.kind === "discount"
+          ? -Math.abs(Number(adjustment.amount))
+          : Math.abs(Number(adjustment.amount));
+      return [
+        ...commonColumns,
+        adjustment.category_name,
+        1,
+        signedAmount,
+        "=[@수량]*[@매입가]",
+        adjustment.note ?? "",
+        orderNote.note,
+        orderNote.taxInvoiceStatus,
+        "",
+      ].join("\t");
+    });
+    const text = [...itemRows, ...adjustmentRows].join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success("엑셀 붙여넣기 형식으로 복사했습니다.");
+    } catch {
+      toast.error("복사하지 못했습니다. 다시 시도해 주세요.");
+    }
+  };
   if (loading)
     return <Loading size="sm" text="입고 예정 목록을 불러오는 중..." />;
   return (
@@ -3083,133 +3149,153 @@ function PurchaseOrderList({
             key={order.id}
             className="overflow-visible rounded-2xl border border-gray-200 bg-gray-50 shadow-sm"
           >
-            <header className="flex flex-wrap items-center gap-3 rounded-t-[15px] bg-gray-50 px-4 py-3">
-              <span
-                className={`rounded-full px-2.5 py-1 text-xs font-bold ${order.status === "completed" ? "bg-emerald-100 text-emerald-700" : order.status === "partial" ? "bg-blue-100 text-blue-700" : order.status === "closed" || order.status === "cancelled" ? "bg-gray-200 text-gray-600" : "bg-amber-100 text-amber-700"}`}
-              >
-                {order.status === "closed"
-                  ? isEntirelyUnreceived
-                    ? "전체 미입고 종료"
-                    : "일부 미입고 종료"
-                  : statusLabels[order.status]}
-              </span>
-              <strong>
-                {order.inventory_suppliers?.name ?? "거래처 정보 없음"}
-              </strong>
-              <div className="flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-white px-2.5 text-sm">
-                <span className="leading-none text-xs font-bold text-brand-600">
-                  주문일
-                </span>
-                <span className="leading-none font-medium text-gray-700">
-                  {formatKoreanDate(order.ordered_on)}
-                </span>
+            <header className="flex flex-col rounded-t-[15px] bg-gray-50 sm:min-h-[112px] sm:flex-row sm:items-stretch">
+              <div className="flex w-full shrink-0 flex-col justify-center gap-2 border-b border-gray-200 px-3 py-3 sm:w-[180px] sm:border-b-0 sm:border-r">
+                <div className="flex min-h-9 items-center justify-center">
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-xs font-bold ${order.status === "completed" ? "bg-emerald-100 text-emerald-700" : order.status === "partial" ? "bg-blue-100 text-blue-700" : order.status === "closed" || order.status === "cancelled" ? "bg-gray-200 text-gray-600" : "bg-amber-100 text-amber-700"}`}
+                  >
+                    {order.status === "closed"
+                      ? isEntirelyUnreceived
+                        ? "전체 미입고 종료"
+                        : "일부 미입고 종료"
+                      : statusLabels[order.status]}
+                  </span>
+                </div>
+                <div className="flex min-h-7 items-center justify-center">
+                  <strong className="text-center">
+                    {order.inventory_suppliers?.name ?? "거래처 정보 없음"}
+                  </strong>
+                </div>
               </div>
-              {order.inventory_purchase_receipts.map((receipt) => (
-                <div
-                  key={receipt.id}
-                  className="flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-white px-2.5 text-sm"
-                >
-                  <span className="leading-none text-xs font-bold text-emerald-700">
-                    도착일
-                  </span>
-                  <span className="leading-none font-medium text-gray-700">
-                    {formatKoreanDate(receipt.arrived_on)}
-                  </span>
-                  {receipt.reversed_at ? (
-                    <span className="text-xs font-semibold text-rose-600">
-                      취소됨
+              <div className="grid min-w-0 flex-1 grid-cols-1 gap-x-3 gap-y-2 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+                <div className="flex w-full flex-wrap items-center gap-3">
+                  <div className="flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-white px-2.5 text-sm">
+                    <span className="leading-none text-xs font-bold text-brand-600">
+                      주문일
                     </span>
-                  ) : (
-                    isAdmin && (
-                      <Button
-                        size="xs"
-                        variant="danger"
-                        onClick={() => {
-                          const reason =
-                            window.prompt("입고 취소 사유를 입력하세요.");
-                          if (reason?.trim())
-                            void run(
-                              () => reversePurchaseReceipt(receipt.id, reason),
-                              "입고를 취소하고 재고를 복구했습니다.",
-                            );
-                        }}
-                        disabled={pending}
-                      >
-                        입고 취소
-                      </Button>
-                    )
+                    <span className="leading-none font-medium text-gray-700">
+                      {formatKoreanDate(order.ordered_on)}
+                    </span>
+                  </div>
+                  {order.inventory_purchase_receipts.map((receipt) => (
+                    <div
+                      key={receipt.id}
+                      className="flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-white px-2.5 text-sm"
+                    >
+                      <span className="leading-none text-xs font-bold text-emerald-700">
+                        도착일
+                      </span>
+                      <span className="leading-none font-medium text-gray-700">
+                        {formatKoreanDate(receipt.arrived_on)}
+                      </span>
+                      {receipt.reversed_at ? (
+                        <span className="text-xs font-semibold text-rose-600">
+                          취소됨
+                        </span>
+                      ) : (
+                        isAdmin && (
+                          <Button
+                            size="xs"
+                            variant="danger"
+                            onClick={() => {
+                              const reason =
+                                window.prompt("입고 취소 사유를 입력하세요.");
+                              if (reason?.trim())
+                                void run(
+                                  () =>
+                                    reversePurchaseReceipt(receipt.id, reason),
+                                  "입고를 취소하고 재고를 복구했습니다.",
+                                );
+                            }}
+                            disabled={pending}
+                          >
+                            입고 취소
+                          </Button>
+                        )
+                      )}
+                    </div>
+                  ))}
+                  {orderNote.note && (
+                    <span className="text-sm text-gray-500">
+                      전체 메모: {orderNote.note}
+                    </span>
+                  )}
+                  {order.status === "closed" && order.closed_reason && (
+                    <span className="rounded-lg bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700">
+                      미입고 종료 사유: {order.closed_reason}
+                    </span>
                   )}
                 </div>
-              ))}
-              {orderNote.taxInvoiceStatus && (
-                <span className="rounded-lg bg-brand-50 px-3 py-1.5 text-sm font-semibold text-brand-700">
-                  발행 종류: {orderNote.taxInvoiceStatus}
-                </span>
-              )}
-              {orderNote.note && (
-                <span className="text-sm text-gray-500">
-                  전체 메모: {orderNote.note}
-                </span>
-              )}
-              {order.status === "closed" && order.closed_reason && (
-                <span className="rounded-lg bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700">
-                  미입고 종료 사유: {order.closed_reason}
-                </span>
-              )}
-              {isAdmin && (
-                <>
-                  {adjustments.map((adjustment) => (
-                    <span
-                      key={adjustment.id}
-                      className={`rounded-full px-2.5 py-1 text-xs font-bold ${
-                        adjustment.kind === "discount"
-                          ? "bg-blue-100 text-blue-700"
-                          : "bg-orange-100 text-orange-700"
-                      }`}
-                    >
-                      {adjustment.category_name}{" "}
-                      {adjustment.kind === "discount" ? "-" : "+"}
-                      {Number(adjustment.amount).toLocaleString("ko-KR")}원
+                <div className="flex min-h-7 w-full flex-wrap items-center gap-1.5">
+                  {orderNote.taxInvoiceStatus && (
+                    <span className="rounded-lg bg-brand-50 px-2.5 py-1 text-xs font-semibold text-brand-700">
+                      발행 종류: {orderNote.taxInvoiceStatus}
                     </span>
-                  ))}
-                  <Button
-                    size="xs"
-                    variant="gray"
-                    onClick={() => setEditingOrder(order)}
-                    className="ml-auto"
-                  >
-                    입고 내용 수정
-                  </Button>
-                  <Button
-                    size="xs"
-                    variant="gray"
-                    onClick={() => setAdjustmentOrder(order)}
-                  >
-                    거래 조정
-                  </Button>
-                </>
-              )}
-              {!open && isAdmin && (
-                <Button
-                  size="xs"
-                  variant="danger"
-                  onClick={() => {
-                    if (
-                      window.confirm(
-                        "이 입고 이력을 삭제할까요? 반영된 입고 재고와 관련 변동 이력도 함께 되돌아갑니다.",
-                      )
-                    )
-                      void run(
-                        () => deletePurchaseOrderHistory(order.id),
-                        "입고 이력을 삭제했습니다.",
-                      );
-                  }}
-                  disabled={pending}
-                  className="ml-auto"
-                >
-                  이력 삭제
-                </Button>
-              )}
+                  )}
+                  {isAdmin &&
+                    adjustments.map((adjustment) => (
+                      <span
+                        key={adjustment.id}
+                        className={`rounded-full px-2.5 py-1 text-xs font-bold ${adjustment.kind === "discount" ? "bg-blue-100 text-blue-700" : "bg-orange-100 text-orange-700"}`}
+                      >
+                        {adjustment.category_name}{" "}
+                        {adjustment.kind === "discount" ? "-" : "+"}
+                        {Number(adjustment.amount).toLocaleString("ko-KR")}원
+                      </span>
+                    ))}
+                </div>
+                <div className="flex flex-wrap items-center gap-2 sm:col-start-2 sm:row-span-2 sm:row-start-1 sm:self-center">
+                  {(order.status === "pending" ||
+                    order.status === "completed") && (
+                    <Button
+                      size="xs"
+                      variant="secondary"
+                      onClick={() => void copyOrderForExcel(order)}
+                    >
+                      엑셀 복사
+                    </Button>
+                  )}
+                  {isAdmin && (
+                    <>
+                      <Button
+                        size="xs"
+                        variant="gray"
+                        onClick={() => setEditingOrder(order)}
+                      >
+                        입고 수정
+                      </Button>
+                      <Button
+                        size="xs"
+                        variant="gray"
+                        onClick={() => setAdjustmentOrder(order)}
+                      >
+                        거래 조정
+                      </Button>
+                    </>
+                  )}
+                  {!open && isAdmin && (
+                    <Button
+                      size="xs"
+                      variant="danger"
+                      onClick={() => {
+                        if (
+                          window.confirm(
+                            "이 입고 이력을 삭제할까요? 반영된 입고 재고와 관련 변동 이력도 함께 되돌아갑니다.",
+                          )
+                        )
+                          void run(
+                            () => deletePurchaseOrderHistory(order.id),
+                            "입고 이력을 삭제했습니다.",
+                          );
+                      }}
+                      disabled={pending}
+                    >
+                      이력 삭제
+                    </Button>
+                  )}
+                </div>
+              </div>
             </header>
             <div
               className={`${open ? "block" : "hidden"} overflow-auto bg-gray-50 px-4 sm:px-5`}
@@ -3324,95 +3410,9 @@ function PurchaseOrderList({
                             {line.item_name}
                           </td>
                           <td className="border border-gray-200 px-3 py-3 text-right">
-                            {order.status === "pending" &&
-                            editingOrderedQuantities[line.id] ? (
-                              <QuantityEditControl
-                                min={1}
-                                disabled={pending}
-                                value={
-                                  orderedQuantities[line.id] ??
-                                  String(line.ordered_quantity)
-                                }
-                                onChange={(nextValue) =>
-                                  setOrderedQuantities((current) => ({
-                                    ...current,
-                                    [line.id]: nextValue,
-                                  }))
-                                }
-                                onSave={() => {
-                                  const nextQuantity = Number(
-                                    orderedQuantities[line.id] ??
-                                      line.ordered_quantity,
-                                  );
-                                  if (
-                                    !Number.isInteger(nextQuantity) ||
-                                    nextQuantity < 1
-                                  ) {
-                                    toast.error(
-                                      "주문 수량은 1개 이상 입력해 주세요.",
-                                    );
-                                    return;
-                                  }
-                                  void (async () => {
-                                    const saved = await run(
-                                      () =>
-                                        updatePurchaseOrderQuantity(
-                                          line.id,
-                                          nextQuantity,
-                                        ),
-                                      "주문 수량을 변경했습니다.",
-                                    );
-                                    if (saved) {
-                                      setEditingOrderedQuantities(
-                                        (current) => ({
-                                          ...current,
-                                          [line.id]: false,
-                                        }),
-                                      );
-                                    }
-                                  })();
-                                }}
-                                onCancel={() => {
-                                  setOrderedQuantities((current) => ({
-                                    ...current,
-                                    [line.id]: String(line.ordered_quantity),
-                                  }));
-                                  setEditingOrderedQuantities((current) => ({
-                                    ...current,
-                                    [line.id]: false,
-                                  }));
-                                }}
-                              />
-                            ) : (
-                              <div className="flex w-full items-center justify-start gap-1">
-                                {order.status === "pending" && isAdmin && (
-                                  <Button
-                                    size="icon-xs"
-                                    variant="secondary"
-                                    aria-label="주문 수량 수정"
-                                    onClick={() => {
-                                      setOrderedQuantities((current) => ({
-                                        ...current,
-                                        [line.id]: String(
-                                          line.ordered_quantity,
-                                        ),
-                                      }));
-                                      setEditingOrderedQuantities(
-                                        (current) => ({
-                                          ...current,
-                                          [line.id]: true,
-                                        }),
-                                      );
-                                    }}
-                                  >
-                                    ✏️
-                                  </Button>
-                                )}
-                                <strong className="text-gray-900">
-                                  {line.ordered_quantity}개
-                                </strong>
-                              </div>
-                            )}
+                            <strong className="text-gray-900">
+                              {line.ordered_quantity}개
+                            </strong>
                           </td>
                           {showPartialDetails && (
                             <td className="border border-gray-200 px-3 py-3 text-right">
@@ -3532,20 +3532,22 @@ function PurchaseOrderList({
                             )}
                           </td>
                           <td className="border border-gray-200 px-3 py-3 text-gray-500">
-                            {line.note || line.quantity_check_note ? (
-                              <div className="space-y-1">
-                                {line.note && (
-                                  <p>{cleanQuantityMemo(line.note)}</p>
-                                )}
-                                {line.quantity_check_note && (
-                                  <p className="font-semibold text-brand-700">
-                                    {line.quantity_check_note}
-                                  </p>
-                                )}
-                              </div>
-                            ) : (
-                              "-"
-                            )}
+                            <div className="flex items-start gap-2">
+                              {line.note || line.quantity_check_note ? (
+                                <div className="min-w-0 space-y-1">
+                                  {line.note && (
+                                    <p>{cleanQuantityMemo(line.note)}</p>
+                                  )}
+                                  {line.quantity_check_note && (
+                                    <p className="font-semibold text-brand-700">
+                                      {line.quantity_check_note}
+                                    </p>
+                                  )}
+                                </div>
+                              ) : (
+                                <span>-</span>
+                              )}
+                            </div>
                           </td>
                           <td className="border border-gray-200 px-3 py-3">
                             {!open ? (
@@ -4052,6 +4054,9 @@ function PurchaseOrderEditOverlay({
   const parsedNote = splitPurchaseOrderNote(order.note);
   const [supplierId, setSupplierId] = useState(order.supplier_id);
   const [orderedOn, setOrderedOn] = useState(order.ordered_on);
+  const [taxInvoiceStatus, setTaxInvoiceStatus] = useState<TaxInvoiceStatus>(
+    parsedNote.taxInvoiceStatus,
+  );
   const [overallNote, setOverallNote] = useState(parsedNote.note);
   const [lines, setLines] = useState(() =>
     order.inventory_purchase_order_lines.map((line) => ({
@@ -4103,7 +4108,7 @@ function PurchaseOrderEditOverlay({
         orderId: order.id,
         supplierId,
         orderedOn,
-        note: mergePurchaseOrderNote(parsedNote.taxInvoiceStatus, overallNote),
+        note: mergePurchaseOrderNote(taxInvoiceStatus, overallNote),
         lines: lines.map((line) => ({
           id: line.id,
           item_name: line.itemName.trim(),
@@ -4190,6 +4195,29 @@ function PurchaseOrderEditOverlay({
                 className="mt-1.5 h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
               />
             </label>
+            <div className="text-xs font-semibold text-gray-600">
+              발행 종류
+              <div className="mt-1.5">
+                <Dropdown controlledValue={taxInvoiceStatus}>
+                  <Dropdown.Trigger>
+                    {taxInvoiceStatus || "발행 종류 선택"}
+                  </Dropdown.Trigger>
+                  <Dropdown.Content>
+                    {TAX_INVOICE_OPTIONS.map((option) => (
+                      <Dropdown.Item
+                        key={option}
+                        option={{ value: option, label: option }}
+                        onSelect={(selected: DropdownOption) =>
+                          setTaxInvoiceStatus(
+                            selected.value as TaxInvoiceStatus,
+                          )
+                        }
+                      />
+                    ))}
+                  </Dropdown.Content>
+                </Dropdown>
+              </div>
+            </div>
             <label className="text-xs font-semibold text-gray-600 md:col-span-2">
               전체 메모
               <textarea
@@ -4802,19 +4830,34 @@ function SupplierManageOverlay({
   onSaved: () => Promise<void>;
   embedded?: boolean;
 }) {
-  const homepageNotePattern = /^\[\[homepage_url:(.*?)\]\]\r?\n?/;
+  const homepageNotePattern = /\[\[homepage_url:(.*?)\]\]/;
+  const defaultTaxInvoicePattern = /\[\[default_tax_invoice:(.*?)\]\]/;
   const splitSupplierNote = (note: string | null | undefined) => {
     const value = note ?? "";
-    const match = value.match(homepageNotePattern);
+    const homepageMatch = value.match(homepageNotePattern);
     return {
-      homepage_url: match?.[1] ?? "",
-      note: value.replace(homepageNotePattern, ""),
+      homepage_url: homepageMatch?.[1] ?? "",
+      default_tax_invoice_status: getSupplierDefaultTaxInvoiceStatus(value),
+      note: value
+        .replace(homepageNotePattern, "")
+        .replace(defaultTaxInvoicePattern, "")
+        .trim(),
     };
   };
-  const mergeSupplierNote = (homepageUrl: string, note: string) => {
+  const mergeSupplierNote = (
+    homepageUrl: string,
+    defaultTaxInvoiceStatus: TaxInvoiceStatus,
+    note: string,
+  ) => {
     const cleanUrl = homepageUrl.trim();
     const cleanNote = note.trim();
-    return [cleanUrl ? `[[homepage_url:${cleanUrl}]]` : "", cleanNote]
+    return [
+      cleanUrl ? `[[homepage_url:${cleanUrl}]]` : "",
+      defaultTaxInvoiceStatus
+        ? `[[default_tax_invoice:${defaultTaxInvoiceStatus}]]`
+        : "",
+      cleanNote,
+    ]
       .filter(Boolean)
       .join("\n");
   };
@@ -4830,6 +4873,7 @@ function SupplierManageOverlay({
     courier_company: "",
     order_cutoff_time: "",
     homepage_url: "",
+    default_tax_invoice_status: "" as TaxInvoiceStatus,
     note: "",
     is_use: true,
   };
@@ -4837,15 +4881,38 @@ function SupplierManageOverlay({
   const [form, setForm] = useState(empty);
   const [saving, setSaving] = useState(false);
   const [supplierSearch, setSupplierSearch] = useState("");
+  const [defaultTaxInvoiceSearch, setDefaultTaxInvoiceSearch] = useState("");
+  const [defaultTaxInvoicePickerOpen, setDefaultTaxInvoicePickerOpen] =
+    useState(false);
+  const defaultTaxInvoicePickerRef = useRef<HTMLDivElement>(null);
   const [editorOpen, setEditorOpen] = useState(false);
   const [supplierEditing, setSupplierEditing] = useState(false);
   const [returnSupplierId, setReturnSupplierId] = useState<string | null>(null);
+  useEffect(() => {
+    if (!defaultTaxInvoicePickerOpen) return;
+    const closePicker = (event: PointerEvent) => {
+      if (!defaultTaxInvoicePickerRef.current?.contains(event.target as Node)) {
+        setDefaultTaxInvoicePickerOpen(false);
+      }
+    };
+    const closePickerWithEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setDefaultTaxInvoicePickerOpen(false);
+    };
+    document.addEventListener("pointerdown", closePicker);
+    document.addEventListener("keydown", closePickerWithEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closePicker);
+      document.removeEventListener("keydown", closePickerWithEscape);
+    };
+  }, [defaultTaxInvoicePickerOpen]);
   const edit = (supplier: InventorySupplier) => {
     const supplierNote = splitSupplierNote(supplier.note);
     setEditorOpen(true);
     setSupplierEditing(false);
     setReturnSupplierId(null);
     setSelectedId(supplier.id);
+    setDefaultTaxInvoiceSearch(supplierNote.default_tax_invoice_status);
+    setDefaultTaxInvoicePickerOpen(false);
     setForm({
       name: supplier.name,
       customer_service_phone: supplier.customer_service_phone ?? "",
@@ -4853,6 +4920,7 @@ function SupplierManageOverlay({
       courier_company: supplier.courier_company ?? "",
       order_cutoff_time: (supplier.order_cutoff_time ?? "").slice(0, 5),
       homepage_url: supplierNote.homepage_url,
+      default_tax_invoice_status: supplierNote.default_tax_invoice_status,
       note: supplierNote.note,
       is_use: supplier.is_use,
     });
@@ -4860,10 +4928,15 @@ function SupplierManageOverlay({
   const save = async () => {
     setSaving(true);
     try {
-      const { homepage_url, ...supplierData } = form;
+      const { homepage_url, default_tax_invoice_status, ...supplierData } =
+        form;
       const savedId = await saveInventorySupplier(selectedId, {
         ...supplierData,
-        note: mergeSupplierNote(homepage_url, supplierData.note),
+        note: mergeSupplierNote(
+          homepage_url,
+          default_tax_invoice_status,
+          supplierData.note,
+        ),
       });
       toast.success("거래처를 저장했습니다.");
       await onSaved();
@@ -4881,6 +4954,8 @@ function SupplierManageOverlay({
     if (selectedId) setReturnSupplierId(selectedId);
     setSelectedId(null);
     setForm(empty);
+    setDefaultTaxInvoiceSearch("");
+    setDefaultTaxInvoicePickerOpen(false);
     setEditorOpen(true);
     setSupplierEditing(true);
   };
@@ -4900,6 +4975,8 @@ function SupplierManageOverlay({
     if (previousSupplier) {
       const supplierNote = splitSupplierNote(previousSupplier.note);
       setSelectedId(previousSupplier.id);
+      setDefaultTaxInvoiceSearch(supplierNote.default_tax_invoice_status);
+      setDefaultTaxInvoicePickerOpen(false);
       setForm({
         name: previousSupplier.name,
         customer_service_phone: previousSupplier.customer_service_phone ?? "",
@@ -4910,6 +4987,7 @@ function SupplierManageOverlay({
           5,
         ),
         homepage_url: supplierNote.homepage_url,
+        default_tax_invoice_status: supplierNote.default_tax_invoice_status,
         note: supplierNote.note,
         is_use: previousSupplier.is_use,
       });
@@ -4926,6 +5004,11 @@ function SupplierManageOverlay({
     supplier.name
       .toLocaleLowerCase("ko-KR")
       .includes(supplierSearch.trim().toLocaleLowerCase("ko-KR")),
+  );
+  const defaultTaxInvoiceSuggestions = TAX_INVOICE_OPTIONS.filter((option) =>
+    option
+      .toLocaleLowerCase("ko-KR")
+      .includes(defaultTaxInvoiceSearch.trim().toLocaleLowerCase("ko-KR")),
   );
   return (
     <div
@@ -5092,12 +5175,39 @@ function SupplierManageOverlay({
                       : "거래처 정보"
                     : "신규 거래처 등록"}
                 </p>
-                <h3 className="mt-1 text-lg font-bold text-gray-950">
-                  {selectedId
-                    ? form.name || "거래처 정보"
-                    : "새 거래처 정보를 입력해 주세요"}
-                </h3>
+                <div className="mt-1 flex items-center gap-2">
+                  <h3 className="text-lg font-bold text-gray-950">
+                    {selectedId
+                      ? form.name || "거래처 정보"
+                      : "새 거래처 정보를 입력해 주세요"}
+                  </h3>
+                  {!supplierEditing && (
+                    <span
+                      className={`rounded-full px-2.5 py-1 text-xs font-semibold ${form.is_use ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}
+                    >
+                      {form.is_use ? "사용" : "미사용"}
+                    </span>
+                  )}
+                </div>
               </div>
+              {supplierEditing && (
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-semibold text-gray-700">
+                    사용 상태
+                  </span>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={form.is_use}
+                    onClick={() => setForm({ ...form, is_use: !form.is_use })}
+                    className={`relative h-7 w-12 cursor-pointer rounded-full transition ${form.is_use ? "bg-brand-500" : "bg-gray-300"}`}
+                  >
+                    <span
+                      className={`absolute top-1 h-5 w-5 rounded-full bg-white shadow transition ${form.is_use ? "left-6" : "left-1"}`}
+                    />
+                  </button>
+                </div>
+              )}
             </div>
 
             <fieldset
@@ -5164,45 +5274,91 @@ function SupplierManageOverlay({
                   className="mt-2 min-h-11 w-full rounded-xl border border-gray-200 px-3 font-normal outline-none focus:border-brand-400 focus:ring-2 focus:ring-brand-100"
                 />
               </label>
-              <label
-                className={`flex min-h-[70px] items-center justify-between rounded-xl border px-4 py-3 ${
-                  supplierEditing
-                    ? "cursor-pointer border-gray-200 bg-gray-50"
-                    : "cursor-default border-transparent bg-transparent px-0"
-                }`}
-              >
-                <div>
-                  <p className="text-sm font-semibold text-gray-800">
-                    사용 상태
-                  </p>
-                  <p className="mt-1 text-xs text-gray-500">
-                    입고 등록 거래처 목록에 표시합니다.
-                  </p>
-                </div>
+              <div className="text-sm font-semibold text-gray-700">
+                기본 발행 종류
                 {supplierEditing ? (
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={form.is_use}
-                    onClick={() => setForm({ ...form, is_use: !form.is_use })}
-                    className={`relative h-7 w-12 rounded-full transition ${form.is_use ? "bg-brand-500" : "bg-gray-300"}`}
+                  <div
+                    ref={defaultTaxInvoicePickerRef}
+                    className="relative mt-2 w-full"
                   >
-                    <span
-                      className={`absolute top-1 h-5 w-5 rounded-full bg-white shadow transition ${form.is_use ? "left-6" : "left-1"}`}
+                    <svg
+                      className="pointer-events-none absolute left-3 top-1/2 z-10 h-4 w-4 -translate-y-1/2 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="m21 21-4.35-4.35m2.1-5.4a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0Z"
+                      />
+                    </svg>
+                    <input
+                      value={defaultTaxInvoiceSearch}
+                      onFocus={() => setDefaultTaxInvoicePickerOpen(true)}
+                      onChange={(event) => {
+                        setDefaultTaxInvoiceSearch(event.target.value);
+                        setForm({ ...form, default_tax_invoice_status: "" });
+                        setDefaultTaxInvoicePickerOpen(true);
+                      }}
+                      placeholder="발행 종류를 검색하세요"
+                      className="min-h-11 w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-10 font-normal outline-none focus:border-brand-400 focus:ring-2 focus:ring-brand-100"
                     />
-                  </button>
+                    {defaultTaxInvoiceSearch && supplierEditing && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setDefaultTaxInvoiceSearch("");
+                          setForm({ ...form, default_tax_invoice_status: "" });
+                          setDefaultTaxInvoicePickerOpen(true);
+                        }}
+                        aria-label="기본 발행 종류 선택 지우기"
+                        className="absolute right-2 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-gray-100 text-base font-medium text-gray-500 transition hover:bg-gray-200 hover:text-gray-700"
+                      >
+                        ×
+                      </button>
+                    )}
+                    {defaultTaxInvoicePickerOpen && supplierEditing && (
+                      <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-56 overflow-y-auto rounded-xl border border-gray-200 bg-white p-1 shadow-xl">
+                        {defaultTaxInvoiceSuggestions.length ? (
+                          defaultTaxInvoiceSuggestions.map((option) => (
+                            <button
+                              type="button"
+                              key={option}
+                              onClick={() => {
+                                setForm({
+                                  ...form,
+                                  default_tax_invoice_status: option,
+                                });
+                                setDefaultTaxInvoiceSearch(option);
+                                setDefaultTaxInvoicePickerOpen(false);
+                              }}
+                              className="flex min-h-11 w-full cursor-pointer items-center justify-between rounded-lg px-3 text-left text-sm font-semibold text-gray-900 hover:bg-brand-50"
+                            >
+                              {option}
+                              {form.default_tax_invoice_status === option && (
+                                <span className="text-brand-500">✓</span>
+                              )}
+                            </button>
+                          ))
+                        ) : (
+                          <p className="px-3 py-4 text-center text-sm font-normal text-gray-400">
+                            검색 결과가 없습니다.
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 ) : (
-                  <span
-                    className={`rounded-full px-2.5 py-1 text-xs font-semibold ${
-                      form.is_use
-                        ? "bg-emerald-50 text-emerald-700"
-                        : "bg-gray-100 text-gray-500"
-                    }`}
+                  <p
+                    className={`mt-2 text-sm font-medium ${form.default_tax_invoice_status ? "text-gray-900" : "text-gray-400"}`}
                   >
-                    {form.is_use ? "사용" : "미사용"}
-                  </span>
+                    {form.default_tax_invoice_status || "미지정 상태입니다."}
+                  </p>
                 )}
-              </label>
+              </div>
               <label className="text-sm font-semibold text-gray-700 sm:col-span-2">
                 홈페이지 링크
                 {supplierEditing ? (

--- a/src/app/_contexts/StaffOpeningContext.tsx
+++ b/src/app/_contexts/StaffOpeningContext.tsx
@@ -10,8 +10,15 @@ import {
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import Loading from "@/app/_components/Loading";
+import Button from "@/app/_components/Button";
 import { useUser } from "@/app/_contexts/UserContext";
 import { getCurrentWorker } from "@/app/_domains/_workJournal/_utils/currentWorker";
+import {
+  acknowledgeOpeningNotice,
+  getOpeningCompletionNotice,
+  hasAcknowledgedOpeningNotice,
+} from "@/app/_domains/_dailyClosing/_services/dailyClosingService";
+import type { OpeningCompletionNotice } from "@/app/_domains/_dailyClosing/_types/dailyClosing.types";
 import supabase from "@/libs/supabaseClient";
 
 type StaffOpeningStep = "unlocked" | "attendance" | "cash" | "checklist";
@@ -55,12 +62,16 @@ export const StaffOpeningProvider = ({
   const [step, setStep] = useState<StaffOpeningStep>("unlocked");
   const [previousCash, setPreviousCash] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [openingNotice, setOpeningNotice] = useState<OpeningCompletionNotice | null>(null);
+  const [noticeBusinessDate, setNoticeBusinessDate] = useState("");
+  const [acknowledgingNotice, setAcknowledgingNotice] = useState(false);
 
   const refresh = useCallback(async () => {
     if (isUserLoading) return;
     if (!user || isAdmin) {
       setStep("unlocked");
       setPreviousCash(null);
+      setOpeningNotice(null);
       setIsLoading(false);
       return;
     }
@@ -135,11 +146,30 @@ export const StaffOpeningProvider = ({
         if (progressError) throw progressError;
 
         const checks = (progress?.checks ?? {}) as Record<string, boolean>;
-        setStep(
-          gateItems.every((item) => checks[item.id])
-            ? "unlocked"
-            : "checklist",
-        );
+        const isOpeningComplete = gateItems.every((item) => checks[item.id]);
+        setStep(isOpeningComplete ? "unlocked" : "checklist");
+
+        if (isOpeningComplete) {
+          try {
+            const notice = await getOpeningCompletionNotice();
+            if (notice?.is_active) {
+              const acknowledged = await hasAcknowledgedOpeningNotice(
+                today,
+                notice.version,
+              );
+              if (!acknowledged) {
+                setNoticeBusinessDate(today);
+                setOpeningNotice(notice);
+              }
+            } else {
+              setOpeningNotice(null);
+            }
+          } catch (noticeError) {
+            console.error("Opening completion notice check failed:", noticeError);
+          }
+        } else {
+          setOpeningNotice(null);
+        }
         return;
       }
 
@@ -204,6 +234,19 @@ export const StaffOpeningProvider = ({
     [isLoading, previousCash, refresh, step],
   );
 
+  const confirmOpeningNotice = async () => {
+    if (!openingNotice || !noticeBusinessDate) return;
+    setAcknowledgingNotice(true);
+    try {
+      await acknowledgeOpeningNotice(noticeBusinessDate, openingNotice.version);
+      setOpeningNotice(null);
+    } catch (error) {
+      console.error("Opening completion notice acknowledgement failed:", error);
+    } finally {
+      setAcknowledgingNotice(false);
+    }
+  };
+
   if (isUserLoading || isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -235,6 +278,38 @@ export const StaffOpeningProvider = ({
   return (
     <StaffOpeningContext.Provider value={value}>
       {children}
+      {openingNotice && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-950/45 p-4 backdrop-blur-[1px]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="opening-completion-notice-title"
+        >
+          <div className="w-full max-w-md overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl">
+            <div className="border-b border-gray-100 px-5 py-4 sm:px-6">
+              <span className="text-xs font-bold text-emerald-600">오픈 완료</span>
+              <h2
+                id="opening-completion-notice-title"
+                className="mt-1 text-lg font-bold text-gray-900"
+              >
+                {openingNotice.title}
+              </h2>
+            </div>
+            <div className="px-5 py-5 sm:px-6">
+              <p className="whitespace-pre-wrap text-sm leading-6 text-gray-700">
+                {openingNotice.content || "오픈 처리가 완료되었습니다."}
+              </p>
+              <Button
+                className="mt-6 w-full"
+                onClick={confirmOpeningNotice}
+                disabled={acknowledgingNotice}
+              >
+                {acknowledgingNotice ? "확인 중..." : "확인"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </StaffOpeningContext.Provider>
   );
 };

--- a/src/app/_domains/_customer/_services/customerService.ts
+++ b/src/app/_domains/_customer/_services/customerService.ts
@@ -1,29 +1,27 @@
-import { CustomerType } from '@/app/_domains/_customer/_types/customer.types';
-import supabase from '@/libs/supabaseClient';
-import { createLog } from '@/app/_domains/_log/_services/logService';
-import { LogCategoryEnum } from '@/app/_enums/enums';
-import { getUpdateLogNote } from '@/app/_utils/utils';
+import { CustomerType } from "@/app/_domains/_customer/_types/customer.types";
+import supabase from "@/libs/supabaseClient";
+import { createLog } from "@/app/_domains/_log/_services/logService";
+import { LogCategoryEnum } from "@/app/_enums/enums";
+import { getUpdateLogNote } from "@/app/_utils/utils";
 
 export interface SearchParams {
-  target?: 'all' | 'name' | 'phone';
+  target?: "all" | "name" | "phone";
   keyword?: string;
-  sortBy?: 'name' | 'stamp' | 'created_at';
-  sortOrder?: 'asc' | 'desc';
+  sortBy?: "name" | "stamp" | "created_at";
+  sortOrder?: "asc" | "desc";
 }
 
 export type CustomerQuickLink = Pick<
   CustomerType,
-  'id' | 'name' | 'phone' | 'gender'
+  "id" | "name" | "phone" | "gender"
 >;
 
 export const getCustomerQuickLinks = async (): Promise<CustomerQuickLink[]> => {
   const { data, error } = await supabase
-    .from('customers')
-    .select('id, name, phone, gender, created_at')
-    .or(
-      'and(name.eq.X,phone.eq.X),name.eq.시연용,name.eq.재고조정',
-    )
-    .order('created_at', { ascending: true });
+    .from("customers")
+    .select("id, name, phone, gender, created_at")
+    .or("and(name.eq.X,phone.eq.X),name.eq.시연용,name.eq.재고조정")
+    .order("created_at", { ascending: true });
 
   if (error) throw error;
   return (data ?? []).map(({ id, name, phone, gender }) => ({
@@ -38,10 +36,10 @@ export const getCustomerQuickLinks = async (): Promise<CustomerQuickLink[]> => {
  * 전체 고객 수 조회
  */
 export const getCustomersCount = async (
-  params?: SearchParams
+  params?: SearchParams,
 ): Promise<number> => {
-  let query = supabase.from('customers').select('*', {
-    count: 'exact',
+  let query = supabase.from("customers").select("*", {
+    count: "exact",
     head: true,
   });
 
@@ -49,11 +47,11 @@ export const getCustomersCount = async (
   if (params?.keyword) {
     const { target, keyword } = params;
 
-    if (target === 'name') {
-      query = query.ilike('name', `%${keyword}%`);
-    } else if (target === 'phone') {
-      query = query.ilike('phone', `%${keyword}%`);
-    } else if (target === 'all') {
+    if (target === "name") {
+      query = query.ilike("name", `%${keyword}%`);
+    } else if (target === "phone") {
+      query = query.ilike("phone", `%${keyword}%`);
+    } else if (target === "all") {
       query = query.or(`name.ilike.%${keyword}%,phone.ilike.%${keyword}%`);
     }
   }
@@ -71,12 +69,12 @@ export const getCustomersCount = async (
 export const getCustomers = async (
   limit = 10,
   offset = 0,
-  params?: SearchParams
+  params?: SearchParams,
 ): Promise<CustomerType[]> => {
   const from = offset;
   const to = offset + limit - 1;
-  
-  let query = supabase.from('customers').select(`
+
+  let query = supabase.from("customers").select(`
     *,
     stamps(count)
   `);
@@ -85,20 +83,20 @@ export const getCustomers = async (
   if (params?.keyword) {
     const { target, keyword } = params;
 
-    if (target === 'name') {
-      query = query.ilike('name', `%${keyword}%`);
-    } else if (target === 'phone') {
-      query = query.ilike('phone', `%${keyword}%`);
-    } else if (target === 'all') {
+    if (target === "name") {
+      query = query.ilike("name", `%${keyword}%`);
+    } else if (target === "phone") {
+      query = query.ilike("phone", `%${keyword}%`);
+    } else if (target === "all") {
       query = query.or(`name.ilike.%${keyword}%,phone.ilike.%${keyword}%`);
     }
   }
 
   // 정렬 처리
-  const sortBy = params?.sortBy || 'name';
-  const sortOrder = params?.sortOrder || (sortBy === 'name' ? 'asc' : 'desc');
+  const sortBy = params?.sortBy || "name";
+  const sortOrder = params?.sortOrder || (sortBy === "name" ? "asc" : "desc");
 
-  if (sortBy === 'stamp') {
+  if (sortBy === "stamp") {
     // 스탬프 많은 순/적은 순은 클라이언트에서 정렬해야 함 (관계형 데이터이므로)
     // 페이지네이션 없이 모든 데이터 가져오기
     const { data: allData, error } = await query;
@@ -109,16 +107,16 @@ export const getCustomers = async (
     const sortedData = [...allData].sort((a, b) => {
       const aCount = a.stamps?.[0]?.count || 0;
       const bCount = b.stamps?.[0]?.count || 0;
-      return sortOrder === 'desc' ? bCount - aCount : aCount - bCount;
+      return sortOrder === "desc" ? bCount - aCount : aCount - bCount;
     });
 
     // 정렬 후 페이지네이션 적용
     return sortedData.slice(from, to + 1);
-  } else if (sortBy === 'created_at') {
-    query = query.order('created_at', { ascending: sortOrder === 'asc' });
+  } else if (sortBy === "created_at") {
+    query = query.order("created_at", { ascending: sortOrder === "asc" });
   } else {
     // 기본: 이름 가나다 순
-    query = query.order('name', { ascending: sortOrder === 'asc' });
+    query = query.order("name", { ascending: sortOrder === "asc" });
   }
 
   // 페이지네이션 적용
@@ -136,14 +134,14 @@ export const getCustomers = async (
  */
 export const getCustomerById = async (id: string): Promise<CustomerType> => {
   const { data, error } = await supabase
-    .from('customers')
+    .from("customers")
     .select(
       `
       *,
       stamps(count)
-    `
+    `,
     )
-    .eq('id', id)
+    .eq("id", id)
     .single();
 
   if (error) throw error;
@@ -157,21 +155,22 @@ export const getCustomerById = async (id: string): Promise<CustomerType> => {
 export const createCustomer = async (customer: {
   name: string;
   phone: string;
-  gender: 'male' | 'female';
+  gender: "male" | "female";
+  is_stamp_eligible?: boolean;
   address?: string;
   note?: string;
 }) => {
   // X는 중복 체크 제외
-  if (customer.phone !== 'X') {
+  if (customer.phone !== "X") {
     const { data: existing, error: existingError } = await supabase
-      .from('customers')
-      .select('id')
-      .eq('phone', customer.phone)
+      .from("customers")
+      .select("id")
+      .eq("phone", customer.phone)
       .maybeSingle();
 
     if (existingError) throw existingError;
     if (existing) {
-      throw new Error('DUPLICATE_CUSTOMER');
+      throw new Error("DUPLICATE_CUSTOMER");
     }
   }
 
@@ -179,12 +178,13 @@ export const createCustomer = async (customer: {
     name: customer.name,
     phone: customer.phone,
     gender: customer.gender,
+    is_stamp_eligible: customer.is_stamp_eligible ?? true,
     note: customer.note,
     ...(customer.address?.trim() ? { address: customer.address.trim() } : {}),
   };
 
   const { data, error } = await supabase
-    .from('customers')
+    .from("customers")
     .insert(insertPayload)
     .select()
     .single();
@@ -194,9 +194,9 @@ export const createCustomer = async (customer: {
   await createLog(
     LogCategoryEnum.CUSTOMER.value,
     data.id,
-    'create-customer',
-    '',
-    null
+    "create-customer",
+    "",
+    null,
   );
 
   return data;
@@ -210,23 +210,24 @@ export const updateCustomer = async (
   updates: {
     name?: string;
     phone?: string;
-    gender?: 'male' | 'female';
+    gender?: "male" | "female";
+    is_stamp_eligible?: boolean;
     address?: string;
     note?: string;
-  }
+  },
 ) => {
   // 중복 체크 (X는 제외)
-  if (updates.phone && updates.phone !== 'X') {
+  if (updates.phone && updates.phone !== "X") {
     const { data: existing, error: existingError } = await supabase
-      .from('customers')
-      .select('id')
-      .eq('phone', updates.phone)
-      .neq('id', id)
+      .from("customers")
+      .select("id")
+      .eq("phone", updates.phone)
+      .neq("id", id)
       .maybeSingle();
 
     if (existingError) throw existingError;
     if (existing) {
-      throw new Error('DUPLICATE_CUSTOMER');
+      throw new Error("DUPLICATE_CUSTOMER");
     }
   }
 
@@ -237,36 +238,39 @@ export const updateCustomer = async (
       name: prevCustomer.name,
       phone: prevCustomer.phone,
       gender: prevCustomer.gender,
-      address: prevCustomer?.address ?? '',
-      note: prevCustomer?.note ?? '',
+      is_stamp_eligible: prevCustomer.is_stamp_eligible ?? true,
+      address: prevCustomer?.address ?? "",
+      note: prevCustomer?.note ?? "",
     },
     {
       name: updates.name ?? prevCustomer.name,
       phone: updates.phone ?? prevCustomer.phone,
       gender: updates.gender ?? prevCustomer.gender,
-      address: updates.address ?? prevCustomer?.address ?? '',
-      note: updates.note ?? prevCustomer?.note ?? '',
-    }
+      is_stamp_eligible:
+        updates.is_stamp_eligible ?? prevCustomer.is_stamp_eligible ?? true,
+      address: updates.address ?? prevCustomer?.address ?? "",
+      note: updates.note ?? prevCustomer?.note ?? "",
+    },
   );
 
   await createLog(
     LogCategoryEnum.CUSTOMER.value,
     id,
-    'update-customer-info',
-    '',
-    changeObj
+    "update-customer-info",
+    "",
+    changeObj,
   );
 
   // 고객 업데이트 (결과 없을 수 있음)
   const { data, error } = await supabase
-    .from('customers')
+    .from("customers")
     .update(updates)
-    .eq('id', id)
+    .eq("id", id)
     .select()
     .maybeSingle();
 
   if (error) throw error;
-  if (!data) throw new Error('NOT_FOUND_CUSTOMER');
+  if (!data) throw new Error("NOT_FOUND_CUSTOMER");
 
   return data;
 };
@@ -275,7 +279,7 @@ export const updateCustomer = async (
  * 고객 삭제
  */
 export const deleteCustomer = async (id: string) => {
-  const { error } = await supabase.from('customers').delete().eq('id', id);
+  const { error } = await supabase.from("customers").delete().eq("id", id);
 
   if (error) throw error;
 };

--- a/src/app/_domains/_customer/_types/customer.types.ts
+++ b/src/app/_domains/_customer/_types/customer.types.ts
@@ -1,10 +1,11 @@
-export type GenderType = 'male' | 'female';
+export type GenderType = "male" | "female";
 
 export type CustomerType = {
   id: string;
   name: string;
   phone: string;
   gender: GenderType;
+  is_stamp_eligible?: boolean;
   address?: string | null;
   note?: string | null;
   created_at: string;

--- a/src/app/_domains/_customer/_utils/specialCustomer.ts
+++ b/src/app/_domains/_customer/_utils/specialCustomer.ts
@@ -3,6 +3,7 @@ export type CustomerMode = "normal" | "demo" | "adjustment" | "x";
 export const getCustomerMode = (
   name: string,
   phone?: string | null,
+  isStampEligible = true,
 ): CustomerMode => {
   const normalizedName = name.trim();
   const normalizedPhone = phone?.trim();
@@ -10,10 +11,12 @@ export const getCustomerMode = (
   if (normalizedName === "시연용") return "demo";
   if (normalizedName === "재고조정") return "adjustment";
   if (normalizedName === "X" && normalizedPhone === "X") return "x";
+  if (!isStampEligible) return "x";
   return "normal";
 };
 
 export const isSpecialCustomer = (
   name: string,
   phone?: string | null,
-) => getCustomerMode(name, phone) !== "normal";
+  isStampEligible = true,
+) => getCustomerMode(name, phone, isStampEligible) !== "normal";

--- a/src/app/_domains/_dailyClosing/_services/dailyClosingService.ts
+++ b/src/app/_domains/_dailyClosing/_services/dailyClosingService.ts
@@ -6,6 +6,7 @@ import {
   DailyClosingReportSnapshot,
   DailyClosingReportRevision,
   DailyClosingReportType,
+  OpeningCompletionNotice,
 } from '../_types/dailyClosing.types';
 
 export const getDailyClosingReport = async (
@@ -170,6 +171,71 @@ export const saveDailyOpeningChecklistProgress = async (
         updated_at: new Date().toISOString(),
       },
       { onConflict: 'business_date' },
+    );
+
+  if (error) throw error;
+};
+
+export const getOpeningCompletionNotice = async (): Promise<OpeningCompletionNotice | null> => {
+  const { data, error } = await supabase
+    .from('opening_completion_notice')
+    .select('id, title, content, is_active, version, updated_at')
+    .eq('id', 1)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data as OpeningCompletionNotice | null;
+};
+
+export const saveOpeningCompletionNotice = async (values: {
+  title: string;
+  content: string;
+  isActive: boolean;
+}): Promise<void> => {
+  const { error } = await supabase.rpc('save_opening_completion_notice', {
+    p_title: values.title.trim(),
+    p_content: values.content.trim(),
+    p_is_active: values.isActive,
+  });
+
+  if (error) throw error;
+};
+
+export const hasAcknowledgedOpeningNotice = async (
+  businessDate: string,
+  noticeVersion: number,
+): Promise<boolean> => {
+  const { data, error } = await supabase
+    .from('opening_completion_notice_reads')
+    .select('notice_version')
+    .eq('business_date', businessDate)
+    .eq('notice_version', noticeVersion)
+    .maybeSingle();
+
+  if (error) throw error;
+  return Boolean(data);
+};
+
+export const acknowledgeOpeningNotice = async (
+  businessDate: string,
+  noticeVersion: number,
+): Promise<void> => {
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+  if (sessionError || !session) throw new Error('세션을 찾을 수 없습니다.');
+
+  const { error } = await supabase
+    .from('opening_completion_notice_reads')
+    .upsert(
+      {
+        business_date: businessDate,
+        user_id: session.user.id,
+        notice_version: noticeVersion,
+        acknowledged_at: new Date().toISOString(),
+      },
+      { onConflict: 'business_date,user_id,notice_version' },
     );
 
   if (error) throw error;

--- a/src/app/_domains/_dailyClosing/_types/dailyClosing.types.ts
+++ b/src/app/_domains/_dailyClosing/_types/dailyClosing.types.ts
@@ -11,6 +11,15 @@ export type DailyClosingChecklistItem = {
   is_opening_gate: boolean;
 };
 
+export type OpeningCompletionNotice = {
+  id: number;
+  title: string;
+  content: string;
+  is_active: boolean;
+  version: number;
+  updated_at: string;
+};
+
 export type DailyClosingReportSnapshot = {
   version: 1;
   businessDate: string;

--- a/src/app/_domains/_inventory/_services/inventoryService.ts
+++ b/src/app/_domains/_inventory/_services/inventoryService.ts
@@ -221,10 +221,13 @@ export const getInventoryMovements = async (
         const direction = ["exchange_in", "adjustment_in"].includes(action)
           ? "in"
           : "out";
-        outboundItemDetails.set(`${row.id}\u0000${itemName}\u0000${direction}`, {
-          inventoryAction,
-          remark: String(item.remark ?? ""),
-        });
+        outboundItemDetails.set(
+          `${row.id}\u0000${itemName}\u0000${direction}`,
+          {
+            inventoryAction,
+            remark: String(item.remark ?? ""),
+          },
+        );
       }
     }
   }
@@ -329,7 +332,7 @@ export const getInventorySuppliers = async (
 ): Promise<InventorySupplier[]> => {
   const { data, error } = await supabase
     .from("inventory_suppliers")
-    .select(isAdmin ? "*" : "id, name, is_use")
+    .select(isAdmin ? "*" : "id, name, note, is_use")
     .order("name");
   if (error) throw error;
   return (data ?? []) as unknown as InventorySupplier[];

--- a/src/app/_domains/_log/_services/logService.ts
+++ b/src/app/_domains/_log/_services/logService.ts
@@ -248,7 +248,7 @@ export const getLogs = async (
       `
       *,
       users!admin_id(name, email, oss_role),
-      customers(name, phone, address, note, gender)
+      customers(name, phone, address, note, gender, is_stamp_eligible)
     `,
     )
     .eq("category", category);

--- a/src/app/_domains/_log/_types/log.types.ts
+++ b/src/app/_domains/_log/_types/log.types.ts
@@ -39,6 +39,7 @@ export type LogCustomerInfo = {
   address?: string | null;
   note?: string | null;
   gender?: "male" | "female" | null;
+  is_stamp_eligible?: boolean;
 };
 
 // 고객 상세 페이지의 로그

--- a/src/app/_utils/utils.ts
+++ b/src/app/_utils/utils.ts
@@ -2,7 +2,7 @@ import {
   AfterServiceStatusEnum,
   AfterServiceStatusGroupEnum,
   AfterServiceStatusGroupEnumType,
-} from '@/app/_enums/enums';
+} from "@/app/_enums/enums";
 
 // AS 상태 그룹 정의 (enum 기반)
 export const getAfterServiceStatusGroups = () => {
@@ -25,65 +25,65 @@ export const getAfterServiceStatusGroups = () => {
 
 // 상태가 속한 그룹 반환 (enum 기반)
 export const getAfterServiceStatusGroup = (
-  status: string
-): AfterServiceStatusGroupEnumType['value'] => {
+  status: string,
+): AfterServiceStatusGroupEnumType["value"] => {
   const statusOption = Object.values(AfterServiceStatusEnum).find(
-    (opt) => opt.value === status
+    (opt) => opt.value === status,
   );
   return statusOption?.group || AfterServiceStatusGroupEnum.RECEIVED.value; // 기본값
 };
 
 export const getActionText = (action: string) => {
-  if (action === 'no-stamp') {
-    return { text: '미적립', color: 'text-gray-500 bg-gray-100' };
+  if (action === "no-stamp") {
+    return { text: "미적립", color: "text-gray-500 bg-gray-100" };
   }
-  if (action.startsWith('add-')) {
-    const amount = action.replace('add-', '');
+  if (action.startsWith("add-")) {
+    const amount = action.replace("add-", "");
     return {
       text: `${amount}개 적립`,
-      color: 'text-emerald-700 bg-emerald-100',
+      color: "text-emerald-700 bg-emerald-100",
     };
   }
-  if (action.startsWith('remove-')) {
-    const amount = action.replace('remove-', '');
-    return { text: `${amount}개 차감`, color: 'text-rose-700 bg-rose-100' };
+  if (action.startsWith("remove-")) {
+    const amount = action.replace("remove-", "");
+    return { text: `${amount}개 차감`, color: "text-rose-700 bg-rose-100" };
   }
-  if (action === 'coupon-10') {
-    return { text: `쿠폰 사용`, color: 'text-blue-700 bg-blue-100' };
-  }
-
-  if (action === 'update-customer-info') {
-    return { text: `고객 정보 수정`, color: 'text-gray-700 bg-gray-100' };
+  if (action === "coupon-10") {
+    return { text: `쿠폰 사용`, color: "text-blue-700 bg-blue-100" };
   }
 
-  if (action === 'create-customer') {
-    return { text: `고객 추가`, color: 'text-green-700 bg-green-100' };
+  if (action === "update-customer-info") {
+    return { text: `고객 정보 수정`, color: "text-gray-700 bg-gray-100" };
   }
 
-  if (action === 'update-after-service-info') {
-    return { text: `AS 정보 수정`, color: 'text-gray-700 bg-gray-100' };
+  if (action === "create-customer") {
+    return { text: `고객 추가`, color: "text-green-700 bg-green-100" };
+  }
+
+  if (action === "update-after-service-info") {
+    return { text: `AS 정보 수정`, color: "text-gray-700 bg-gray-100" };
   }
 
   // AS 상태 액션 처리
-  if (action.startsWith('after-service-')) {
-    const statusValue = action.replace('after-service-', '');
+  if (action.startsWith("after-service-")) {
+    const statusValue = action.replace("after-service-", "");
 
     // enum에서 상태 정보 가져오기
     const statusOption = Object.values(AfterServiceStatusEnum).find(
-      (opt) => opt.value === statusValue
+      (opt) => opt.value === statusValue,
     );
     const statusName = statusOption?.name || statusValue;
 
     // 상태 그룹별 색상 분류 (enum 기반)
     const statusGroup =
       statusOption?.group || AfterServiceStatusGroupEnum.RECEIVED.value;
-    let color = 'text-gray-700 bg-gray-100'; // 기본값
+    let color = "text-gray-700 bg-gray-100"; // 기본값
     if (statusGroup === AfterServiceStatusGroupEnum.RECEIVED.value) {
-      color = 'text-gray-700 bg-gray-100'; // 접수: 회색
+      color = "text-gray-700 bg-gray-100"; // 접수: 회색
     } else if (statusGroup === AfterServiceStatusGroupEnum.IN_PROGRESS.value) {
-      color = 'text-blue-700 bg-blue-100'; // 진행: 파란색
+      color = "text-blue-700 bg-blue-100"; // 진행: 파란색
     } else if (statusGroup === AfterServiceStatusGroupEnum.COMPLETED.value) {
-      color = 'text-green-700 bg-green-100'; // 완료: 녹색
+      color = "text-green-700 bg-green-100"; // 완료: 녹색
     }
 
     return {
@@ -92,18 +92,18 @@ export const getActionText = (action: string) => {
     };
   }
 
-  return { text: action, color: 'text-gray-700 bg-gray-100' };
+  return { text: action, color: "text-gray-700 bg-gray-100" };
 };
 
 export const formatPhoneNumber = (phone: string | null | undefined): string => {
-  if (!phone) return '';
-  const digits = phone.replace(/\D/g, '');
+  if (!phone) return "";
+  const digits = phone.replace(/\D/g, "");
   if (digits.length === 11) {
     // 010-1234-5678 format
     return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
   } else if (digits.length === 10) {
     // 010-123-4567 or 02-1234-5678 format
-    if (digits.startsWith('02')) {
+    if (digits.startsWith("02")) {
       return `${digits.slice(0, 2)}-${digits.slice(2, 6)}-${digits.slice(6)}`;
     } else {
       return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
@@ -117,16 +117,16 @@ export const formatPhoneNumber = (phone: string | null | undefined): string => {
  * items의 순서를 보존 (DB에서 이미 정렬되어 온 순서 유지)
  */
 export const groupLogsByDate = <T extends { created_at: string }>(
-  items: T[]
+  items: T[],
 ): { itemsByDate: Record<string, T[]>; sortedDates: string[] } => {
   const itemsByDate: Record<string, T[]> = {};
   const sortedDates: string[] = [];
 
   for (const log of items) {
-    const dateKey = new Date(log.created_at).toLocaleDateString('ko-KR', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
+    const dateKey = new Date(log.created_at).toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
     });
 
     if (!itemsByDate[dateKey]) {
@@ -143,27 +143,37 @@ export const groupLogsByDate = <T extends { created_at: string }>(
  * 날짜 키(예: "25. 12. 02.")를 보기 좋은 형식(예: "25년 12월 02일")으로 변환
  */
 export const formatDateKey = (dateKey: string): string => {
-  const [yyyy, mm, dd] = dateKey.split('.').map((s) => s.trim());
+  const [yyyy, mm, dd] = dateKey.split(".").map((s) => s.trim());
   return `${yyyy}년 ${mm}월 ${dd}일`;
 };
 
 type CustomerValue = {
   name: string;
   phone: string;
-  gender: 'male' | 'female';
+  gender: "male" | "female";
+  is_stamp_eligible?: boolean;
   address?: string | null;
   note?: string | null;
 };
 
 export const getUpdateLogNote = (
   prevValue: CustomerValue,
-  newValue: CustomerValue
+  newValue: CustomerValue,
 ) => {
   const changeArray = [];
-  const changeObj: Record<string, { old: string | null; new: string | null }> =
-    {};
+  const changeObj: Record<
+    string,
+    { old: string | boolean | null; new: string | boolean | null }
+  > = {};
 
-  const fieldNameMap = ['name', 'phone', 'gender', 'address', 'note'];
+  const fieldNameMap = [
+    "name",
+    "phone",
+    "gender",
+    "is_stamp_eligible",
+    "address",
+    "note",
+  ];
 
   const prevValueArray = Object.values(prevValue);
   const newValueArray = Object.values(newValue);
@@ -183,4 +193,3 @@ export const getUpdateLogNote = (
 
   return changeObj;
 };
-

--- a/supabase/migrations/20260803010000_add_customer_stamp_eligibility.sql
+++ b/supabase/migrations/20260803010000_add_customer_stamp_eligibility.sql
@@ -1,0 +1,12 @@
+alter table public.customers
+add column if not exists is_stamp_eligible boolean;
+
+update public.customers
+set is_stamp_eligible = true
+where is_stamp_eligible is null;
+
+alter table public.customers
+alter column is_stamp_eligible set default true;
+
+alter table public.customers
+alter column is_stamp_eligible set not null;

--- a/supabase/migrations/20260803020000_open_notice.sql
+++ b/supabase/migrations/20260803020000_open_notice.sql
@@ -1,0 +1,89 @@
+create table if not exists public.opening_completion_notice (
+  id smallint primary key default 1 check (id = 1),
+  title text not null default '오픈 처리가 완료되었습니다',
+  content text not null default '',
+  is_active boolean not null default false,
+  version integer not null default 1,
+  updated_at timestamptz not null default now(),
+  updated_by uuid references auth.users(id)
+);
+
+insert into public.opening_completion_notice (id)
+values (1)
+on conflict (id) do nothing;
+
+create table if not exists public.opening_completion_notice_reads (
+  business_date date not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  notice_version integer not null,
+  acknowledged_at timestamptz not null default now(),
+  primary key (business_date, user_id, notice_version)
+);
+
+alter table public.opening_completion_notice enable row level security;
+alter table public.opening_completion_notice_reads enable row level security;
+
+drop policy if exists "authenticated users can read opening notice" on public.opening_completion_notice;
+create policy "authenticated users can read opening notice"
+on public.opening_completion_notice for select
+to authenticated
+using (true);
+
+drop policy if exists "users can read own opening notice acknowledgements" on public.opening_completion_notice_reads;
+create policy "users can read own opening notice acknowledgements"
+on public.opening_completion_notice_reads for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists "users can acknowledge opening notice" on public.opening_completion_notice_reads;
+create policy "users can acknowledge opening notice"
+on public.opening_completion_notice_reads for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists "users can update own opening notice acknowledgements" on public.opening_completion_notice_reads;
+create policy "users can update own opening notice acknowledgements"
+on public.opening_completion_notice_reads for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create or replace function public.save_opening_completion_notice(
+  p_title text,
+  p_content text,
+  p_is_active boolean
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (
+    select 1 from public.users
+    where id = auth.uid() and oss_role = 'admin'
+  ) then
+    raise exception '관리자만 오픈 완료 알림을 수정할 수 있습니다.';
+  end if;
+
+  if btrim(coalesce(p_title, '')) = '' then
+    raise exception '알림 제목을 입력해 주세요.';
+  end if;
+
+  insert into public.opening_completion_notice (
+    id, title, content, is_active, version, updated_at, updated_by
+  ) values (
+    1, btrim(p_title), btrim(coalesce(p_content, '')), p_is_active, 1, now(), auth.uid()
+  )
+  on conflict (id) do update set
+    title = excluded.title,
+    content = excluded.content,
+    is_active = excluded.is_active,
+    version = public.opening_completion_notice.version + 1,
+    updated_at = now(),
+    updated_by = auth.uid();
+end;
+$$;
+
+revoke all on function public.save_opening_completion_notice(text, text, boolean) from public;
+grant execute on function public.save_opening_completion_notice(text, text, boolean) to authenticated;


### PR DESCRIPTION
## 주요 변경사항

### 1. 고객별 적립 대상 설정

- 고객 추가 및 수정 시 적립 대상과 미적립 대상을 선택할 수 있도록 변경했습니다.
- 신규 고객은 기본적으로 적립 대상으로 설정됩니다.
- 기존 고객 데이터도 적립 대상으로 적용되도록 SQL을 추가했습니다.
- 일반 고객이 미적립 대상으로 설정된 경우 고객 상세 화면에
  `미적립 남자 고객입니다.` 또는 `미적립 여자 고객입니다.`로 표시됩니다.
- X 남자, X 여자, 시연용, 재고조정 등 기존 특수계정의 처리 방식은 유지했습니다.
- 고객 변경 이력에도 적립 대상 여부가 기록되도록 반영했습니다.

### 2. 거래처 기본 발행 종류 설정

- 거래처 관리 화면에서 기본 발행 종류를 검색형 드롭다운으로 지정할 수 있도록 추가했습니다.
- 지정된 발행 종류가 없으면 `미지정 상태입니다.`로 표시됩니다.
- 거래처명 옆에 사용 상태가 표시되도록 레이아웃을 정리했습니다.
- 입고 등록 시 거래처에 저장된 기본 발행 종류가 있으면 불러올지 확인하는 창이 표시됩니다.
- `예`를 선택하면 저장된 발행 종류를 적용합니다.
- `아니오`를 선택하면 발행 종류 검색 상태로 이동하며 미리 X를 적용하지 않습니다.

### 3. 입고 등록 및 수정 기능 개선

- `입고 내용 수정` 버튼명을 `입고 수정`으로 변경했습니다.
- 입고 수정 화면에서 다음 정보를 함께 변경할 수 있도록 확장했습니다.
  - 거래처
  - 주문일
  - 발행 종류
  - 주문 수량
  - 개별 메모
  - 전체 메모
- 주문 수량과 개별 메모 옆의 개별 연필 버튼을 제거했습니다.
- 실제 입고 수량을 수정하는 연필 버튼은 유지했습니다.
- 관리자 계정이 입고 개별 메모를 수정할 수 있도록 반영했습니다.

### 4. 입고 내역 엑셀 복사

- 입고 대기 및 입고 완료 카드에 `엑셀 복사` 버튼을 추가했습니다.
- 복사된 내용을 기존 엑셀 표에 바로 붙여넣을 수 있도록 탭과 줄바꿈 형식으로 구성했습니다.
- 일반 품목은 다음과 같이 복사됩니다.
  - 도매처
  - 주문 날짜
  - 제품명
  - 수량
  - 매입가 열은 공란
  - 총매입가 열에 `=[@수량]*[@매입가]` 수식 입력
  - 개별 메모
  - 전체 메모
  - 발행 종류
- 거래 조정의 할인 및 지불 항목도 개별 품목 행처럼 함께 복사됩니다.
- 거래 조정 항목의 수량은 1로 고정됩니다.
- 거래 조정 금액은 매입가 열에 입력됩니다.
- 할인 항목은 음수, 지불 항목은 양수로 복사됩니다.
- 거래 조정 항목의 총매입가에도 동일한 계산 수식이 입력됩니다.

### 5. 입고 카드 표시 개선

- 입고 대기 및 입고 완료 카드에서 발행 종류를 바로 확인할 수 있도록 추가했습니다.
- 거래 조정에 포함된 할인 및 지불 내역을 카드에 함께 표시합니다.
- 입고 완료 상태, 거래처명, 주문일, 도착일 및 작업 버튼의 가로 정렬을 정리했습니다.
- 거래처명 아래쪽에 발행 종류와 거래 조정 내역이 표시되도록 구성했습니다.
- 엑셀 복사, 입고 수정, 거래 조정, 이력 삭제 버튼의 위치를 정돈했습니다.

### 6. 시재 입력 방식 개선

- `전날 시재 불러오기` 버튼을 제거했습니다.
- `실제 현금 입력` 제목을 클릭하면 기존 전날 시재 불러오기 기능이 실행됩니다.
- 별도 버튼처럼 보이지 않으면서 키보드 접근성은 유지하도록 처리했습니다.

### 7. 오픈 완료 알림 기능

- 체크리스트 관리 화면에 관리자용 `오픈 완료 알림` 설정을 추가했습니다.
- 관리자가 다음 항목을 작성하고 수정할 수 있습니다.
  - 알림 사용 여부
  - 알림 제목
  - 알림 내용
- 오픈 대상 체크리스트가 모두 완료되어 기능이 열리는 시점에 직원에게 알림 모달이 표시됩니다.
- 직원이 확인 버튼을 누르면 확인 날짜, 사용자, 알림 버전이 기록됩니다.
- 같은 직원에게 동일한 알림 버전은 같은 영업일에 다시 표시되지 않습니다.
- 관리자가 알림을 수정하고 저장하면 새로운 버전으로 처리되어 다시 안내할 수 있습니다.
- 알림 내용에 직접 입력한 줄바꿈은 실제 모달에서도 그대로 유지됩니다.

## 데이터베이스 적용

다음 SQL 파일을 순서대로 적용해야 합니다.

1. `20260803010000_add_customer_stamp_eligibility.sql`
2. `20260803020000_open_notice.sql`

첫 번째 SQL은 고객별 적립 대상 필드와 기존 고객 기본값을 추가합니다.

두 번째 SQL은 오픈 완료 알림 설정, 직원별 확인 기록, 관리자 전용 알림 저장 함수를 추가합니다.

## 검수 결과

- ESLint 통과
- TypeScript 검사 통과
- Next.js 프로덕션 빌드 통과
- Git diff 공백 및 충돌 검사 통과