### PR TITLE
고객 및 출고 이력 UX 개선

### DIFF
--- a/src/app/(auth)/_components/Header/_components/PendingStatusButton.tsx
+++ b/src/app/(auth)/_components/Header/_components/PendingStatusButton.tsx
@@ -125,7 +125,11 @@ export default function PendingStatusButton() {
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
-    const inProgressStatuses = getAfterServiceStatusGroups().inProgress;
+    const afterServiceStatusGroups = getAfterServiceStatusGroups();
+    const pendingAfterServiceStatuses = [
+      ...afterServiceStatusGroups.received,
+      ...afterServiceStatusGroups.inProgress,
+    ];
     const [reservationResult, afterServiceResult, purchaseOrderResult, memoResult] =
       await Promise.all([
         supabase
@@ -138,7 +142,7 @@ export default function PendingStatusButton() {
           .select(
             "id, item_name, status, customer_note, shop_note, customers(name, phone)",
           )
-          .in("status", inProgressStatuses)
+          .in("status", pendingAfterServiceStatuses)
           .order("created_at", { ascending: false }),
         supabase
           .from("inventory_purchase_orders")
@@ -397,9 +401,14 @@ export default function PendingStatusButton() {
                           {formatReservationItems(reservation.jsonb)}
                         </p>
                       </div>
-                      <span className="text-sm font-semibold text-brand-600">
-                        {formatReservationDate(reservation.jsonb)}
-                      </span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-semibold text-brand-600">
+                          {formatReservationDate(reservation.jsonb)}
+                        </span>
+                        <span aria-hidden="true" className="text-lg text-gray-400">
+                          ›
+                        </span>
+                      </div>
                     </Link>
                   ))}
                   {!isLoading && reservations.length === 0 && (
@@ -410,12 +419,12 @@ export default function PendingStatusButton() {
                 <StatusCard
                   title="진행 중 A/S"
                   count={afterServices.length}
-                  href="/after-services?group=inProgress"
+                  href="/after-services?group=all"
                 >
                   {afterServices.slice(0, 5).map((afterService) => (
                     <Link
                       key={afterService.id}
-                      href={`/after-services?group=inProgress&id=${afterService.id}`}
+                      href={`/after-services?group=all&id=${afterService.id}`}
                       onClick={() => setIsOpen(false)}
                       className="grid gap-3 border-b border-gray-100 px-1 py-3 last:border-b-0 hover:bg-gray-50 sm:grid-cols-[minmax(100px,0.8fr)_minmax(100px,1fr)_minmax(110px,1fr)_auto] sm:items-center"
                     >
@@ -443,9 +452,14 @@ export default function PendingStatusButton() {
                           {afterService.shop_note || "없음"}
                         </p>
                       </div>
-                      <span className="rounded-md bg-amber-50 px-2 py-1 text-sm font-semibold text-amber-700">
-                        {getAfterServiceStatusName(afterService.status)}
-                      </span>
+                      <div className="flex items-center gap-2">
+                        <span className="rounded-md bg-amber-50 px-2 py-1 text-sm font-semibold text-amber-700">
+                          {getAfterServiceStatusName(afterService.status)}
+                        </span>
+                        <span aria-hidden="true" className="text-lg text-gray-400">
+                          ›
+                        </span>
+                      </div>
                     </Link>
                   ))}
                   {!isLoading && afterServices.length === 0 && (
@@ -464,9 +478,14 @@ export default function PendingStatusButton() {
                       <span className="truncate text-base font-semibold text-gray-900">
                         {supplier.name}
                       </span>
-                      <span className="text-sm font-semibold text-brand-600">
-                        {supplier.pendingQuantity.toLocaleString()}개 미입고
-                      </span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-semibold text-brand-600">
+                          {supplier.pendingQuantity.toLocaleString()}개 미입고
+                        </span>
+                        <span aria-hidden="true" className="text-lg text-gray-400">
+                          ›
+                        </span>
+                      </div>
                     </Link>
                   ))}
                   {!isLoading && pendingSuppliers.length === 0 && (
@@ -753,7 +772,7 @@ const StatusCard = ({
       </div>
       {action ?? (href && (
         <Link href={href} className="text-sm font-semibold text-gray-500 hover:text-brand-600">
-          전체 보기
+          전체보기 ›
         </Link>
       ))}
     </div>

--- a/src/app/(auth)/_components/StampLogEditModal.tsx
+++ b/src/app/(auth)/_components/StampLogEditModal.tsx
@@ -55,10 +55,11 @@ const getItemDisplayMemo = (
 ) => {
   const remark = item.remark?.trim();
   if (!remark) return "";
-  const wrappedMemo = remark.match(
-    /^(?:서비스|교환입고|교환출고)\((.*)\)$/,
-  )?.[1];
-  if (wrappedMemo) return wrappedMemo.trim();
+  const typedMemo = remark.match(
+    /^(?:서비스|교환입고|교환출고)(?:,(.*)|\((.*)\))$/,
+  );
+  const displayMemo = typedMemo?.[1] ?? typedMemo?.[2];
+  if (displayMemo) return displayMemo.trim();
   if (
     remark === "서비스" ||
     remark === "교환입고" ||
@@ -119,6 +120,8 @@ const StampLogEditModal = ({
   const [xPhoneLastDigits, setXPhoneLastDigits] = useState(
     initialLogMeta?.xPhoneLastDigits ?? "",
   );
+  const isCustomerInfoDeclined =
+    xCustomerName === "X" && xPhoneLastDigits === "X";
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [step, setStep] = useState<1 | 2 | 3>(2);
   const [formValidity, setFormValidity] = useState({
@@ -168,16 +171,30 @@ const StampLogEditModal = ({
 
   const xCustomerInfoFields = (
     <div className="h-full rounded-lg border border-gray-200 bg-gray-50 p-3">
-      <p className="mb-2 text-sm font-semibold text-gray-800">고객 정보</p>
+      <div className="mb-2 flex items-center gap-2">
+        <p className="text-sm font-semibold text-gray-800">고객 정보</p>
+        <Button
+          type="button"
+          size="xs"
+          variant={isCustomerInfoDeclined ? "primary" : "gray"}
+          onClick={() => {
+            setXCustomerName(isCustomerInfoDeclined ? "" : "X");
+            setXPhoneLastDigits(isCustomerInfoDeclined ? "" : "X");
+          }}
+        >
+          정보 제공 안 함
+        </Button>
+      </div>
       <div className="grid grid-cols-2 gap-2">
         <label className="min-w-0">
           <input
             type="text"
             aria-label="이름"
             value={xCustomerName}
+            disabled={isCustomerInfoDeclined}
             onChange={(event) => setXCustomerName(event.target.value)}
             placeholder="이름 입력"
-            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
           />
         </label>
         <label className="min-w-0">
@@ -187,11 +204,12 @@ const StampLogEditModal = ({
             inputMode="numeric"
             maxLength={4}
             value={xPhoneLastDigits}
+            disabled={isCustomerInfoDeclined}
             onChange={(event) =>
               setXPhoneLastDigits(event.target.value.replace(/\D/g, "").slice(0, 4))
             }
             placeholder="뒷번호 4자리"
-            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
           />
         </label>
       </div>
@@ -578,6 +596,7 @@ const StampLogEditModal = ({
                     : !formValidity.hasItems ||
                       !hasValidSplitPaymentAmounts ||
                       (customerMode === "x" &&
+                        !isCustomerInfoDeclined &&
                         (!xCustomerName.trim() || xPhoneLastDigits.length !== 4))
                 }
               >
@@ -592,6 +611,7 @@ const StampLogEditModal = ({
                 isSubmitting ||
                 !stampLog ||
                 (customerMode === "x" &&
+                  !isCustomerInfoDeclined &&
                   (!xCustomerName.trim() || xPhoneLastDigits.length !== 4))
               }
             >

--- a/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
+++ b/src/app/(auth)/customers/[id]/_components/CustomersDetailStampsHistories/index.tsx
@@ -27,6 +27,9 @@ import StampLogEditModal from "@/app/(auth)/_components/StampLogEditModal";
 import RemarkLogCreateModal from "../RemarkLogCreateModal";
 import type { StampLogMeta } from "@/app/_domains/_stamp/_services/stampService";
 
+const formatHistoryNote = (note: string) =>
+  note.replace(/\(서비스\((.*?)\)\)/g, "(서비스,$1)");
+
 const CustomersDetailStampsHistories = ({
   targetUser,
   logs,
@@ -327,7 +330,7 @@ const CustomersDetailStampsHistories = ({
                       </Button>
                       <div className="min-w-[240px] flex-1 break-words whitespace-normal text-xs text-gray-600 sm:text-sm">
                         <p className="whitespace-pre-line">
-                          {log.note || (
+                          {log.note ? formatHistoryNote(log.note) : (
                             <span className="text-gray-400"> - </span>
                           )}
                         </p>

--- a/src/app/(auth)/customers/_components/CustomerList/index.tsx
+++ b/src/app/(auth)/customers/_components/CustomerList/index.tsx
@@ -18,6 +18,7 @@ interface CustomerListProps {
   sortBy?: "name" | "stamp" | "created_at";
   sortOrder?: "asc" | "desc";
   onSortChange?: (sortBy: "name" | "stamp" | "created_at") => void;
+  headerActions?: React.ReactNode;
 }
 
 const CustomerList = ({
@@ -30,6 +31,7 @@ const CustomerList = ({
   totalCount,
   sortBy,
   onSortChange,
+  headerActions,
 }: CustomerListProps) => {
   const router = useRouter();
   if (isLoading) {
@@ -46,51 +48,58 @@ const CustomerList = ({
 
   return (
     <div className="mb-10">
-      <div className="flex justify-start items-center gap-3 mb-3">
-        <div className="text-xs sm:text-sm text-gray-600">
-          <span className="font-semibold text-brand-600">
-            {customers.length}
-          </span>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3 sm:flex-nowrap">
+        <div className="flex items-center justify-start gap-3">
+          <div className="text-xs text-gray-600 sm:text-sm">
+            <span className="font-semibold text-brand-600">
+              {customers.length}
+            </span>
 
-          {totalCount !== undefined && totalCount > 0 && (
-            <>
-              {" / "}
-              <span className="font-semibold text-gray-600">{totalCount}</span>
-            </>
+            {totalCount !== undefined && totalCount > 0 && (
+              <>
+                {" / "}
+                <span className="font-semibold text-gray-600">{totalCount}</span>
+              </>
+            )}
+          </div>
+          {onSortChange && (
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => onSortChange("name")}
+                className={`whitespace-nowrap px-2 py-1 text-xs rounded border transition-colors cursor-pointer ${
+                  sortBy === "name"
+                    ? "bg-brand-100 border-brand-300 text-brand-700 font-medium"
+                    : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
+                }`}
+              >
+                가나다순
+              </button>
+              <button
+                onClick={() => onSortChange("stamp")}
+                className={`whitespace-nowrap px-2 py-1 text-xs rounded border transition-colors cursor-pointer ${
+                  sortBy === "stamp"
+                    ? "bg-brand-100 border-brand-300 text-brand-700 font-medium"
+                    : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
+                }`}
+              >
+                스탬프 많은 순
+              </button>
+              <button
+                onClick={() => onSortChange("created_at")}
+                className={`whitespace-nowrap px-2 py-1 text-xs rounded border transition-colors cursor-pointer ${
+                  sortBy === "created_at"
+                    ? "bg-brand-100 border-brand-300 text-brand-700 font-medium"
+                    : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
+                }`}
+              >
+                등록일 순
+              </button>
+            </div>
           )}
         </div>
-        {onSortChange && (
-          <div className="flex items-center gap-1.5">
-            <button
-              onClick={() => onSortChange("name")}
-              className={`whitespace-nowrap px-2 py-1 text-xs rounded border transition-colors cursor-pointer ${
-                sortBy === "name"
-                  ? "bg-brand-100 border-brand-300 text-brand-700 font-medium"
-                  : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
-              }`}
-            >
-              가나다순
-            </button>
-            <button
-              onClick={() => onSortChange("stamp")}
-              className={`whitespace-nowrap px-2 py-1 text-xs rounded border transition-colors cursor-pointer ${
-                sortBy === "stamp"
-                  ? "bg-brand-100 border-brand-300 text-brand-700 font-medium"
-                  : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
-              }`}
-            >
-              스탬프 많은 순
-            </button>
-            <button
-              onClick={() => onSortChange("created_at")}
-              className={`whitespace-nowrap px-2 py-1 text-xs rounded border transition-colors cursor-pointer ${
-                sortBy === "created_at"
-                  ? "bg-brand-100 border-brand-300 text-brand-700 font-medium"
-                  : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
-              }`}
-            >
-              등록일 순
-            </button>
+        {headerActions && (
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            {headerActions}
           </div>
         )}
       </div>

--- a/src/app/(auth)/customers/_components/StampConfirmModal.tsx
+++ b/src/app/(auth)/customers/_components/StampConfirmModal.tsx
@@ -51,10 +51,11 @@ const getItemDisplayMemo = (
   const remark = item.remark?.trim();
   if (!remark) return "";
 
-  const wrappedMemo = remark.match(
-    /^(?:서비스|교환입고|교환출고)\((.*)\)$/,
-  )?.[1];
-  if (wrappedMemo) return wrappedMemo.trim();
+  const typedMemo = remark.match(
+    /^(?:서비스|교환입고|교환출고)(?:,(.*)|\((.*)\))$/,
+  );
+  const displayMemo = typedMemo?.[1] ?? typedMemo?.[2];
+  if (displayMemo) return displayMemo.trim();
 
   if (
     remark === "서비스" ||
@@ -120,6 +121,8 @@ export default function StampConfirmModal({
   const [reservationDate, setReservationDate] = useState("");
   const [xCustomerName, setXCustomerName] = useState("");
   const [xPhoneLastDigits, setXPhoneLastDigits] = useState("");
+  const isCustomerInfoDeclined =
+    xCustomerName === "X" && xPhoneLastDigits === "X";
   const [customerMatches, setCustomerMatches] = useState<
     ExistingCustomerMatch[]
   >([]);
@@ -364,19 +367,34 @@ export default function StampConfirmModal({
 
   const xCustomerInfoFields = (
     <div className="h-full rounded-lg border border-gray-200 bg-gray-50 p-3">
-      <p className="mb-2 text-sm font-semibold text-gray-800">고객 정보</p>
+      <div className="mb-2 flex items-center gap-2">
+        <p className="text-sm font-semibold text-gray-800">고객 정보</p>
+        <Button
+          type="button"
+          size="xs"
+          variant={isCustomerInfoDeclined ? "primary" : "gray"}
+          onClick={() => {
+            setXCustomerName(isCustomerInfoDeclined ? "" : "X");
+            setXPhoneLastDigits(isCustomerInfoDeclined ? "" : "X");
+            setSelectedCustomer(null);
+          }}
+        >
+          정보 제공 안 함
+        </Button>
+      </div>
       <div className="grid grid-cols-2 gap-2">
         <label className="min-w-0">
           <input
             type="text"
             aria-label="이름"
             value={xCustomerName}
+            disabled={isCustomerInfoDeclined}
             onChange={(event) => {
               setXCustomerName(event.target.value);
               setSelectedCustomer(null);
             }}
             placeholder="이름 입력"
-            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
           />
         </label>
         <label className="min-w-0">
@@ -386,6 +404,7 @@ export default function StampConfirmModal({
             inputMode="numeric"
             maxLength={4}
             value={xPhoneLastDigits}
+            disabled={isCustomerInfoDeclined}
             onChange={(event) => {
               setXPhoneLastDigits(
                 event.target.value.replace(/\D/g, "").slice(0, 4),
@@ -393,7 +412,7 @@ export default function StampConfirmModal({
               setSelectedCustomer(null);
             }}
             placeholder="뒷번호 4자리"
-            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
           />
         </label>
       </div>
@@ -937,6 +956,7 @@ export default function StampConfirmModal({
                   if (
                     addStep === 2 &&
                     effectiveFormCustomerMode === "x" &&
+                    !isCustomerInfoDeclined &&
                     (!xCustomerName.trim() || xPhoneLastDigits.length !== 4)
                   ) {
                     toast.error("이름과 핸드폰 뒷번호 4자리를 입력해 주세요.");

--- a/src/app/(auth)/customers/_components/StampLogForm.tsx
+++ b/src/app/(auth)/customers/_components/StampLogForm.tsx
@@ -253,6 +253,10 @@ export default function StampLogForm({
     () =>
       initialValue?.logMeta?.items?.map((item, index) => ({
         ...item,
+        lineText: item.lineText.replace(
+          /\(서비스\((.*?)\)\)/g,
+          "(서비스,$1)",
+        ),
         id: `${item.itemId}-${index}`,
       })) ?? [],
   );
@@ -758,6 +762,8 @@ export default function StampLogForm({
     const remarkText =
       remarkType === "price_adjust"
         ? `${remark}, ${formatAmount(adjustedPrice)}원`
+        : remarkType === "service"
+          ? `서비스${customRemark.trim() ? `,${customRemark.trim()}` : ""}`
         : remark;
     const lineText = `${selectedItem.item_name} ${quantity}개${
       remarkText ? ` (${remarkText})` : ""
@@ -896,10 +902,11 @@ export default function StampLogForm({
     const remark = line.remark?.trim();
     if (!remark) return "";
 
-    const wrappedMemo = remark.match(
-      /^(?:서비스|교환입고|교환출고)\((.*)\)$/,
-    )?.[1];
-    if (wrappedMemo) return wrappedMemo.trim();
+    const typedMemo = remark.match(
+      /^(?:서비스|교환입고|교환출고)(?:,(.*)|\((.*)\))$/,
+    );
+    const displayMemo = typedMemo?.[1] ?? typedMemo?.[2];
+    if (displayMemo) return displayMemo.trim();
 
     if (
       remark === "서비스" ||

--- a/src/app/(auth)/customers/page.tsx
+++ b/src/app/(auth)/customers/page.tsx
@@ -170,44 +170,6 @@ export default function CustomersPage() {
       {/* 검색 박스 */}
       <SearchBox onSearch={search} />
 
-      {/* 고객 추가 버튼 */}
-      <div className="flex flex-wrap justify-end gap-2">
-        {quickLinkDefinitions.map((definition) => {
-          const customer = findQuickLink(definition.key);
-          return (
-            <Button
-              key={definition.key}
-              size="sm"
-              variant="secondary"
-              disabled={isQuickLinksLoading || !customer}
-              onClick={() =>
-                customer && router.push(`/customers/${customer.id}`)
-              }
-            >
-              {isQuickLinksLoading ? "불러오는 중..." : definition.label}
-            </Button>
-          );
-        })}
-        <Button
-          size="sm"
-          onClick={() => {
-            setIsSubmitting(false);
-            open({
-              content: (
-                <CustomerCreateModal
-                  onCancel={close}
-                  isSubmitting={isSubmitting}
-                  onSubmit={handleCustomerSubmit}
-                />
-              ),
-              options: { dismissOnBackdrop: false, dismissOnEsc: true },
-            });
-          }}
-        >
-          고객 추가
-        </Button>
-      </div>
-
       {/* 고객 목록 */}
       <CustomerList
         customers={customers}
@@ -223,6 +185,44 @@ export default function CustomersPage() {
         sortBy={sortBy}
         sortOrder={sortOrder}
         onSortChange={setSort}
+        headerActions={
+          <>
+            {quickLinkDefinitions.map((definition) => {
+              const customer = findQuickLink(definition.key);
+              return (
+                <Button
+                  key={definition.key}
+                  size="sm"
+                  variant="secondary"
+                  disabled={isQuickLinksLoading || !customer}
+                  onClick={() =>
+                    customer && router.push(`/customers/${customer.id}`)
+                  }
+                >
+                  {isQuickLinksLoading ? "불러오는 중..." : definition.label}
+                </Button>
+              );
+            })}
+            <Button
+              size="sm"
+              onClick={() => {
+                setIsSubmitting(false);
+                open({
+                  content: (
+                    <CustomerCreateModal
+                      onCancel={close}
+                      isSubmitting={isSubmitting}
+                      onSubmit={handleCustomerSubmit}
+                    />
+                  ),
+                  options: { dismissOnBackdrop: false, dismissOnEsc: true },
+                });
+              }}
+            >
+              고객 추가
+            </Button>
+          </>
+        }
       />
     </div>
   );

--- a/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
+++ b/src/app/(auth)/histories/_components/StampHistories/StampHistoryItem.tsx
@@ -23,6 +23,9 @@ interface StampHistoryItemProps {
   showCopy?: boolean;
 }
 
+const formatHistoryNote = (note: string) =>
+  note.replace(/\(서비스\((.*?)\)\)/g, "(서비스,$1)");
+
 const StampHistoryItem = ({
   log,
   onEdit,
@@ -57,11 +60,11 @@ const StampHistoryItem = ({
     !Array.isArray(log.jsonb?.items) &&
     !log.jsonb?.paymentType;
   const customerBadge = isCustomerRemark ? (
-    <span className="inline-flex whitespace-nowrap rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-500">
+    <span className="inline-flex items-center justify-center whitespace-nowrap rounded-full bg-gray-100 px-2 py-1 text-center text-xs font-medium text-gray-500">
       고객 특이사항
     </span>
   ) : isCouponUse ? (
-    <span className="inline-flex whitespace-nowrap rounded-full bg-blue-100 px-2 py-1 text-xs font-semibold text-blue-700">
+    <span className="inline-flex items-center justify-center whitespace-nowrap rounded-full bg-blue-100 px-2 py-1 text-center text-xs font-semibold text-blue-700">
       쿠폰 사용
     </span>
   ) : isStampAdjustment ? (
@@ -121,7 +124,7 @@ const StampHistoryItem = ({
                       ? "분할결제,"
                       : "분할결제) "
                     : ""
-                }${log.note}`
+                }${formatHistoryNote(log.note)}`
               ) : (
                 <span className="text-gray-400"> - </span>
               )}

--- a/src/app/_domains/_log/_hooks/useCopy.ts
+++ b/src/app/_domains/_log/_hooks/useCopy.ts
@@ -24,6 +24,9 @@ const storeNameByValue = Object.values(StoreTypeEnum).reduce(
   {} as Record<StoreTypeEnumType['value'], string>,
 );
 
+const formatHistoryNote = (note: string) =>
+  note.replace(/\(서비스\((.*?)\)\)/g, '(서비스,$1)');
+
 const buildAmountFormula = (
   jsonb: Record<string, unknown> | null | undefined,
 ): string => {
@@ -198,14 +201,14 @@ const useCopy = () => {
         ? splitPayments
             .map((payment) =>
               buildClipboardRow(
-                `${hasTransactionTag ? '분할결제,' : '분할결제) '}${log.note}`,
+                `${hasTransactionTag ? '분할결제,' : '분할결제) '}${formatHistoryNote(log.note)}`,
                 String(payment.amount),
                 paymentTypeNameByValue[payment.paymentType] ?? '',
               ),
             )
             .join('\n')
         : buildClipboardRow(
-            log.note,
+            formatHistoryNote(log.note),
             amountFormula,
             paymentTypeName ?? '',
           );


### PR DESCRIPTION
## 변경 내용

- X 남자·X 여자 계정에 `정보 제공 안 함` 기능 추가
  - 선택 시 고객 이름과 핸드폰 뒷번호를 `X`로 저장
  - 클립보드 복사 시 `X`, `X`로 반영
  - 신규 출고 및 출고 이력 수정 화면에 동일하게 적용

- 출고 유형별 메모 표시 방식 개선
  - 출고 추가·수정 화면: `제품명 (메모)`
  - 출고 이력: `제품명 (서비스,메모)`, `제품명 (교환입고,메모)`, `제품명 (교환출고,메모)`
  - 기존 서비스 이력과 클립보드 복사 형식도 보정

- 고객 이력의 `쿠폰 사용`, `고객 특이사항` 배지 가운데 정렬

- 미처리 현황 사용성 개선
  - 카드 헤더에 `전체보기 ›` 표시
  - 이동 가능한 개별 항목에 화살표 표시
  - 진행 중 A/S에 `접수` 상태 포함

- 고객관리 목록 상단 레이아웃 개선
  - 결과 수·정렬 버튼과 빠른 계정·고객 추가 버튼을 같은 행에 배치
  - 휴대폰에서는 화면 너비에 따라 줄바꿈

## 검증

- 전체 ESLint 통과
- TypeScript 타입 검사 통과
- Git staged diff 검사 통과