### PR TITLE
출고 처리 개선 및 미처리 현황·이력 UI 고도화

### DIFF
--- a/src/app/(auth)/_components/Header/_components/PendingStatusButton.tsx
+++ b/src/app/(auth)/_components/Header/_components/PendingStatusButton.tsx
@@ -1,0 +1,766 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { AfterServiceStatusEnum } from "@/app/_enums/enums";
+import { getAfterServiceStatusGroups } from "@/app/_utils/utils";
+import { getCurrentWorkerName } from "@/app/_domains/_workJournal/_utils/currentWorker";
+import { useUser } from "@/app/_contexts/UserContext";
+import supabase from "@/libs/supabaseClient";
+
+type ReservationRow = {
+  id: string;
+  note: string | null;
+  jsonb: Record<string, unknown> | null;
+  customers: { name: string; phone: string } | null;
+};
+
+type AfterServiceRow = {
+  id: string;
+  item_name: string;
+  status: string;
+  customer_note: string | null;
+  shop_note: string | null;
+  customers: { name: string; phone: string } | null;
+};
+
+type PurchaseOrderRow = {
+  id: string;
+  status: string;
+  inventory_suppliers: { name: string } | null;
+  inventory_purchase_order_lines: Array<{
+    pending_quantity: number;
+  }>;
+};
+
+type HandoverMemo = {
+  id: string;
+  content: string;
+  author_name: string;
+  created_at: string;
+  is_completed: boolean;
+  completed_at: string | null;
+  completed_by_name: string | null;
+};
+
+const getRelation = <T,>(value: T | T[] | null): T | null =>
+  Array.isArray(value) ? (value[0] ?? null) : value;
+
+const formatReservationItems = (jsonb: Record<string, unknown> | null) => {
+  const items = Array.isArray(jsonb?.items)
+    ? (jsonb.items as Array<{ itemName?: string; quantity?: number }>)
+    : [];
+  if (!items.length) return "예약 품목 확인";
+  const quantity = items.reduce((sum, item) => sum + (item.quantity ?? 0), 0);
+  return `${items[0].itemName ?? "품목"}${items.length > 1 ? ` 외 ${items.length - 1}종` : ""} · 총 ${quantity}개`;
+};
+
+const formatReservationDate = (jsonb: Record<string, unknown> | null) =>
+  typeof jsonb?.reservationDate === "string"
+    ? jsonb.reservationDate
+    : "날짜 미정";
+
+const formatMemoTime = (value: string) =>
+  new Intl.DateTimeFormat("ko-KR", {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Seoul",
+  }).format(new Date(value));
+
+const getAfterServiceStatusName = (status: string) =>
+  Object.values(AfterServiceStatusEnum).find((item) => item.value === status)
+    ?.name ?? status;
+
+export default function PendingStatusButton() {
+  const { isAdmin } = useUser();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [reservations, setReservations] = useState<ReservationRow[]>([]);
+  const [afterServices, setAfterServices] = useState<AfterServiceRow[]>([]);
+  const [purchaseOrders, setPurchaseOrders] = useState<PurchaseOrderRow[]>([]);
+  const [memos, setMemos] = useState<HandoverMemo[]>([]);
+  const [memoInput, setMemoInput] = useState("");
+  const [isMemoFormOpen, setIsMemoFormOpen] = useState(false);
+  const [isSavingMemo, setIsSavingMemo] = useState(false);
+  const [memoStorageAvailable, setMemoStorageAvailable] = useState(true);
+  const [memoToComplete, setMemoToComplete] = useState<HandoverMemo | null>(
+    null,
+  );
+  const [isMemoHistoryOpen, setIsMemoHistoryOpen] = useState(false);
+  const [memoHistory, setMemoHistory] = useState<HandoverMemo[]>([]);
+  const [memoHistoryCount, setMemoHistoryCount] = useState(0);
+  const [isMemoHistoryLoading, setIsMemoHistoryLoading] = useState(false);
+  const [actorName, setActorName] = useState(isAdmin ? "관리자" : "");
+
+  const resolveActorName = useCallback(async () => {
+    if (isAdmin) {
+      setActorName("관리자");
+      return "관리자";
+    }
+    const storedWorkerName = getCurrentWorkerName();
+    if (storedWorkerName) {
+      setActorName(storedWorkerName);
+      return storedWorkerName;
+    }
+    const today = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "Asia/Seoul",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date());
+    const { data } = await supabase
+      .from("work_journals")
+      .select("worker_name")
+      .eq("work_date", today)
+      .eq("status", "working")
+      .limit(2);
+    const resolvedName = data?.length === 1 ? data[0].worker_name : "";
+    setActorName(resolvedName);
+    return resolvedName;
+  }, [isAdmin]);
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    const inProgressStatuses = getAfterServiceStatusGroups().inProgress;
+    const [reservationResult, afterServiceResult, purchaseOrderResult, memoResult] =
+      await Promise.all([
+        supabase
+          .from("logs")
+          .select("id, note, jsonb, customers(name, phone)")
+          .eq("category", "reservation")
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("after_services")
+          .select(
+            "id, item_name, status, customer_note, shop_note, customers(name, phone)",
+          )
+          .in("status", inProgressStatuses)
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("inventory_purchase_orders")
+          .select(
+            "id, status, inventory_suppliers(name), inventory_purchase_order_lines(pending_quantity)",
+          )
+          .in("status", ["pending", "partial"])
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("handover_memos")
+          .select(
+            "id, content, author_name, created_at, is_completed, completed_at, completed_by_name",
+          )
+          .eq("is_completed", false)
+          .order("created_at", { ascending: false }),
+      ]);
+
+    if (reservationResult.error) console.error(reservationResult.error);
+    if (afterServiceResult.error) console.error(afterServiceResult.error);
+    if (purchaseOrderResult.error) console.error(purchaseOrderResult.error);
+
+    setReservations(
+      ((reservationResult.data ?? []) as unknown as Array<
+        Omit<ReservationRow, "customers"> & {
+          customers: ReservationRow["customers"] | ReservationRow["customers"][];
+        }
+      >).map((row) => ({ ...row, customers: getRelation(row.customers) })),
+    );
+    setAfterServices(
+      ((afterServiceResult.data ?? []) as unknown as Array<
+        Omit<AfterServiceRow, "customers"> & {
+          customers: AfterServiceRow["customers"] | AfterServiceRow["customers"][];
+        }
+      >).map((row) => ({ ...row, customers: getRelation(row.customers) })),
+    );
+    setPurchaseOrders(
+      ((purchaseOrderResult.data ?? []) as unknown as Array<
+        Omit<PurchaseOrderRow, "inventory_suppliers"> & {
+          inventory_suppliers:
+            | PurchaseOrderRow["inventory_suppliers"]
+            | PurchaseOrderRow["inventory_suppliers"][];
+        }
+      >).map((row) => ({
+        ...row,
+        inventory_suppliers: getRelation(row.inventory_suppliers),
+      })),
+    );
+
+    if (memoResult.error) {
+      console.warn("전달 메모 저장소를 불러오지 못했습니다.", memoResult.error);
+      setMemoStorageAvailable(false);
+      setMemos([]);
+    } else {
+      setMemoStorageAvailable(true);
+      setMemos((memoResult.data ?? []) as HandoverMemo[]);
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    void loadData();
+    void resolveActorName();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsOpen(false);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, loadData, resolveActorName]);
+
+  const pendingSuppliers = useMemo(
+    () =>
+      purchaseOrders
+        .map((order) => ({
+          id: order.id,
+          name: order.inventory_suppliers?.name ?? "거래처 미지정",
+          pendingQuantity: order.inventory_purchase_order_lines.reduce(
+            (sum, line) => sum + Math.max(0, line.pending_quantity ?? 0),
+            0,
+          ),
+        }))
+        .filter((order) => order.pendingQuantity > 0),
+    [purchaseOrders],
+  );
+  const loadMemoHistory = async (offset = 0) => {
+    setIsMemoHistoryLoading(true);
+    const { data, error, count } = await supabase
+      .from("handover_memos")
+      .select(
+        "id, content, author_name, created_at, is_completed, completed_at, completed_by_name",
+        { count: "exact" },
+      )
+      .eq("is_completed", true)
+      .order("completed_at", { ascending: false })
+      .range(offset, offset + 19);
+    setIsMemoHistoryLoading(false);
+    if (error) {
+      toast.error("이전 메모 기록을 불러오지 못했습니다.");
+      return;
+    }
+    setMemoHistory((current) =>
+      offset === 0
+        ? ((data ?? []) as HandoverMemo[])
+        : [...current, ...((data ?? []) as HandoverMemo[])],
+    );
+    setMemoHistoryCount(count ?? 0);
+  };
+
+  const addMemo = async () => {
+    const content = memoInput.trim();
+    if (!content || !memoStorageAvailable) return;
+    const resolvedActorName = await resolveActorName();
+    if (!resolvedActorName) {
+      toast.error("현재 근무자를 확인할 수 없습니다. 출근 기록을 확인해 주세요.");
+      return;
+    }
+    setIsSavingMemo(true);
+    const { error } = await supabase.from("handover_memos").insert({
+      content,
+      author_name: resolvedActorName,
+    });
+    setIsSavingMemo(false);
+    if (error) {
+      toast.error("전달 메모를 저장하지 못했습니다.");
+      return;
+    }
+    setMemoInput("");
+    setIsMemoFormOpen(false);
+    toast.success("전달 메모를 추가했습니다.");
+    void loadData();
+  };
+
+  const completeMemo = async () => {
+    if (!memoToComplete) return;
+    const resolvedActorName = await resolveActorName();
+    if (!resolvedActorName) {
+      toast.error("현재 근무자를 확인할 수 없습니다. 출근 기록을 확인해 주세요.");
+      return;
+    }
+    const {
+      data: { user: authUser },
+    } = await supabase.auth.getUser();
+    const { error } = await supabase
+      .from("handover_memos")
+      .update({
+        is_completed: true,
+        completed_at: new Date().toISOString(),
+        completed_by: authUser?.id ?? null,
+        completed_by_name: resolvedActorName,
+      })
+      .eq("id", memoToComplete.id);
+    if (error) {
+      toast.error("전달 메모를 완료 처리하지 못했습니다.");
+      return;
+    }
+    setMemoToComplete(null);
+    toast.success("전달 메모를 완료 처리했습니다.");
+    void loadData();
+  };
+
+  const deleteCompletedMemo = async (memo: HandoverMemo) => {
+    if (!isAdmin) return;
+    const shouldDelete = window.confirm(
+      `이전 메모 기록을 삭제하시겠습니까?\n\n내용: ${memo.content}\n작성자: ${memo.author_name}\n처리자: ${memo.completed_by_name || "알 수 없음"}`,
+    );
+    if (!shouldDelete) return;
+    const { error } = await supabase
+      .from("handover_memos")
+      .delete()
+      .eq("id", memo.id)
+      .eq("is_completed", true);
+    if (error) {
+      toast.error("이전 메모 기록을 삭제하지 못했습니다.");
+      return;
+    }
+    setMemoHistory((current) =>
+      current.filter((item) => item.id !== memo.id),
+    );
+    setMemoHistoryCount((current) => Math.max(0, current - 1));
+    toast.success("이전 메모 기록을 삭제했습니다.");
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="hidden h-10 cursor-pointer items-center gap-2 rounded-lg border border-brand-100 bg-white/90 px-3 text-sm font-semibold text-brand-700 shadow-sm transition-all hover:border-brand-200 hover:bg-white hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300 lg:flex"
+      >
+        <span className="h-2 w-2 rounded-full bg-brand-500" />
+        미처리 현황
+      </button>
+
+      {isOpen && (
+        <div className="fixed inset-0 z-[2100] flex items-center justify-center p-4 sm:p-6">
+          <button
+            type="button"
+            aria-label="미처리 현황 닫기"
+            className="absolute inset-0 cursor-pointer bg-gray-950/50 backdrop-blur-[2px]"
+            onClick={() => setIsOpen(false)}
+          />
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="pending-status-title"
+            className="relative z-10 flex max-h-[90vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl"
+          >
+            <header className="flex items-center justify-between border-b border-gray-200 px-5 py-4 sm:px-6">
+              <div>
+                <h2 id="pending-status-title" className="text-xl font-bold text-gray-950">
+                  미처리 현황
+                </h2>
+                <p className="mt-0.5 text-sm text-gray-500">
+                  예약, A/S, 미입고와 전달 메모를 한곳에서 확인합니다.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void loadData()}
+                  disabled={isLoading}
+                  className="cursor-pointer rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isLoading ? "불러오는 중" : "새로고침"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setIsOpen(false)}
+                  aria-label="닫기"
+                  className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full text-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+                >
+                  ×
+                </button>
+              </div>
+            </header>
+
+            <div className="min-h-0 flex-1 overflow-y-auto bg-gray-50/70 p-4 sm:p-6">
+              <div className="grid gap-4 lg:grid-cols-2">
+                <StatusCard
+                  title="출고 예약"
+                  count={reservations.length}
+                  href="/histories?tab=reservation"
+                >
+                  {reservations.slice(0, 5).map((reservation) => (
+                    <Link
+                      key={reservation.id}
+                      href="/histories?tab=reservation"
+                      onClick={() => setIsOpen(false)}
+                      className="grid grid-cols-[1fr_auto] gap-3 border-b border-gray-100 px-1 py-3 last:border-b-0 hover:bg-gray-50"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-base font-semibold text-gray-900">
+                          {reservation.customers?.name ?? "고객 정보 없음"}
+                        </p>
+                        <p className="mt-0.5 truncate text-sm text-gray-500">
+                          {formatReservationItems(reservation.jsonb)}
+                        </p>
+                      </div>
+                      <span className="text-sm font-semibold text-brand-600">
+                        {formatReservationDate(reservation.jsonb)}
+                      </span>
+                    </Link>
+                  ))}
+                  {!isLoading && reservations.length === 0 && (
+                    <EmptyState text="미처리 출고 예약이 없습니다." />
+                  )}
+                </StatusCard>
+
+                <StatusCard
+                  title="진행 중 A/S"
+                  count={afterServices.length}
+                  href="/after-services?group=inProgress"
+                >
+                  {afterServices.slice(0, 5).map((afterService) => (
+                    <Link
+                      key={afterService.id}
+                      href={`/after-services?group=inProgress&id=${afterService.id}`}
+                      onClick={() => setIsOpen(false)}
+                      className="grid gap-3 border-b border-gray-100 px-1 py-3 last:border-b-0 hover:bg-gray-50 sm:grid-cols-[minmax(100px,0.8fr)_minmax(100px,1fr)_minmax(110px,1fr)_auto] sm:items-center"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-base font-semibold text-gray-900">
+                          {afterService.customers?.name ?? "고객 정보 없음"}
+                        </p>
+                        <p className="mt-0.5 truncate text-sm text-gray-500">
+                          {afterService.item_name}
+                        </p>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-gray-400">
+                          고객 특이사항
+                        </p>
+                        <p className="mt-0.5 line-clamp-2 text-sm text-gray-600">
+                          {afterService.customer_note || "없음"}
+                        </p>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-gray-400">
+                          매장 특이사항
+                        </p>
+                        <p className="mt-0.5 line-clamp-2 text-sm text-gray-600">
+                          {afterService.shop_note || "없음"}
+                        </p>
+                      </div>
+                      <span className="rounded-md bg-amber-50 px-2 py-1 text-sm font-semibold text-amber-700">
+                        {getAfterServiceStatusName(afterService.status)}
+                      </span>
+                    </Link>
+                  ))}
+                  {!isLoading && afterServices.length === 0 && (
+                    <EmptyState text="진행 중인 A/S가 없습니다." />
+                  )}
+                </StatusCard>
+
+                <StatusCard title="미입고 거래처" count={pendingSuppliers.length} href="/inventory/receive">
+                  {pendingSuppliers.slice(0, 5).map((supplier) => (
+                    <Link
+                      key={supplier.id}
+                      href="/inventory/receive"
+                      onClick={() => setIsOpen(false)}
+                      className="flex items-center justify-between gap-3 border-b border-gray-100 px-1 py-3 last:border-b-0 hover:bg-gray-50"
+                    >
+                      <span className="truncate text-base font-semibold text-gray-900">
+                        {supplier.name}
+                      </span>
+                      <span className="text-sm font-semibold text-brand-600">
+                        {supplier.pendingQuantity.toLocaleString()}개 미입고
+                      </span>
+                    </Link>
+                  ))}
+                  {!isLoading && pendingSuppliers.length === 0 && (
+                    <EmptyState text="미입고 거래처가 없습니다." />
+                  )}
+                </StatusCard>
+
+                <StatusCard
+                  title="전달 메모"
+                  count={memos.length}
+                  action={
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setIsMemoHistoryOpen(true);
+                          void loadMemoHistory(0);
+                        }}
+                        className="cursor-pointer rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-semibold text-gray-600 hover:border-brand-200 hover:bg-gray-50 hover:text-brand-600"
+                      >
+                        이전 메모 기록
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setIsMemoFormOpen(true)}
+                        disabled={!memoStorageAvailable || isMemoFormOpen}
+                        className="cursor-pointer rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        메모 추가
+                      </button>
+                    </div>
+                  }
+                >
+                  {memos.slice(0, 5).map((memo) => (
+                    <div
+                      key={memo.id}
+                      className="flex items-start gap-3 border-b border-gray-100 px-1 py-3 last:border-b-0"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="break-words text-base text-gray-800">{memo.content}</p>
+                        <p className="mt-1 text-sm text-gray-400">
+                          {memo.author_name} · {formatMemoTime(memo.created_at)}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void resolveActorName().then((resolvedName) => {
+                            if (!resolvedName) {
+                              toast.error(
+                                "현재 근무자를 확인할 수 없습니다. 출근 기록을 확인해 주세요.",
+                              );
+                              return;
+                            }
+                            setMemoToComplete(memo);
+                          });
+                        }}
+                        className="cursor-pointer rounded-md border border-gray-200 bg-white px-2 py-1 text-sm font-semibold text-gray-500 hover:bg-gray-50"
+                      >
+                        완료
+                      </button>
+                    </div>
+                  ))}
+                  {!isLoading && memos.length === 0 && (
+                    <EmptyState
+                      text={
+                        memoStorageAvailable
+                          ? "등록된 전달 메모가 없습니다."
+                          : "전달 메모 DB 적용이 필요합니다."
+                      }
+                    />
+                  )}
+                  {isMemoFormOpen && (
+                    <div className="border-t border-gray-100 pt-3">
+                      <input
+                        type="text"
+                        value={memoInput}
+                        onChange={(event) => setMemoInput(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" && memoInput.trim()) {
+                            void addMemo();
+                          }
+                        }}
+                        autoFocus
+                        disabled={!memoStorageAvailable || isSavingMemo}
+                        placeholder="전달할 내용을 입력하세요"
+                        className="w-full min-w-0 rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-base text-gray-900 shadow-sm outline-none placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:bg-gray-100"
+                      />
+                      <div className="mt-2 flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setMemoInput("");
+                            setIsMemoFormOpen(false);
+                          }}
+                          disabled={isSavingMemo}
+                          className="cursor-pointer rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-semibold text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          취소
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void addMemo()}
+                          disabled={
+                            !memoInput.trim() ||
+                            isSavingMemo ||
+                            !memoStorageAvailable
+                          }
+                          className="cursor-pointer rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                          {isSavingMemo ? "등록 중" : "등록"}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </StatusCard>
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {memoToComplete && (
+        <div className="fixed inset-0 z-[2200] flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-gray-950/40" />
+          <section
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="complete-memo-title"
+            className="relative z-10 w-full max-w-md rounded-2xl bg-white p-5 shadow-2xl"
+          >
+            <h3 id="complete-memo-title" className="text-lg font-bold text-gray-900">
+              전달 메모 완료 처리
+            </h3>
+            <div className="mt-4 space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4">
+              <div>
+                <p className="text-xs font-semibold text-gray-500">내용</p>
+                <p className="mt-1 break-words text-sm text-gray-900">
+                  {memoToComplete.content}
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <p className="text-xs font-semibold text-gray-500">작성자</p>
+                  <p className="mt-1 text-sm font-semibold text-gray-800">
+                    {memoToComplete.author_name}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold text-gray-500">처리자</p>
+                  <p className="mt-1 text-sm font-semibold text-gray-800">
+                    {actorName}
+                  </p>
+                </div>
+              </div>
+            </div>
+            <p className="mt-4 text-sm font-medium text-gray-700">
+              완료 처리하시겠습니까?
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setMemoToComplete(null)}
+                className="cursor-pointer rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+              >
+                아니오
+              </button>
+              <button
+                type="button"
+                onClick={() => void completeMemo()}
+                className="cursor-pointer rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-600"
+              >
+                네
+              </button>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {isMemoHistoryOpen && (
+        <div className="fixed inset-0 z-[2200] flex items-center justify-center p-4">
+          <button
+            type="button"
+            aria-label="이전 메모 기록 닫기"
+            onClick={() => setIsMemoHistoryOpen(false)}
+            className="absolute inset-0 cursor-pointer bg-gray-950/45"
+          />
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="memo-history-title"
+            className="relative z-10 flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl"
+          >
+            <header className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+              <div>
+                <h3 id="memo-history-title" className="text-lg font-bold text-gray-900">
+                  이전 메모 기록
+                </h3>
+                <p className="mt-0.5 text-sm text-gray-500">
+                  완료 처리된 전달 메모 {memoHistoryCount.toLocaleString()}건
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsMemoHistoryOpen(false)}
+                aria-label="닫기"
+                className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full text-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+              >
+                ×
+              </button>
+            </header>
+            <div className="min-h-0 flex-1 overflow-y-auto p-5">
+              {memoHistory.map((memo) => (
+                <article
+                  key={memo.id}
+                  className="border-b border-gray-200 py-4 first:pt-0 last:border-b-0"
+                >
+                  <p className="break-words text-base text-gray-800">
+                    {memo.content}
+                  </p>
+                  <div className="mt-2 flex items-end justify-between gap-3">
+                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-500">
+                      <span>작성자 {memo.author_name}</span>
+                      <span>처리자 {memo.completed_by_name || "알 수 없음"}</span>
+                      {memo.completed_at && (
+                        <span>완료 {formatMemoTime(memo.completed_at)}</span>
+                      )}
+                    </div>
+                    {isAdmin && (
+                      <button
+                        type="button"
+                        onClick={() => void deleteCompletedMemo(memo)}
+                        className="shrink-0 cursor-pointer rounded-md border border-red-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-red-600 hover:bg-red-50"
+                      >
+                        삭제
+                      </button>
+                    )}
+                  </div>
+                </article>
+              ))}
+              {!isMemoHistoryLoading && memoHistory.length === 0 && (
+                <EmptyState text="완료된 전달 메모가 없습니다." />
+              )}
+              {memoHistory.length < memoHistoryCount && (
+                <div className="mt-4 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => void loadMemoHistory(memoHistory.length)}
+                    disabled={isMemoHistoryLoading}
+                    className="cursor-pointer rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isMemoHistoryLoading ? "불러오는 중" : "더 보기"}
+                  </button>
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      )}
+    </>
+  );
+}
+
+const StatusCard = ({
+  title,
+  count,
+  href,
+  action,
+  children,
+}: {
+  title: string;
+  count: number;
+  href?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <article className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+    <div className="flex items-center justify-between border-b border-gray-100 pb-3">
+      <div className="flex items-center gap-2">
+        <h3 className="text-base font-bold text-gray-900">{title}</h3>
+        <span className="rounded-full bg-brand-50 px-2.5 py-1 text-sm font-semibold text-brand-600">
+          {count}
+        </span>
+      </div>
+      {action ?? (href && (
+        <Link href={href} className="text-sm font-semibold text-gray-500 hover:text-brand-600">
+          전체 보기
+        </Link>
+      ))}
+    </div>
+    <div>{children}</div>
+  </article>
+);
+
+const EmptyState = ({ text }: { text: string }) => (
+  <p className="py-9 text-center text-base text-gray-400">{text}</p>
+);

--- a/src/app/(auth)/_components/Header/index.tsx
+++ b/src/app/(auth)/_components/Header/index.tsx
@@ -2,6 +2,7 @@ import Logo from './_components/Logo';
 import Nav from './_components/Nav';
 import UserInfo from './_components/UserInfo';
 import FullscreenButton from './_components/FullscreenButton';
+import PendingStatusButton from './_components/PendingStatusButton';
 
 const Header = () => {
   return (
@@ -16,6 +17,7 @@ const Header = () => {
 
           {/* 유저 정보 */}
           <div className="flex items-center gap-5 whitespace-nowrap">
+            <PendingStatusButton />
             <FullscreenButton />
             <UserInfo />
           </div>

--- a/src/app/(auth)/_components/HistoriesComponents/ChangeFields.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/ChangeFields.tsx
@@ -2,6 +2,7 @@ const fieldMap = {
   name: '이름',
   phone: '전화번호',
   gender: '성별',
+  is_stamp_eligible: '적립 대상',
   address: '주소지',
   note: '특이사항',
   customer_id: '고객 ID',
@@ -37,6 +38,10 @@ const ChangeFields = ({ jsonb }: { jsonb: Record<string, unknown> }) => {
     if (fieldName === 'gender') {
       if (value === 'male') return '남자';
       if (value === 'female') return '여자';
+    }
+
+    if (fieldName === 'is_stamp_eligible') {
+      return value === true ? '적립' : '미적립';
     }
 
     if (fieldName === 'item_type') {

--- a/src/app/(auth)/_components/HistoriesComponents/PaymentTypeLabel.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/PaymentTypeLabel.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
 import { PaymentTypeEnum, PaymentTypeEnumType } from '@/app/_enums/enums';
 
 const paymentTypeNameByValue = Object.values(PaymentTypeEnum).reduce(
@@ -9,6 +12,8 @@ const paymentTypeNameByValue = Object.values(PaymentTypeEnum).reduce(
 );
 
 const PaymentTypeLabel = ({ jsonb }: { jsonb: Record<string, unknown> }) => {
+  const [isSplitDetailOpen, setIsSplitDetailOpen] = useState(false);
+  const splitDetailRef = useRef<HTMLDivElement>(null);
   const splitPayments = Array.isArray(jsonb.payments)
     ? jsonb.payments.filter(
         (
@@ -24,21 +29,63 @@ const PaymentTypeLabel = ({ jsonb }: { jsonb: Record<string, unknown> }) => {
       )
     : [];
 
+  useEffect(() => {
+    if (!isSplitDetailOpen) return;
+
+    const closeOnOutsideClick = (event: PointerEvent) => {
+      if (
+        splitDetailRef.current &&
+        !splitDetailRef.current.contains(event.target as Node)
+      ) {
+        setIsSplitDetailOpen(false);
+      }
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsSplitDetailOpen(false);
+    };
+
+    document.addEventListener('pointerdown', closeOnOutsideClick);
+    document.addEventListener('keydown', closeOnEscape);
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsideClick);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [isSplitDetailOpen]);
+
   if (splitPayments.length >= 2) {
     return (
-      <div className="flex flex-col items-start gap-1">
-        {splitPayments.map((payment, index) => (
-          <span
-            key={`${payment.paymentType}-${index}`}
-            className="inline-flex items-center rounded-full bg-gray-100 px-1.5 py-1 text-xs font-medium text-gray-500"
-          >
-            {paymentTypeNameByValue[payment.paymentType]?.replace(
-              '이구베이프',
-              '',
-            )}{' '}
-            {payment.amount.toLocaleString('ko-KR')}원
-          </span>
-        ))}
+      <div ref={splitDetailRef} className="relative w-full">
+        <button
+          type="button"
+          aria-expanded={isSplitDetailOpen}
+          onClick={() => setIsSplitDetailOpen((current) => !current)}
+          className="flex h-7 w-full cursor-pointer items-center justify-center whitespace-nowrap rounded-full bg-gray-200 px-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-300"
+        >
+          분할결제 {splitPayments.length}건
+        </button>
+        {isSplitDetailOpen && (
+          <div className="absolute left-0 top-full z-30 mt-1.5 min-w-44 rounded-xl border border-gray-200 bg-white p-2.5 shadow-lg">
+          <p className="mb-2 text-xs font-semibold text-gray-700">결제 상세</p>
+          <div className="space-y-1.5">
+            {splitPayments.map((payment, index) => (
+              <div
+                key={`${payment.paymentType}-${index}`}
+                className="flex items-center justify-between gap-4 whitespace-nowrap text-xs"
+              >
+                <span className="text-gray-500">
+                  {paymentTypeNameByValue[payment.paymentType]?.replace(
+                    '이구베이프',
+                    '',
+                  )}
+                </span>
+                <span className="font-semibold text-gray-800">
+                  {payment.amount.toLocaleString('ko-KR')}원
+                </span>
+              </div>
+            ))}
+          </div>
+          </div>
+        )}
       </div>
     );
   }
@@ -52,7 +99,7 @@ const PaymentTypeLabel = ({ jsonb }: { jsonb: Record<string, unknown> }) => {
     : undefined;
 
   return (
-    <span className="inline-flex items-center rounded-full bg-gray-100 text-gray-500 text-xs font-medium px-1.5 py-1">
+    <span className="flex h-7 w-full items-center justify-center whitespace-nowrap rounded-full bg-gray-200 px-2 text-xs font-semibold text-gray-700">
       {paymentTypeName}
     </span>
   );

--- a/src/app/(auth)/_components/HistoriesComponents/StoreLabel.tsx
+++ b/src/app/(auth)/_components/HistoriesComponents/StoreLabel.tsx
@@ -23,7 +23,7 @@ const StoreLabel = ({ jsonb }: { jsonb: Record<string, unknown> }) => {
 
   return (
     <span
-      className={`inline-flex items-center rounded-full text-xs font-medium px-1.5 py-1 ${style}`}
+      className={`flex h-7 w-full items-center justify-center whitespace-nowrap rounded-full px-2 text-xs font-medium ${style}`}
     >
       {storeName}
     </span>

--- a/src/app/(auth)/_components/StampLogEditModal.tsx
+++ b/src/app/(auth)/_components/StampLogEditModal.tsx
@@ -113,6 +113,12 @@ const StampLogEditModal = ({
     target.is_stamp_eligible ?? true,
   );
   const [stampLog, setStampLog] = useState<StampLogValue | null>(null);
+  const [xCustomerName, setXCustomerName] = useState(
+    initialLogMeta?.xCustomerName ?? "",
+  );
+  const [xPhoneLastDigits, setXPhoneLastDigits] = useState(
+    initialLogMeta?.xPhoneLastDigits ?? "",
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [step, setStep] = useState<1 | 2 | 3>(2);
   const [formValidity, setFormValidity] = useState({
@@ -159,6 +165,38 @@ const StampLogEditModal = ({
       setIsSubmitting(false);
     }
   };
+
+  const xCustomerInfoFields = (
+    <div className="h-full rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <p className="mb-2 text-sm font-semibold text-gray-800">고객 정보</p>
+      <div className="grid grid-cols-2 gap-2">
+        <label className="min-w-0">
+          <input
+            type="text"
+            aria-label="이름"
+            value={xCustomerName}
+            onChange={(event) => setXCustomerName(event.target.value)}
+            placeholder="이름 입력"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+          />
+        </label>
+        <label className="min-w-0">
+          <input
+            type="text"
+            aria-label="핸드폰 뒷번호"
+            inputMode="numeric"
+            maxLength={4}
+            value={xPhoneLastDigits}
+            onChange={(event) =>
+              setXPhoneLastDigits(event.target.value.replace(/\D/g, "").slice(0, 4))
+            }
+            placeholder="뒷번호 4자리"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+          />
+        </label>
+      </div>
+    </div>
+  );
 
   return (
     <div className="relative flex max-h-[calc(90vh-2rem)] min-h-0 w-full flex-col">
@@ -234,24 +272,35 @@ const StampLogEditModal = ({
           step={step}
           customerMode={customerMode}
           customerAddress={target.address}
+          reservationSlot={
+            customerMode === "x" ? xCustomerInfoFields : undefined
+          }
+          xCustomerName={xCustomerName}
+          xPhoneLastDigits={xPhoneLastDigits}
           onChange={setStampLog}
           onValidityChange={setFormValidity}
         />
 
         {step === 3 && stampLog && (
           <div className="space-y-4">
-            <div
-              className={`grid grid-cols-2 gap-2 ${
-                customerMode === "x" ? "md:grid-cols-4" : "md:grid-cols-5"
-              }`}
-            >
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-5">
               {[
-                {
-                  label: "출고 방식",
-                  value: stampLog.logMeta.reservationDate
-                    ? `${stampLog.logMeta.reservationDate} 예약 출고`
-                    : "즉시 출고",
-                },
+                ...(customerMode === "x"
+                  ? [
+                      { label: "이름", value: xCustomerName.trim() },
+                      {
+                        label: "핸드폰 뒷번호",
+                        value: xPhoneLastDigits.trim(),
+                      },
+                    ]
+                  : [
+                      {
+                        label: "출고 방식",
+                        value: stampLog.logMeta.reservationDate
+                          ? `${stampLog.logMeta.reservationDate} 예약 출고`
+                          : "즉시 출고",
+                      },
+                    ]),
                 { label: "출고 매장", value: stampLog.storeLabel },
                 {
                   label: "수령 방식",
@@ -526,7 +575,10 @@ const StampLogEditModal = ({
                 disabled={
                   step === 1
                     ? !formValidity.hasCompletedBasicSequence
-                    : !formValidity.hasItems || !hasValidSplitPaymentAmounts
+                    : !formValidity.hasItems ||
+                      !hasValidSplitPaymentAmounts ||
+                      (customerMode === "x" &&
+                        (!xCustomerName.trim() || xPhoneLastDigits.length !== 4))
                 }
               >
                 다음
@@ -536,7 +588,12 @@ const StampLogEditModal = ({
             <Button
               size="sm"
               onClick={handleSubmit}
-              disabled={isSubmitting || !stampLog}
+              disabled={
+                isSubmitting ||
+                !stampLog ||
+                (customerMode === "x" &&
+                  (!xCustomerName.trim() || xPhoneLastDigits.length !== 4))
+              }
             >
               {isSubmitting ? "저장 중..." : "수정"}
             </Button>

--- a/src/app/(auth)/after-services/page.tsx
+++ b/src/app/(auth)/after-services/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import Button from '@/app/_components/Button';
@@ -27,7 +27,22 @@ const AfterServicesPage = () => {
     groupStatus?: 'received' | 'inProgress' | 'completed';
     searchTarget?: string;
     searchKeyword?: string;
-  }>({});
+  }>(() =>
+    searchParams.get('group') === 'inProgress'
+      ? { groupStatus: 'inProgress' }
+      : {},
+  );
+
+  useEffect(() => {
+    if (searchParams.get('group') === 'inProgress') {
+      setFilters((current) => ({
+        ...current,
+        groupStatus: 'inProgress',
+        status: undefined,
+      }));
+      setStatusValue('all');
+    }
+  }, [searchParams]);
 
   // 쿼리 파라미터에서 id 가져오기
   const selectedAfterServiceId = searchParams.get('id');

--- a/src/app/(auth)/customers/[id]/_components/StampSection.tsx
+++ b/src/app/(auth)/customers/[id]/_components/StampSection.tsx
@@ -104,11 +104,27 @@ const StampSection = ({
             logMeta?: StampLogMeta,
             _adjustDirection?: "add" | "remove",
             isReservation?: boolean,
+            targetCustomerId?: string,
+            shouldAddStampForSelectedCustomer?: boolean,
           ) => {
             if (isReservation) {
-              await handleReserve(modalNote, paymentType, amount, logMeta);
+              await handleReserve(
+                modalNote,
+                paymentType,
+                amount,
+                logMeta,
+                targetCustomerId,
+                shouldAddStampForSelectedCustomer,
+              );
             } else {
-              await handleAdd(modalNote, paymentType, amount, logMeta);
+              await handleAdd(
+                modalNote,
+                paymentType,
+                amount,
+                logMeta,
+                targetCustomerId,
+                shouldAddStampForSelectedCustomer,
+              );
             }
             close();
           }}
@@ -130,12 +146,20 @@ const StampSection = ({
     paymentType?: PaymentTypeEnumType["value"],
     amount: number = 0,
     logMeta?: StampLogMeta,
+    targetCustomerId?: string,
+    shouldAddStampForSelectedCustomer?: boolean,
   ) => {
     try {
       setIsLoading(true);
-      const effectiveAmount = customerMode === "x" ? 0 : amount;
+      const effectiveAmount = targetCustomerId
+        ? shouldAddStampForSelectedCustomer
+          ? amount
+          : 0
+        : customerMode === "x"
+          ? 0
+          : amount;
       await addStamp(
-        target.id,
+        targetCustomerId ?? target.id,
         effectiveAmount,
         memo ?? "",
         paymentType,
@@ -162,12 +186,20 @@ const StampSection = ({
     paymentType?: PaymentTypeEnumType["value"],
     amount: number = 0,
     logMeta?: StampLogMeta,
+    targetCustomerId?: string,
+    shouldAddStampForSelectedCustomer?: boolean,
   ) => {
     try {
       setIsLoading(true);
-      const effectiveAmount = customerMode === "x" ? 0 : amount;
+      const effectiveAmount = targetCustomerId
+        ? shouldAddStampForSelectedCustomer
+          ? amount
+          : 0
+        : customerMode === "x"
+          ? 0
+          : amount;
       await addReservationStamp(
-        target.id,
+        targetCustomerId ?? target.id,
         effectiveAmount,
         memo ?? "",
         paymentType,

--- a/src/app/(auth)/customers/_components/CustomerList/index.tsx
+++ b/src/app/(auth)/customers/_components/CustomerList/index.tsx
@@ -164,7 +164,9 @@ const CustomerList = ({
                     </td>
                     <td className="px-3 sm:px-6 py-2 sm:py-3 text-center whitespace-nowrap">
                       <span className="inline-flex items-center justify-center px-2.5 sm:px-3 py-0.5 sm:py-1 rounded-full text-xs sm:text-sm font-semibold bg-brand-100 text-brand-700">
-                        {stampCount}
+                        {customer.is_stamp_eligible === false
+                          ? "미적립"
+                          : stampCount}
                       </span>
                     </td>
                     <td className="px-3 sm:px-6 py-2 sm:py-3 whitespace-nowrap">

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -13,6 +13,10 @@ import { useModal } from "@/app/_contexts/ModalContext";
 import StampLogForm, { StampLogValue } from "./StampLogForm";
 import TargetCustomerCard from "./TargetCustomerCard";
 import { getCustomerMode } from "@/app/_domains/_customer/_utils/specialCustomer";
+import {
+  ExistingCustomerMatch,
+  findCustomersByNameAndPhoneLastDigits,
+} from "@/app/_domains/_customer/_services/customerService";
 
 const formatAmount = (value: number) => value.toLocaleString("ko-KR");
 
@@ -92,6 +96,8 @@ export default function StampConfirmModal({
     logMeta?: StampLogMeta,
     adjustDirection?: "add" | "remove",
     isReservation?: boolean,
+    targetCustomerId?: string,
+    shouldAddStampForSelectedCustomer?: boolean,
   ) => Promise<void> | void;
   onCancel: () => void;
 }) {
@@ -112,6 +118,18 @@ export default function StampConfirmModal({
   const [stampLog, setStampLog] = useState<StampLogValue | null>(null);
   const [isReservation, setIsReservation] = useState(false);
   const [reservationDate, setReservationDate] = useState("");
+  const [xCustomerName, setXCustomerName] = useState("");
+  const [xPhoneLastDigits, setXPhoneLastDigits] = useState("");
+  const [customerMatches, setCustomerMatches] = useState<
+    ExistingCustomerMatch[]
+  >([]);
+  const [selectedCustomer, setSelectedCustomer] =
+    useState<ExistingCustomerMatch | null>(null);
+  const [pendingCustomer, setPendingCustomer] =
+    useState<ExistingCustomerMatch | null>(null);
+  const [shouldAddStampForSelectedCustomer, setShouldAddStampForSelectedCustomer] =
+    useState(false);
+  const [isSearchingCustomer, setIsSearchingCustomer] = useState(false);
   const hasValidReservationDate =
     !isReservation || /^\d{1,2}\/\d{1,2}$/.test(reservationDate.trim());
   const hasValidSplitPaymentAmounts =
@@ -128,6 +146,41 @@ export default function StampConfirmModal({
   );
   const usesStandardSalesFlow =
     customerMode === "normal" || customerMode === "x";
+  const effectiveFormCustomerMode = selectedCustomer ? "normal" : customerMode;
+  const canSelectedCustomerAccrueStamp =
+    selectedCustomer?.is_stamp_eligible !== false;
+
+  useEffect(() => {
+    if (
+      customerMode !== "x" ||
+      !xCustomerName.trim() ||
+      xPhoneLastDigits.length !== 4
+    ) {
+      setCustomerMatches([]);
+      return;
+    }
+
+    let isActive = true;
+    const timer = window.setTimeout(async () => {
+      try {
+        setIsSearchingCustomer(true);
+        const matches = await findCustomersByNameAndPhoneLastDigits(
+          xCustomerName,
+          xPhoneLastDigits,
+        );
+        if (isActive) setCustomerMatches(matches);
+      } catch {
+        if (isActive) setCustomerMatches([]);
+      } finally {
+        if (isActive) setIsSearchingCustomer(false);
+      }
+    }, 300);
+
+    return () => {
+      isActive = false;
+      window.clearTimeout(timer);
+    };
+  }, [customerMode, xCustomerName, xPhoneLastDigits]);
 
   // 출고 이력 추가(mode === 'add') 전용 스텝 상태
   const [addStep, setAddStep] = useState<1 | 2 | 3>(
@@ -144,18 +197,21 @@ export default function StampConfirmModal({
   useEffect(() => {
     if (mode !== "add") return;
     setSize(
-      !usesStandardSalesFlow && addStep === 3
-        ? "max-w-xl"
-        : addStep >= 2
-          ? "max-w-6xl"
-          : "max-w-2xl",
+      addStep >= 2
+        ? (customerMode === "adjustment" || customerMode === "demo") &&
+          addStep === 3
+          ? "max-w-4xl"
+          : "max-w-6xl"
+        : "max-w-2xl",
     );
-  }, [mode, addStep, usesStandardSalesFlow, setSize]);
+  }, [mode, addStep, customerMode, setSize]);
 
   const title =
     mode === "add"
       ? customerMode === "adjustment"
         ? "재고조정 (입고 또는 출고)"
+        : customerMode === "demo"
+          ? "시연용 처리"
         : isReservation
           ? "출고 예약 추가"
           : "출고 이력 추가"
@@ -244,6 +300,8 @@ export default function StampConfirmModal({
           },
           undefined,
           isReservation,
+          selectedCustomer?.id,
+          selectedCustomer ? shouldAddStampForSelectedCustomer : undefined,
         );
       } else if (mode === "adjust") {
         await onConfirm(note, undefined, amount, undefined, adjustDirection);
@@ -301,6 +359,74 @@ export default function StampConfirmModal({
           <div aria-hidden="true" className="h-11" />
         )}
       </div>
+    </div>
+  );
+
+  const xCustomerInfoFields = (
+    <div className="h-full rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <p className="mb-2 text-sm font-semibold text-gray-800">고객 정보</p>
+      <div className="grid grid-cols-2 gap-2">
+        <label className="min-w-0">
+          <input
+            type="text"
+            aria-label="이름"
+            value={xCustomerName}
+            onChange={(event) => {
+              setXCustomerName(event.target.value);
+              setSelectedCustomer(null);
+            }}
+            placeholder="이름 입력"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+          />
+        </label>
+        <label className="min-w-0">
+          <input
+            type="text"
+            aria-label="핸드폰 뒷번호"
+            inputMode="numeric"
+            maxLength={4}
+            value={xPhoneLastDigits}
+            onChange={(event) => {
+              setXPhoneLastDigits(
+                event.target.value.replace(/\D/g, "").slice(0, 4),
+              );
+              setSelectedCustomer(null);
+            }}
+            placeholder="뒷번호 4자리"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+          />
+        </label>
+      </div>
+      {isSearchingCustomer && (
+        <p className="mt-2 text-xs text-gray-500">기존 고객을 확인하고 있습니다.</p>
+      )}
+      {!isSearchingCustomer && customerMatches.length > 0 && (
+        <div className="mt-2 space-y-1.5 border-t border-gray-200 pt-2">
+          <p className="text-xs font-semibold text-brand-700">
+            일치하는 기존 고객이 있습니다.
+          </p>
+          {customerMatches.map((customer) => (
+            <div
+              key={customer.id}
+              className="flex items-center justify-between gap-2 rounded-lg bg-white px-2.5 py-2 text-xs"
+            >
+              <span className="min-w-0 truncate font-medium text-gray-700">
+                {customer.name} · {customer.phone}
+              </span>
+              <Button
+                type="button"
+                size="xs"
+                variant={selectedCustomer?.id === customer.id ? "primary" : "gray"}
+                onClick={() => setPendingCustomer(customer)}
+              >
+                {selectedCustomer?.id === customer.id
+                  ? "변경됨"
+                  : "이 고객으로 변경"}
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 
@@ -375,10 +501,10 @@ export default function StampConfirmModal({
       {/* 대상 고객: 모든 스텝에서 고정 노출 */}
       {!(!usesStandardSalesFlow && addStep === 3) && (
         <TargetCustomerCard
-          name={target.name}
-          phone={target.phone}
-          address={target.address}
-          note={target.note}
+          name={selectedCustomer?.name ?? target.name}
+          phone={selectedCustomer?.phone ?? target.phone}
+          address={selectedCustomer?.address ?? target.address}
+          note={selectedCustomer?.note ?? target.note}
           className="mr-1 mb-4 shrink-0"
         />
       )}
@@ -389,9 +515,17 @@ export default function StampConfirmModal({
           step={addStep}
           onChange={setStampLog}
           onValidityChange={setFormValidity}
-          reservationSlot={reservationToggle}
-          customerMode={customerMode}
-          isStampAmountEditable={customerMode !== "x"}
+          reservationSlot={
+            effectiveFormCustomerMode === "x"
+              ? xCustomerInfoFields
+              : reservationToggle
+          }
+          xCustomerName={xCustomerName}
+          xPhoneLastDigits={xPhoneLastDigits}
+          customerMode={effectiveFormCustomerMode}
+          isStampAmountEditable={
+            effectiveFormCustomerMode !== "x" && canSelectedCustomerAccrueStamp
+          }
           currentStampCount={stampCount}
           customerAddress={target.address}
         />
@@ -401,17 +535,23 @@ export default function StampConfirmModal({
             {stampLog && usesStandardSalesFlow && (
               <>
                 <div
-                  className={`grid grid-cols-2 gap-2 ${
-                    customerMode === "x" ? "md:grid-cols-4" : "md:grid-cols-5"
-                  }`}
+                  className="grid grid-cols-2 gap-2 md:grid-cols-5"
                 >
                   {[
-                    {
+                    ...(effectiveFormCustomerMode === "x"
+                      ? [
+                          { label: "이름", value: xCustomerName.trim() },
+                          {
+                            label: "핸드폰 뒷번호",
+                            value: xPhoneLastDigits.trim(),
+                          },
+                        ]
+                      : [{
                       label: "출고 방식",
                       value: isReservation
                         ? `${reservationDate} 예약 출고`
                         : "즉시 출고",
-                    },
+                      }]),
                     { label: "출고 매장", value: stampLog.storeLabel },
                     {
                       label: "수령 방식",
@@ -427,7 +567,7 @@ export default function StampConfirmModal({
                                 : "배달대행"
                             : "매장방문",
                     },
-                    ...(customerMode === "x"
+                    ...(effectiveFormCustomerMode === "x"
                       ? []
                       : [
                           {
@@ -524,11 +664,21 @@ export default function StampConfirmModal({
                 </span>
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full min-w-[760px] table-fixed text-sm">
+                <table
+                  className={`w-full table-fixed text-sm ${
+                    customerMode === "adjustment" || customerMode === "demo"
+                      ? "min-w-[520px]"
+                      : "min-w-[760px]"
+                  }`}
+                >
                   <thead className="bg-gray-50 text-xs font-semibold text-gray-600">
                     <tr className="border-b border-gray-200">
                       <th className="w-[6%] px-2 py-2 text-center">번호</th>
-                      <th className="w-[33%] px-2 py-2 text-left">품목명</th>
+                      <th
+                        className={`${customerMode === "adjustment" ? "w-[47%]" : "w-[33%]"} px-2 py-2 text-left`}
+                      >
+                        품목명
+                      </th>
                       <th className="w-[13%] px-2 py-2 text-center">
                         품목종류
                       </th>
@@ -536,8 +686,17 @@ export default function StampConfirmModal({
                         출고 유형
                       </th>
                       <th className="w-[8%] px-2 py-2 text-center">수량</th>
-                      <th className="w-[13%] px-2 py-2 text-right">단가</th>
-                      <th className="w-[14%] px-3 py-2 text-right">소계</th>
+                      {customerMode !== "adjustment" &&
+                        customerMode !== "demo" && (
+                        <>
+                          <th className="w-[13%] px-2 py-2 text-right">
+                            단가
+                          </th>
+                          <th className="w-[14%] px-3 py-2 text-right">
+                            소계
+                          </th>
+                        </>
+                      )}
                     </tr>
                   </thead>
                   <tbody>
@@ -578,17 +737,22 @@ export default function StampConfirmModal({
                           <td className="px-2 py-2 text-center font-medium text-gray-800">
                             {item.quantity}개
                           </td>
-                          <td className="px-2 py-2 text-right text-gray-700">
-                            {formatAmount(
-                              typeof item.adjustedUnitPrice === "number"
-                                ? item.adjustedUnitPrice
-                                : item.unitPrice,
-                            )}
-                            원
-                          </td>
-                          <td className="px-3 py-2 text-right font-medium text-gray-900">
-                            {formatAmount(item.amount)}원
-                          </td>
+                          {customerMode !== "adjustment" &&
+                            customerMode !== "demo" && (
+                            <>
+                              <td className="px-2 py-2 text-right text-gray-700">
+                                {formatAmount(
+                                  typeof item.adjustedUnitPrice === "number"
+                                    ? item.adjustedUnitPrice
+                                    : item.unitPrice,
+                                )}
+                                원
+                              </td>
+                              <td className="px-3 py-2 text-right font-medium text-gray-900">
+                                {formatAmount(item.amount)}원
+                              </td>
+                            </>
+                          )}
                         </tr>
                       );
                     })}
@@ -770,6 +934,14 @@ export default function StampConfirmModal({
                     toast.error("예약 날짜를 7/19 형식으로 입력해 주세요.");
                     return;
                   }
+                  if (
+                    addStep === 2 &&
+                    effectiveFormCustomerMode === "x" &&
+                    (!xCustomerName.trim() || xPhoneLastDigits.length !== 4)
+                  ) {
+                    toast.error("이름과 핸드폰 뒷번호 4자리를 입력해 주세요.");
+                    return;
+                  }
                   if (addStep === 2 && stampLog?.logMeta.payments?.length) {
                     if (
                       stampLog.logMeta.payments.some(
@@ -809,6 +981,60 @@ export default function StampConfirmModal({
           )}
         </div>
       </div>
+      {pendingCustomer && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center rounded-xl bg-gray-900/25 p-4">
+          <div className="w-full max-w-sm rounded-xl border border-gray-200 bg-white p-5 shadow-xl">
+            <h3 className="text-base font-semibold text-gray-900">
+              {pendingCustomer.is_stamp_eligible === false
+                ? "미적립 대상 고객입니다."
+                : "스탬프를 추가하시겠습니까?"}
+            </h3>
+            <p className="mt-2 text-sm text-gray-600">
+              {pendingCustomer.name} · {pendingCustomer.phone} 고객으로 변경합니다.
+            </p>
+            <div
+              className={`mt-5 grid gap-2 ${
+                pendingCustomer.is_stamp_eligible === false
+                  ? "grid-cols-2"
+                  : "grid-cols-3"
+              }`}
+            >
+              <Button
+                type="button"
+                variant="gray"
+                onClick={() => setPendingCustomer(null)}
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                variant="gray"
+                onClick={() => {
+                  setSelectedCustomer(pendingCustomer);
+                  setShouldAddStampForSelectedCustomer(false);
+                  setPendingCustomer(null);
+                  setAddStep(2);
+                }}
+              >
+                미적립
+              </Button>
+              {pendingCustomer.is_stamp_eligible !== false && (
+                <Button
+                  type="button"
+                  onClick={() => {
+                    setSelectedCustomer(pendingCustomer);
+                    setShouldAddStampForSelectedCustomer(true);
+                    setPendingCustomer(null);
+                    setAddStep(1);
+                  }}
+                >
+                  적립
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -122,6 +122,8 @@ export default function StampLogForm({
   step,
   onValidityChange,
   reservationSlot,
+  xCustomerName,
+  xPhoneLastDigits,
   customerMode = "normal",
   currentStampCount = 0,
   customerAddress,
@@ -153,6 +155,8 @@ export default function StampLogForm({
   }) => void;
   /** step 모드에서 2번 스텝의 출고 특이사항 입력 오른쪽에 함께 렌더링할 요소 (예: 출고 예약 토글) */
   reservationSlot?: React.ReactNode;
+  xCustomerName?: string;
+  xPhoneLastDigits?: string;
   customerMode?: CustomerMode;
   currentStampCount?: number;
   customerAddress?: string | null;
@@ -518,6 +522,12 @@ export default function StampLogForm({
       storeName,
       totalAmount: finalAmount,
       extraNote: extraNote.trim() || undefined,
+      xCustomerName:
+        customerMode === "x" ? xCustomerName?.trim() || undefined : undefined,
+      xPhoneLastDigits:
+        customerMode === "x"
+          ? xPhoneLastDigits?.trim() || undefined
+          : undefined,
       deliveryMethod,
       deliveryType:
         deliveryMethod === "delivery" ? deliveryType || undefined : undefined,
@@ -616,6 +626,9 @@ export default function StampLogForm({
     discountType,
     discountLine,
     extraNote,
+    xCustomerName,
+    xPhoneLastDigits,
+    customerMode,
     paymentMode,
     splitPayments,
     hasValidPayment,
@@ -727,7 +740,7 @@ export default function StampLogForm({
               ? `재고조정-출고${optionalOperationMemo ? `,${optionalOperationMemo}` : ""}`
               : ""
           : isExchange
-            ? `${exchangeLabel}${exchangeMemo.trim() ? `(${exchangeMemo.trim()})` : ""}`
+            ? `${exchangeLabel}${exchangeMemo.trim() ? `,${exchangeMemo.trim()}` : ""}`
             : remarkType === "service"
               ? `서비스${customRemark.trim() ? `(${customRemark.trim()})` : ""}`
               : remarkType === "custom"
@@ -822,13 +835,26 @@ export default function StampLogForm({
         : "0",
     );
     setPriceAdjustMemo("");
+    setOperationMemo("");
 
-    if (line.inventoryAction === "exchange_in") {
+    if (line.inventoryAction === "adjustment_in") {
+      setRemarkType("adjustment_in");
+      setOperationMemo(
+        line.remark?.replace(/^재고조정-입고,?/, "").trim() ?? "",
+      );
+    } else if (line.inventoryAction === "adjustment_out") {
+      setRemarkType("adjustment_out");
+      setOperationMemo(
+        line.remark?.replace(/^재고조정-출고,?/, "").trim() ?? "",
+      );
+    } else if (line.inventoryAction === "exchange_in") {
       setRemarkType("exchange_in");
-      setExchangeMemo(line.remark?.match(/^교환입고\((.*)\)$/)?.[1] ?? "");
+      const match = line.remark?.match(/^교환입고(?:,(.*)|\((.*)\))$/);
+      setExchangeMemo(match?.[1] ?? match?.[2] ?? "");
     } else if (line.inventoryAction === "exchange_out") {
       setRemarkType("exchange_out");
-      setExchangeMemo(line.remark?.match(/^교환출고\((.*)\)$/)?.[1] ?? "");
+      const match = line.remark?.match(/^교환출고(?:,(.*)|\((.*)\))$/);
+      setExchangeMemo(match?.[1] ?? match?.[2] ?? "");
     } else if (typeof line.adjustedUnitPrice === "number") {
       setRemarkType("price_adjust");
       setPriceAdjustMemo(
@@ -1443,9 +1469,16 @@ export default function StampLogForm({
     <div className="grid grid-cols-1 gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 lg:grid-cols-2 lg:items-stretch">
       <div className="grid gap-2 sm:grid-cols-[minmax(0,2fr)_minmax(270px,1fr)]">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            품목 선택 <span className="text-rose-600">*</span>
-          </label>
+          <div className="mb-1 flex items-center gap-2">
+            <label className="block text-sm font-medium text-gray-700">
+              품목 선택 <span className="text-rose-600">*</span>
+            </label>
+            {editingLineId && (
+              <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600">
+                선택 품목 수정 중
+              </span>
+            )}
+          </div>
           <div ref={itemSearchRef} className="relative">
             <div className="relative">
               <svg
@@ -1734,16 +1767,30 @@ export default function StampLogForm({
         <p className="text-sm text-gray-400">추가된 품목이 없습니다.</p>
       ) : (
         <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
-          <table className="w-full min-w-[820px] table-fixed text-sm">
+          <table
+            className={`w-full table-fixed text-sm ${
+              customerMode === "adjustment" || customerMode === "demo"
+                ? "min-w-[650px]"
+                : "min-w-[820px]"
+            }`}
+          >
             <thead className="bg-gray-50 text-xs font-semibold text-gray-600">
               <tr className="border-b border-gray-200">
                 <th className="w-[5%] px-2 py-2 text-center">번호</th>
-                <th className="w-[29%] px-2 py-2 text-left">품목명</th>
+                <th
+                  className={`${customerMode === "adjustment" ? "w-[39%]" : "w-[29%]"} px-2 py-2 text-left`}
+                >
+                  품목명
+                </th>
                 <th className="w-[11%] px-2 py-2 text-center">품목종류</th>
                 <th className="w-[10%] px-2 py-2 text-center">출고 유형</th>
                 <th className="w-[7%] px-2 py-2 text-center">수량</th>
-                <th className="w-[10%] px-2 py-2 text-right">단가</th>
-                <th className="w-[10%] px-2 py-2 text-right">소계</th>
+                {customerMode !== "adjustment" && customerMode !== "demo" && (
+                  <>
+                    <th className="w-[10%] px-2 py-2 text-right">단가</th>
+                    <th className="w-[10%] px-2 py-2 text-right">소계</th>
+                  </>
+                )}
                 <th className="w-[18%] px-3 py-2 text-center">작업</th>
               </tr>
             </thead>
@@ -1782,17 +1829,22 @@ export default function StampLogForm({
                   <td className="px-2 py-2 text-center font-medium text-gray-800">
                     {line.quantity}개
                   </td>
-                  <td className="px-2 py-2 text-right text-gray-700">
-                    {formatAmount(
-                      typeof line.adjustedUnitPrice === "number"
-                        ? line.adjustedUnitPrice
-                        : line.unitPrice,
-                    )}
-                    원
-                  </td>
-                  <td className="px-2 py-2 text-right font-medium text-gray-900">
-                    {formatAmount(line.amount)}원
-                  </td>
+                  {customerMode !== "adjustment" &&
+                    customerMode !== "demo" && (
+                    <>
+                      <td className="px-2 py-2 text-right text-gray-700">
+                        {formatAmount(
+                          typeof line.adjustedUnitPrice === "number"
+                            ? line.adjustedUnitPrice
+                            : line.unitPrice,
+                        )}
+                        원
+                      </td>
+                      <td className="px-2 py-2 text-right font-medium text-gray-900">
+                        {formatAmount(line.amount)}원
+                      </td>
+                    </>
+                  )}
                   <td className="px-3 py-2">
                     <div className="flex items-center justify-center gap-1">
                       <Button

--- a/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
@@ -35,6 +35,15 @@ const StampHistoryItem = ({
   const { copyLogToClipboard } = useCopy();
   const isSplitPayment =
     Array.isArray(log.jsonb?.payments) && log.jsonb.payments.length >= 2;
+  const hasTransactionTag = Boolean(
+    log.jsonb?.discount ||
+      (typeof log.jsonb?.deliveryFee === "number" &&
+        log.jsonb.deliveryFee > 0) ||
+      log.jsonb?.deliveryType === "self" ||
+      log.jsonb?.deliveryType === "customer_quick" ||
+      (typeof log.jsonb?.reservationDate === "string" &&
+        log.jsonb.reservationDate.trim()),
+  );
   const hasSpecialCustomer =
     Boolean(log.customers?.name) &&
     isSpecialCustomer(log.customers.name, log.customers.phone);
@@ -62,7 +71,7 @@ const StampHistoryItem = ({
   ) : null;
 
   return (
-    <div className="grid grid-cols-[125px_88px_minmax(260px,1fr)_115px_auto] items-center gap-2 whitespace-nowrap rounded-lg border border-brand-50 p-2.5 text-xs transition-colors hover:bg-brand-50/30 sm:px-2 sm:py-4 sm:text-sm">
+    <div className="grid grid-cols-[125px_128px_minmax(260px,1fr)_115px_auto] items-center gap-2 whitespace-nowrap rounded-lg border border-brand-50 p-2.5 text-xs transition-colors hover:bg-brand-50/30 sm:px-2 sm:py-4 sm:text-sm">
       <div className="flex min-w-0 self-center flex-col items-center text-center">
         {!isCustomerRemark && !isCouponUse && (
           <div>
@@ -82,7 +91,7 @@ const StampHistoryItem = ({
         />
       </div>
 
-      <div className="ml-2 flex min-w-0 self-center flex-col items-start gap-1">
+      <div className="ml-2 flex min-w-0 self-center flex-col items-stretch gap-1.5">
         {customerBadge}
         {log.jsonb && "storeName" in log.jsonb && (
           <StoreLabel jsonb={log.jsonb} />
@@ -92,7 +101,7 @@ const StampHistoryItem = ({
         )}
         {typeof log.jsonb?.totalAmount === "number" &&
           log.jsonb.totalAmount > 0 && (
-            <span className="inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 text-xs font-semibold px-2 py-1">
+            <span className="flex h-7 w-full items-center justify-center whitespace-nowrap rounded-full bg-emerald-100 px-2 text-xs font-semibold text-emerald-700">
               {log.jsonb.totalAmount.toLocaleString("ko-KR")}원
             </span>
           )}
@@ -106,7 +115,13 @@ const StampHistoryItem = ({
           <div className="min-w-0 flex-1 break-words whitespace-normal text-xs text-gray-600 sm:text-sm">
             <p className="whitespace-pre-line">
               {log.note ? (
-                `${isSplitPayment ? "분할결제) " : ""}${log.note}`
+                `${
+                  isSplitPayment
+                    ? hasTransactionTag
+                      ? "분할결제,"
+                      : "분할결제) "
+                    : ""
+                }${log.note}`
               ) : (
                 <span className="text-gray-400"> - </span>
               )}
@@ -115,6 +130,18 @@ const StampHistoryItem = ({
               log.jsonb.extraNote.trim() && (
                 <p className="mt-1 italic text-gray-400">
                   출고 특이사항: &quot;{log.jsonb.extraNote.trim()}&quot;
+                </p>
+              )}
+            {typeof log.jsonb?.xCustomerName === "string" &&
+              log.jsonb.xCustomerName.trim() && (
+                <p className="mt-1 italic text-gray-400">
+                  이름: {log.jsonb.xCustomerName.trim()}
+                </p>
+              )}
+            {typeof log.jsonb?.xPhoneLastDigits === "string" &&
+              log.jsonb.xPhoneLastDigits.trim() && (
+                <p className="mt-1 italic text-gray-400">
+                  핸드폰 뒷번호: {log.jsonb.xPhoneLastDigits.trim()}
                 </p>
               )}
             {(log.jsonb?.deliveryMethod === "parcel" ||

--- a/src/app/(auth)/histories/page.tsx
+++ b/src/app/(auth)/histories/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import StampHistories from './_components/StampHistories';
 import { LogCategoryEnum, LogCategoryEnumType } from '@/app/_enums/enums';
 import Button from '@/app/_components/Button';
@@ -8,9 +9,18 @@ import CustomerHistories from './_components/CustomerHistories';
 // import RemarkHistories from './_components/RemarkHistories';
 
 export default function HistoriesPage() {
+  const searchParams = useSearchParams();
   const [logType, setLogType] = useState<LogCategoryEnumType['value']>(
-    LogCategoryEnum.STAMP.value,
+    searchParams.get('tab') === 'reservation'
+      ? LogCategoryEnum.RESERVATION.value
+      : LogCategoryEnum.STAMP.value,
   );
+
+  useEffect(() => {
+    if (searchParams.get('tab') === 'reservation') {
+      setLogType(LogCategoryEnum.RESERVATION.value);
+    }
+  }, [searchParams]);
 
   return (
     <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-10 mb-10">

--- a/src/app/(auth)/product-search/page.tsx
+++ b/src/app/(auth)/product-search/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Dropdown, DropdownOption } from '@/app/_components/Dropdown';
 import Loading from '@/app/_components/Loading';
@@ -11,6 +11,12 @@ import {
   liquidCategorySettingKey,
 } from '@/app/_domains/_item/_services/productSearchCategoryService';
 import LiquidCategorySettingsModal from './_components/LiquidCategorySettingsModal';
+import {
+  getProductSearchColumnSettings,
+  productSearchColumnSettingKey,
+  saveProductSearchColumnSettings,
+} from '@/app/_domains/_item/_services/productSearchColumnSettingService';
+import toast from 'react-hot-toast';
 
 type SearchMode = 'liquid' | 'other';
 type UsageFilter = 'all' | 'used' | 'unused';
@@ -155,6 +161,8 @@ export default function ProductSearchPage() {
   });
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [columnEditing, setColumnEditing] = useState(false);
+  const [isSavingColumnWidths, setIsSavingColumnWidths] = useState(false);
+  const hasAppliedSharedColumnWidths = useRef(false);
   const [columnWidthSnapshot, setColumnWidthSnapshot] = useState<Record<
     SearchMode,
     Record<ProductColumnKey, number>
@@ -181,6 +189,26 @@ export default function ProductSearchPage() {
     queryFn: getLiquidSearchCategoryIds,
     retry: false,
   });
+  const columnSettingQuery = useQuery({
+    queryKey: productSearchColumnSettingKey,
+    queryFn: getProductSearchColumnSettings,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (!columnSettingQuery.data || hasAppliedSharedColumnWidths.current) return;
+    hasAppliedSharedColumnWidths.current = true;
+    setColumnWidthsByMode((current) => ({
+      liquid: {
+        ...current.liquid,
+        ...columnSettingQuery.data.liquid,
+      },
+      other: {
+        ...current.other,
+        ...columnSettingQuery.data.other,
+      },
+    }));
+  }, [columnSettingQuery.data]);
   const activeSearch = searchValues[mode];
   const liquidCategoryIds = useMemo(
     () => new Set(liquidCategoryQuery.data ?? []),
@@ -266,13 +294,29 @@ export default function ProductSearchPage() {
     });
     setColumnEditing(true);
   };
-  const saveColumnWidths = () => {
-    window.localStorage.setItem(
-      `product-search-column-widths-${mode}`,
-      JSON.stringify(columnWidths),
-    );
-    setColumnWidthSnapshot(null);
-    setColumnEditing(false);
+  const saveColumnWidths = async () => {
+    try {
+      setIsSavingColumnWidths(true);
+      await saveProductSearchColumnSettings(mode, columnWidths);
+      window.localStorage.setItem(
+        `product-search-column-widths-${mode}`,
+        JSON.stringify(columnWidths),
+      );
+      setColumnWidthSnapshot(null);
+      setColumnEditing(false);
+      toast.success('표 너비를 공통 설정으로 저장했습니다.');
+    } catch (error) {
+      console.error('Failed to save shared column widths:', error);
+      window.localStorage.setItem(
+        `product-search-column-widths-${mode}`,
+        JSON.stringify(columnWidths),
+      );
+      setColumnWidthSnapshot(null);
+      setColumnEditing(false);
+      toast.error('공통 DB 미적용으로 이 브라우저에만 임시 저장했습니다.');
+    } finally {
+      setIsSavingColumnWidths(false);
+    }
   };
   const cancelColumnEditing = () => {
     if (columnWidthSnapshot) setColumnWidthsByMode(columnWidthSnapshot);
@@ -570,10 +614,11 @@ export default function ProductSearchPage() {
               <>
                 <button
                   type="button"
-                  onClick={saveColumnWidths}
+                  onClick={() => void saveColumnWidths()}
+                  disabled={isSavingColumnWidths}
                   className="min-h-9 rounded-lg bg-brand-500 px-3 text-xs font-semibold text-white shadow-sm hover:bg-brand-600"
                 >
-                  변경 값 저장
+                  {isSavingColumnWidths ? '저장 중' : '변경 값 저장'}
                 </button>
                 <button
                   type="button"

--- a/src/app/(auth)/work-journal/_components/AttendanceRecordModal.tsx
+++ b/src/app/(auth)/work-journal/_components/AttendanceRecordModal.tsx
@@ -404,8 +404,8 @@ export default function AttendanceRecordModal({
           </div>
 
           {step === 1 ? (
-            <div className="space-y-4">
-              <section className="rounded-xl bg-gray-50 p-4">
+            <div className="space-y-5 rounded-xl border border-gray-200 bg-gray-50/70 p-4">
+              <section>
                 <p className="mb-2 text-xs font-bold text-brand-600">
                   근무 날짜
                 </p>
@@ -419,21 +419,21 @@ export default function AttendanceRecordModal({
                 />
               </section>
 
-              <div className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-gray-50 p-3 sm:flex-row sm:items-stretch">
-                <div className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:min-w-0 sm:flex-1">
-                  <p className="mb-1 text-xs font-semibold text-gray-600">
+              <div className="grid gap-3 border-t border-gray-200 pt-4 sm:grid-cols-[minmax(0,1fr)_140px_auto] sm:items-end">
+                <div className="min-w-0">
+                  <p className="mb-1.5 text-xs font-semibold text-gray-600">
                     근무자 이름
                   </p>
                   <Dropdown controlledValue={workerName}>
-                    <Dropdown.Trigger compact>
+                    <Dropdown.Trigger neutral>
                       {workerName || "선택"}
                     </Dropdown.Trigger>
-                    <Dropdown.Content compact>
+                    <Dropdown.Content neutral>
                       {workerNames.map((name) => (
                         <Dropdown.Item
                           key={name}
                           option={{ value: name, label: name }}
-                          compact
+                          neutral
                           onSelect={(selected: DropdownOption) => {
                             setWorkerName(String(selected.value));
                             setPin("");
@@ -444,9 +444,8 @@ export default function AttendanceRecordModal({
                     </Dropdown.Content>
                   </Dropdown>
                 </div>
-                <div className="hidden w-px shrink-0 self-stretch bg-gray-300 sm:block" />
-                <label className="flex w-full flex-col rounded-xl border border-gray-200 bg-gray-50/70 p-2.5 sm:w-[150px] sm:shrink-0">
-                  <span className="mb-1 text-xs font-semibold text-gray-600">
+                <label className="block">
+                  <span className="mb-1.5 block text-xs font-semibold text-gray-600">
                     개인 PIN
                   </span>
                   <input
@@ -459,23 +458,22 @@ export default function AttendanceRecordModal({
                       resetVerification();
                     }}
                     placeholder="4자리"
-                    className="h-9 w-full rounded-lg border border-gray-300 bg-white px-2 text-center text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+                    className="h-10 w-full rounded-lg border border-gray-300 bg-white px-2 text-center text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
                   />
                 </label>
-                <div className="hidden w-px shrink-0 self-stretch bg-gray-300 sm:block" />
                 <Button
                   type="button"
                   size="sm"
                   onClick={handleVerify}
                   disabled={verifying}
-                  className="h-9 min-w-16 self-center px-3"
+                  className="h-10 w-full px-4 sm:w-auto"
                 >
                   {verifying ? "확인 중" : "조회"}
                 </Button>
               </div>
 
               <section className="border-t border-gray-200 pt-4">
-                <p className="mb-2 text-sm font-semibold text-gray-700">
+                <p className="mb-2 text-xs font-semibold text-gray-600">
                   출근/퇴근 선택
                 </p>
                 <div className="grid grid-cols-2 gap-2">
@@ -483,10 +481,10 @@ export default function AttendanceRecordModal({
                     type="button"
                     disabled={!verified}
                     onClick={() => selectMode("start")}
-                    className={`h-11 cursor-pointer rounded-lg border font-semibold transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                    className={`h-12 cursor-pointer rounded-lg border text-sm font-semibold shadow-sm transition disabled:cursor-not-allowed disabled:opacity-40 ${
                       mode === "start"
                         ? "border-brand-500 bg-brand-500 text-white"
-                        : "border-gray-300 bg-white text-gray-600 hover:border-brand-300"
+                        : "border-gray-300 bg-white text-gray-700 hover:border-brand-300 hover:bg-brand-50/40"
                     }`}
                   >
                     출근
@@ -495,10 +493,10 @@ export default function AttendanceRecordModal({
                     type="button"
                     disabled={!verified}
                     onClick={() => selectMode("end")}
-                    className={`h-11 cursor-pointer rounded-lg border font-semibold transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                    className={`h-12 cursor-pointer rounded-lg border text-sm font-semibold shadow-sm transition disabled:cursor-not-allowed disabled:opacity-40 ${
                       mode === "end"
                         ? "border-brand-500 bg-brand-500 text-white"
-                        : "border-gray-300 bg-white text-gray-600 hover:border-brand-300"
+                        : "border-gray-300 bg-white text-gray-700 hover:border-brand-300 hover:bg-brand-50/40"
                     }`}
                   >
                     퇴근

--- a/src/app/_components/Dropdown/index.tsx
+++ b/src/app/_components/Dropdown/index.tsx
@@ -202,9 +202,11 @@ export const useDropdown = () => {
 const DropdownTrigger = ({
   children,
   compact = false,
+  neutral = false,
 }: {
   children: React.ReactNode;
   compact?: boolean;
+  neutral?: boolean;
 }) => {
   const {
     toggleDropdown,
@@ -241,15 +243,19 @@ const DropdownTrigger = ({
       onClick={disabled ? undefined : toggleDropdown}
       onKeyDown={handleKeyDown}
       disabled={disabled}
-      className={`flex w-full items-center justify-between gap-2 rounded-lg border text-left shadow-sm outline-none transition-colors focus:border-brand-500 focus:ring-2 focus:ring-brand-500 ${
+      className={`flex w-full items-center justify-between gap-2 rounded-lg border text-left shadow-sm outline-none transition-colors focus:ring-2 ${
         compact
           ? 'h-11 border-gray-300 bg-white px-2.5 text-xs font-semibold text-gray-700'
+          : neutral
+            ? 'border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 focus:border-gray-400 focus:ring-gray-200 sm:px-6 sm:py-2 sm:text-base'
           : 'border-brand-200 bg-white/70 px-3 py-1.5 text-xs font-medium text-brand-700 focus:ring-offset-2 sm:px-6 sm:py-2 sm:text-base'
       } ${
         disabled
           ? 'opacity-50 cursor-not-allowed'
           : compact
             ? 'cursor-pointer hover:border-brand-300 hover:bg-gray-50'
+            : neutral
+              ? 'cursor-pointer hover:border-gray-400 hover:bg-gray-50'
             : 'cursor-pointer hover:bg-brand-50 hover:border-brand-300'
       }`}
       aria-expanded={isOpen}
@@ -283,9 +289,11 @@ const DropdownTrigger = ({
 const DropdownContent = ({
   children,
   compact = false,
+  neutral = false,
 }: {
   children: React.ReactNode;
   compact?: boolean;
+  neutral?: boolean;
 }) => {
   const { isOpen, setItemCount, triggerRef, contentRef } = useDropdown();
   const [position, setPosition] = useState<{
@@ -353,7 +361,7 @@ const DropdownContent = ({
     <div
       ref={contentRef}
       className={`fixed z-[3000] overflow-hidden rounded-lg border bg-white opacity-100 shadow-lg transition-all duration-200 translate-y-0 ${
-        compact ? "border-gray-300" : "border-brand-200"
+        compact || neutral ? "border-gray-300" : "border-brand-200"
       }`}
       style={{
         top: `${position.top}px`,
@@ -379,11 +387,13 @@ const DropdownItem = ({
   onSelect,
   index = -1,
   compact = false,
+  neutral = false,
 }: {
   option: DropdownOption;
   onSelect?: (option: DropdownOption) => void;
   index?: number;
   compact?: boolean;
+  neutral?: boolean;
 }) => {
   const {
     handleSelect,
@@ -431,19 +441,27 @@ const DropdownItem = ({
       className={`${
         compact
           ? "px-2.5 py-1.5 text-xs text-gray-700 focus:bg-gray-100"
+          : neutral
+            ? "px-4 py-1.5 text-sm text-gray-700 focus:bg-gray-100 focus:ring-2 focus:ring-gray-300 focus:ring-inset sm:px-6 sm:py-2 sm:text-base"
           : "px-4 py-1.5 text-sm text-brand-700 focus:bg-brand-100 focus:ring-2 focus:ring-brand-500 focus:ring-inset sm:px-6 sm:py-2 sm:text-base"
       } cursor-pointer outline-none transition-colors ${
         isSelected
           ? compact
             ? "bg-gray-100 font-semibold text-brand-700"
+            : neutral
+              ? "bg-gray-100 font-medium text-gray-900"
             : "bg-brand-50 font-medium text-brand-900"
           : compact
             ? "hover:bg-gray-50"
+            : neutral
+              ? "hover:bg-gray-50"
             : "hover:bg-brand-50"
       } ${
         isFocused && !isSelected
           ? compact
             ? "bg-gray-100"
+            : neutral
+              ? "bg-gray-100"
             : "bg-brand-100"
           : ""
       }`}
@@ -452,7 +470,7 @@ const DropdownItem = ({
         <span>{option.label}</span>
         {isSelected && (
           <svg
-            className={`${compact ? "h-3.5 w-3.5" : "h-5 w-5"} flex-shrink-0 text-brand-600`}
+            className={`${compact ? "h-3.5 w-3.5" : "h-5 w-5"} flex-shrink-0 ${neutral ? "text-gray-600" : "text-brand-600"}`}
             fill="currentColor"
             viewBox="0 0 20 20"
             aria-hidden="true"

--- a/src/app/_domains/_customer/_services/customerService.ts
+++ b/src/app/_domains/_customer/_services/customerService.ts
@@ -16,6 +16,31 @@ export type CustomerQuickLink = Pick<
   "id" | "name" | "phone" | "gender"
 >;
 
+export type ExistingCustomerMatch = Pick<
+  CustomerType,
+  "id" | "name" | "phone" | "address" | "note" | "is_stamp_eligible"
+>;
+
+export const findCustomersByNameAndPhoneLastDigits = async (
+  name: string,
+  phoneLastDigits: string,
+): Promise<ExistingCustomerMatch[]> => {
+  const normalizedName = name.trim();
+  const normalizedDigits = phoneLastDigits.replace(/\D/g, "");
+  if (!normalizedName || normalizedDigits.length !== 4) return [];
+
+  const { data, error } = await supabase
+    .from("customers")
+    .select("id, name, phone, address, note, is_stamp_eligible")
+    .eq("name", normalizedName)
+    .like("phone", `%${normalizedDigits}`)
+    .neq("phone", "X")
+    .limit(5);
+
+  if (error) throw error;
+  return data ?? [];
+};
+
 export const getCustomerQuickLinks = async (): Promise<CustomerQuickLink[]> => {
   const { data, error } = await supabase
     .from("customers")

--- a/src/app/_domains/_item/_services/productSearchColumnSettingService.ts
+++ b/src/app/_domains/_item/_services/productSearchColumnSettingService.ts
@@ -1,0 +1,39 @@
+import supabase from '@/libs/supabaseClient';
+
+export type ProductSearchMode = 'liquid' | 'other';
+
+export const productSearchColumnSettingKey = [
+  'product-search',
+  'column-settings',
+] as const;
+
+export const getProductSearchColumnSettings = async (): Promise<
+  Partial<Record<ProductSearchMode, Record<string, number>>>
+> => {
+  const { data, error } = await supabase
+    .from('product_search_column_settings')
+    .select('search_mode, column_widths');
+
+  if (error) throw error;
+  return Object.fromEntries(
+    (data ?? []).map((row) => [row.search_mode, row.column_widths]),
+  );
+};
+
+export const saveProductSearchColumnSettings = async (
+  mode: ProductSearchMode,
+  columnWidths: Record<string, number>,
+): Promise<void> => {
+  const { error } = await supabase
+    .from('product_search_column_settings')
+    .upsert(
+      {
+        search_mode: mode,
+        column_widths: columnWidths,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'search_mode' },
+    );
+
+  if (error) throw error;
+};

--- a/src/app/_domains/_log/_hooks/useCopy.ts
+++ b/src/app/_domains/_log/_hooks/useCopy.ts
@@ -107,6 +107,15 @@ const useCopy = () => {
             typeof payment.amount === 'number',
         )
       : [];
+    const hasTransactionTag = Boolean(
+      log.jsonb?.discount ||
+        (typeof log.jsonb?.deliveryFee === 'number' &&
+          log.jsonb.deliveryFee > 0) ||
+        log.jsonb?.deliveryType === 'self' ||
+        log.jsonb?.deliveryType === 'customer_quick' ||
+        (typeof log.jsonb?.reservationDate === 'string' &&
+          log.jsonb.reservationDate.trim()),
+    );
 
     const isEguPayment =
       typeof paymentTypeValue === 'string' &&
@@ -124,8 +133,22 @@ const useCopy = () => {
 
     const amountFormula = buildAmountFormula(log.jsonb);
 
-    const name = targetUser.name || '이름 없음';
-    const phone = formatPhoneNumber(targetUser.phone);
+    const isXCustomer =
+      targetUser.name.trim() === 'X' && targetUser.phone.trim() === 'X';
+    const savedXCustomerName =
+      typeof log.jsonb?.xCustomerName === 'string'
+        ? log.jsonb.xCustomerName.trim()
+        : '';
+    const savedXPhoneLastDigits =
+      typeof log.jsonb?.xPhoneLastDigits === 'string'
+        ? log.jsonb.xPhoneLastDigits.trim()
+        : '';
+    const name =
+      (isXCustomer && savedXCustomerName) || targetUser.name || '이름 없음';
+    const phone =
+      isXCustomer && savedXPhoneLastDigits
+        ? savedXPhoneLastDigits
+        : formatPhoneNumber(targetUser.phone);
     const specialCustomerName =
       targetUser.name.trim() === '시연용'
         ? '시연용'
@@ -175,7 +198,7 @@ const useCopy = () => {
         ? splitPayments
             .map((payment) =>
               buildClipboardRow(
-                `분할결제) ${log.note}`,
+                `${hasTransactionTag ? '분할결제,' : '분할결제) '}${log.note}`,
                 String(payment.amount),
                 paymentTypeNameByValue[payment.paymentType] ?? '',
               ),

--- a/src/app/_domains/_stamp/_services/stampService.ts
+++ b/src/app/_domains/_stamp/_services/stampService.ts
@@ -35,6 +35,8 @@ export type StampLogMeta = {
   storeName?: StoreTypeEnumType["value"];
   totalAmount?: number;
   extraNote?: string;
+  xCustomerName?: string;
+  xPhoneLastDigits?: string;
   reservationDate?: string;
   deliveryMethod?: "store_visit" | "parcel" | "delivery";
   deliveryType?: "agency" | "self" | "customer_quick";

--- a/supabase/migrations/20260805000000_handover_memos.sql
+++ b/supabase/migrations/20260805000000_handover_memos.sql
@@ -1,0 +1,48 @@
+create table if not exists public.handover_memos (
+  id uuid primary key default gen_random_uuid(),
+  content text not null check (btrim(content) <> ''),
+  author_name text not null default '직원',
+  created_by uuid references auth.users(id) on delete set null default auth.uid(),
+  created_at timestamptz not null default now(),
+  is_completed boolean not null default false,
+  completed_at timestamptz,
+  completed_by uuid references auth.users(id) on delete set null,
+  completed_by_name text
+);
+
+create index if not exists handover_memos_active_created_at_idx
+on public.handover_memos (is_completed, created_at desc);
+
+alter table public.handover_memos enable row level security;
+
+drop policy if exists "authenticated users can read handover memos" on public.handover_memos;
+create policy "authenticated users can read handover memos"
+on public.handover_memos for select
+to authenticated
+using (true);
+
+drop policy if exists "authenticated users can add handover memos" on public.handover_memos;
+create policy "authenticated users can add handover memos"
+on public.handover_memos for insert
+to authenticated
+with check (created_by = auth.uid());
+
+drop policy if exists "authenticated users can complete handover memos" on public.handover_memos;
+create policy "authenticated users can complete handover memos"
+on public.handover_memos for update
+to authenticated
+using (true)
+with check (true);
+
+drop policy if exists "admins can delete handover memos" on public.handover_memos;
+create policy "admins can delete handover memos"
+on public.handover_memos for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.users
+    where users.id = auth.uid()
+      and users.oss_role = 'admin'
+  )
+);

--- a/supabase/migrations/20260805010000_product_search_column_settings.sql
+++ b/supabase/migrations/20260805010000_product_search_column_settings.sql
@@ -1,0 +1,33 @@
+create table if not exists public.product_search_column_settings (
+  search_mode text primary key check (search_mode in ('liquid', 'other')),
+  column_widths jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now(),
+  updated_by uuid references auth.users(id) on delete set null default auth.uid()
+);
+
+alter table public.product_search_column_settings enable row level security;
+
+drop policy if exists "authenticated users can read product search column settings"
+on public.product_search_column_settings;
+create policy "authenticated users can read product search column settings"
+on public.product_search_column_settings for select
+to authenticated
+using (true);
+
+drop policy if exists "admins can save product search column settings"
+on public.product_search_column_settings;
+create policy "admins can save product search column settings"
+on public.product_search_column_settings for all
+to authenticated
+using (
+  exists (
+    select 1 from public.users
+    where users.id = auth.uid() and users.oss_role = 'admin'
+  )
+)
+with check (
+  exists (
+    select 1 from public.users
+    where users.id = auth.uid() and users.oss_role = 'admin'
+  )
+);


### PR DESCRIPTION
## 작업 개요

출고 이력 추가·수정 흐름과 특수 고객 처리 방식을 개선하고, 예약/A/S/미입고/전달 메모를 한곳에서 확인할 수 있는 미처리 현황 화면을 추가했습니다.

이력 표시와 복사 형식을 정리하고, 근무 기록 및 상품검색 설정 UI도 함께 개선했습니다.

## 주요 변경사항

### 1. X 고객 출고 처리 개선

- X남자·X여자 고객의 출고 방식은 즉시 출고 고정값으로 처리
- 불필요한 출고 방식 선택 영역 제거
- 해당 영역에 고객 정보 입력 기능 추가
  - 이름
  - 핸드폰 뒷번호 4자리
- 입력한 정보는 출고 이력 JSON 데이터에 저장
- 출고 이력에서 다음 형식으로 표시
  - 이름: 홍길동
  - 핸드폰 뒷번호: 1234
- X 고객 이력을 복사할 때 기존 X/X 대신 입력한 이름과 뒷번호 사용
- 기존에 저장된 X 고객 이력은 값이 없어도 정상 표시되도록 호환 유지

### 2. 기존 고객 검색 및 전환 기능

- X 고객 출고 화면에서 이름과 핸드폰 뒷번호를 입력하면 기존 고객 검색
- 이름과 전화번호 끝 4자리가 일치하는 고객을 최대 5명까지 표시
- 사용자가 `이 고객으로 변경`을 눌러야 출고 대상이 변경되도록 처리
- 고객 변경 시 상단 대상 고객 정보도 함께 갱신
- 고객 선택 후 스탬프 처리 방식 선택
  - 취소
  - 미적립
  - 적립
- 미적립 선택 시 현재 품목·금액 단계 유지
- 적립 선택 시 기본 정보 단계로 이동하여 스탬프 수량 입력
- 미적립 대상 고객은 적립 버튼을 표시하지 않음
- 미적립 대상 고객의 스탬프 입력도 비활성화

### 3. 출고 이력 추가·수정 화면 통일

- X 고객 수정 화면에서도 신규 출고 추가 화면과 같은 고객 정보 입력 폼 사용
- 저장된 이름과 핸드폰 뒷번호를 수정 화면 초기값으로 표시
- 수정 최종 화면에서 불필요한 즉시 출고 표시 제거
- 최종 확인 요약을 한 줄 5열 구성으로 정리
  - 이름
  - 핸드폰 뒷번호
  - 출고 매장
  - 수령 방식
  - 결제 정보
- 재고조정 및 시연용 처리 모달에서 단가·소계 제거
- 최종 확인 모달 폭과 품목명 영역 조정
- 수정 시 선택한 출고 유형 버튼이 유지되도록 개선

### 4. 출고 메모 형식 개선

- 교환입고 메모 형식 변경
  - 기존: `(교환입고(메모))`
  - 변경: `(교환입고,메모)`
- 교환출고 메모도 같은 방식으로 변경
- 기존 괄호 방식으로 저장된 이력도 수정 시 정상적으로 불러오도록 호환 처리
- 분할결제에 할인·배송비·예약 등의 거래 태그가 붙는 경우 쉼표로 연결
  - 거래 태그 없음: `분할결제) 품목명`
  - 거래 태그 있음: `분할결제,현금할인3000) 품목명`
- 화면 표시와 복사 결과에 동일한 형식 적용

### 5. 분할결제 이력 표시 개선

- 결제수단별 배지를 모두 나열하던 방식을 `분할결제 N건` 요약 배지로 변경
- 배지를 클릭하면 결제수단별 금액을 팝오버로 표시
- 팝오버 닫기 방식 개선
  - 버튼 재클릭
  - 팝오버 외부 클릭
  - Esc 키
- 매장·결제수단·총금액 배지를 동일한 너비와 높이로 통일
- 결제 정보 열을 88px에서 128px로 확대
- 최대 100만원대 금액까지 한 줄로 표시
- 결제방식·특이사항 배경과 글자 대비 강화

### 6. 미처리 현황 화면 추가

헤더 전체화면 버튼 왼쪽에 `미처리 현황` 버튼을 추가했습니다.

한 화면에서 다음 정보를 확인할 수 있습니다.

- 출고 예약
- 진행 중 A/S
- 미입고 거래처
- 전달 메모

각 영역의 전체 보기 연결도 개선했습니다.

- 출고 예약 → 예약 이력 탭
- A/S → 전체가 아닌 진행 중 상태
- A/S 목록에 고객명, 제품명, 고객 특이사항, 매장 특이사항 표시
- 미처리 현황 전체 폰트 크기 및 가독성 개선

### 7. 전달 메모 기능

- 기존 `handover_memos` 기반 전달 메모 저장
- 관리자 작성 시 작성자를 `관리자`로 표시
- 스태프 작성 시 현재 근무자 이름 표시
- 완료 처리 전 확인창 표시
  - 내용
  - 작성자
  - 처리자
  - 취소/완료 버튼
- 처리자는 계정명이 아닌 현재 근무자 이름으로 저장
- 완료된 메모는 별도의 `이전 메모 기록` 창에서 조회
- 관리자는 이전 메모 기록 삭제 가능
- 전달 메모 헤더 버튼 정리
  - 이전 메모 기록
  - 메모 추가
- 두 버튼을 동일한 네모 버튼 형태로 정리
- 평소에는 메모 입력창 숨김
- 메모 추가를 누르면 입력창과 취소/등록 버튼 표시
- 등록 또는 Enter 입력 후 저장 및 입력창 닫기

### 8. 근무 기록 추가 UI 개선

- 근무 날짜부터 출퇴근 선택 영역까지 레이아웃 개선
- 근무자 드롭다운 배경을 핑크색에서 중립 회색으로 변경
- 기존 화면 수준으로 폰트 크기 확대
- 드롭다운 선택 상태와 버튼 가독성 개선

### 9. 고객 스탬프 표시 개선

- 고객 관리 목록에서 미적립 대상 고객은 잔여 스탬프 대신 `미적립` 표시
- 기존 스탬프 데이터는 삭제하지 않음
- 향후 적립 대상으로 재전환될 경우 기존 데이터 활용 가능
- 고객 정보 변경 이력에서 내부 필드명 대신 사용자 친화적인 문구 표시

### 10. 상품검색 표 공통 너비 설정

- 상품검색 열 너비를 공통 DB 설정으로 저장할 수 있는 서비스 추가
- 관리자가 저장한 값을 관리자와 스태프가 동일하게 불러오도록 구성
- 액상/나머지 검색 모드별 열 너비를 구분하여 저장
- DB 설정이 없거나 적용되지 않은 환경에서는 기존 브라우저 저장값으로 fallback
- 신규 마이그레이션 추가
  - `product_search_column_settings`

## DB 마이그레이션

다음 마이그레이션 파일이 포함되어 있습니다.

- `20260805000000_handover_memos.sql`
- `20260805010000_product_search_column_settings.sql`

### 배포 주의사항

`product_search_column_settings` 마이그레이션은 현재 로컬 Supabase CLI가 프로젝트에 연결되지 않아 운영 DB에는 자동 적용하지 못했습니다.

배포 전에 연결된 Supabase 프로젝트에서 다음 파일을 반드시 적용해야 합니다.

`supabase/migrations/20260805010000_product_search_column_settings.sql`

적용 전에는 상품검색 열 너비가 기존처럼 브라우저에 임시 저장되며, 적용 후부터 관리자와 스태프가 동일한 공통 너비를 사용합니다.

## 검증 결과

- `npm run lint` 통과
- `npm run build` 통과
- TypeScript 검사 통과
- Git diff 공백 오류 검사 통과