### PR TITLE
성인인증 일회성 링크 및 비바톤 연동 기능 추가

### DIFF
--- a/docs/adult_verification.md
+++ b/docs/adult_verification.md
@@ -1,0 +1,35 @@
+# 비바톤 성인 인증 운영 설정
+
+## 구현 범위
+
+- 고객별 24시간 유효 일회성 링크
+- 비바톤 OAuth 2.0 성인 여부 확인
+- 인증 성공 시 고객 상세의 성인 인증 상태 자동 갱신
+- 직원의 실물 신분증 확인 완료 및 인증 해제
+- 원본 링크 토큰, 비바톤 액세스 토큰, 이름, 생년월일, 전화번호 미저장
+
+## 적용 순서
+
+1. Supabase SQL Editor에서 `supabase/migrations/20260810000000_adult_verification.sql` 실행
+2. 로컬 `.env.local` 및 Vercel 환경변수 등록
+3. 운영 재배포
+
+## 필요한 환경변수
+
+```env
+SUPABASE_SERVICE_ROLE_KEY=Supabase 프로젝트의 service_role 키
+NEXT_PUBLIC_APP_URL=https://ovape-stamp-system-lczx.vercel.app
+BBATON_CLIENT_ID=비바톤에서 발급받은 Client ID
+BBATON_CLIENT_SECRET=비바톤에서 발급받은 Secret Key
+BBATON_REDIRECT_URI=https://ovape-stamp-system-lczx.vercel.app/api/adult-verification/bbaton/callback
+```
+
+`SUPABASE_SERVICE_ROLE_KEY`와 `BBATON_CLIENT_SECRET`은 서버 전용 비밀값이다. `NEXT_PUBLIC_` 접두사를 붙이거나 저장소에 커밋하지 않는다.
+
+## 운영 확인
+
+1. 고객 상세에서 `인증 링크 생성` 클릭
+2. 복사된 링크를 시크릿 창에서 열기
+3. 비바톤 인증 완료
+4. 고객 상세를 새로고침하고 `인증 완료 · 비바톤` 표시 확인
+5. 같은 링크를 다시 열었을 때 재사용 불가 안내 확인

--- a/src/app/(auth)/adult-verifications/page.tsx
+++ b/src/app/(auth)/adult-verifications/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import Button from "@/app/_components/Button";
+import supabase from "@/libs/supabaseClient";
+
+type VerificationRequest = {
+  id: string;
+  request_label: string;
+  status: "pending" | "completed" | "expired" | "cancelled" | "rejected";
+  expires_at: string;
+  completed_at: string | null;
+  created_at: string;
+  customer_id: string | null;
+};
+
+const statusLabels: Record<VerificationRequest["status"], string> = {
+  pending: "인증 대기",
+  completed: "인증 완료",
+  expired: "만료",
+  cancelled: "취소",
+  rejected: "성인 아님",
+};
+
+const statusClasses: Record<VerificationRequest["status"], string> = {
+  pending: "bg-amber-50 text-amber-700",
+  completed: "bg-emerald-50 text-emerald-700",
+  expired: "bg-gray-100 text-gray-600",
+  cancelled: "bg-gray-100 text-gray-600",
+  rejected: "bg-rose-50 text-rose-700",
+};
+
+const getAccessToken = async () => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) throw new Error("로그인이 필요합니다.");
+  return session.access_token;
+};
+
+export default function AdultVerificationsPage() {
+  const [label, setLabel] = useState("");
+  const [items, setItems] = useState<VerificationRequest[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCreating, setIsCreating] = useState(false);
+  const [createdUrl, setCreatedUrl] = useState("");
+
+  const loadRequests = useCallback(async () => {
+    try {
+      const accessToken = await getAccessToken();
+      const response = await fetch("/api/adult-verification/requests", {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        cache: "no-store",
+      });
+      const result = (await response.json()) as {
+        items?: VerificationRequest[];
+        message?: string;
+      };
+      if (!response.ok) throw new Error(result.message || "목록을 불러오지 못했습니다.");
+      setItems(result.items ?? []);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "목록을 불러오지 못했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRequests();
+  }, [loadRequests]);
+
+  const createLink = async () => {
+    if (!label.trim()) {
+      toast.error("고객을 구분할 이름이나 메모를 입력해 주세요.");
+      return;
+    }
+
+    setIsCreating(true);
+    try {
+      const accessToken = await getAccessToken();
+      const response = await fetch("/api/adult-verification/requests", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ label: label.trim() }),
+      });
+      const result = (await response.json()) as { url?: string; message?: string };
+      if (!response.ok || !result.url) throw new Error(result.message || "링크를 만들지 못했습니다.");
+
+      setCreatedUrl(result.url);
+      await navigator.clipboard.writeText(result.url);
+      setLabel("");
+      toast.success("24시간 유효한 인증 링크를 복사했습니다.");
+      await loadRequests();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "링크를 만들지 못했습니다.");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto mt-10 max-w-6xl px-4 pb-10 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">성인 인증 관리</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          고객 등록 전에도 일회성 링크를 만들고 인증 완료 여부를 확인할 수 있습니다.
+        </p>
+      </div>
+
+      <section className="mb-8 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-900">인증 링크 생성</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          인증자를 구분할 수 있도록 이름, 전화번호 뒷자리 또는 메모를 입력하세요.
+        </p>
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+          <input
+            value={label}
+            maxLength={100}
+            onChange={(event) => setLabel(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void createLink();
+            }}
+            placeholder="예: 김고객 1234 / 카카오 문의 고객"
+            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm font-medium text-gray-900 shadow-sm outline-none transition placeholder:font-normal placeholder:text-gray-500 hover:border-brand-300 focus:border-brand-500 focus:ring-2 focus:ring-brand-100"
+          />
+          <Button onClick={createLink} disabled={isCreating}>
+            {isCreating ? "생성 중..." : "인증 링크 생성"}
+          </Button>
+        </div>
+
+        {createdUrl && (
+          <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50/70 p-3">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <input readOnly value={createdUrl} className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800" />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={async () => {
+                  await navigator.clipboard.writeText(createdUrl);
+                  toast.success("인증 링크를 복사했습니다.");
+                }}
+              >
+                복사
+              </Button>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <p className="text-xs text-gray-600 sm:text-sm">
+          최근 인증 요청 <span className="font-semibold text-brand-600">{items.length}</span>
+        </p>
+        <Button size="sm" variant="gray" onClick={() => void loadRequests()} disabled={isLoading}>
+          새로고침
+        </Button>
+      </div>
+
+      <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        {isLoading ? (
+          <p className="p-8 text-center text-sm text-gray-500">불러오는 중...</p>
+        ) : items.length === 0 ? (
+          <p className="p-8 text-center text-sm text-gray-500">아직 생성된 인증 요청이 없습니다.</p>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {items.map((item) => (
+              <div key={item.id} className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-semibold text-gray-900">{item.request_label}</p>
+                  <p className="mt-1 text-xs text-gray-500">
+                    요청 {new Date(item.created_at).toLocaleString("ko-KR")}
+                    {item.completed_at ? ` · 완료 ${new Date(item.completed_at).toLocaleString("ko-KR")}` : ""}
+                  </p>
+                </div>
+                <span className={`w-fit rounded-full px-2.5 py-1 text-xs font-semibold ${statusClasses[item.status]}`}>
+                  {statusLabels[item.status]}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/(auth)/customers/page.tsx
+++ b/src/app/(auth)/customers/page.tsx
@@ -187,6 +187,13 @@ export default function CustomersPage() {
         onSortChange={setSort}
         headerActions={
           <>
+            <Button
+              size="sm"
+              variant="gray"
+              onClick={() => router.push("/adult-verifications")}
+            >
+              성인 인증 관리
+            </Button>
             {quickLinkDefinitions.map((definition) => {
               const customer = findQuickLink(definition.key);
               return (

--- a/src/app/(public)/adult-verify/[token]/page.tsx
+++ b/src/app/(public)/adult-verify/[token]/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useSearchParams } from "next/navigation";
+
+type VerificationStatus = "loading" | "pending" | "completed" | "expired" | "cancelled" | "rejected" | "invalid" | "error";
+
+const messages: Record<string, { title: string; description: string }> = {
+  success: { title: "성인 인증이 완료되었습니다", description: "이 창을 닫아도 됩니다. 인증을 요청한 담당자에게 결과가 전달됩니다." },
+  rejected: { title: "성인 인증을 완료할 수 없습니다", description: "성인으로 확인되지 않았습니다. 담당자에게 문의해 주세요." },
+  expired: { title: "인증 링크가 만료되었습니다", description: "담당자에게 새로운 인증 링크를 요청해 주세요." },
+  invalid: { title: "사용할 수 없는 인증 링크입니다", description: "이미 사용했거나 취소된 링크일 수 있습니다." },
+  unavailable: { title: "현재 인증을 시작할 수 없습니다", description: "서비스 설정이 완료되지 않았습니다. 담당자에게 문의해 주세요." },
+  error: { title: "인증 처리 중 문제가 발생했습니다", description: "잠시 후 다시 시도하거나 담당자에게 문의해 주세요." },
+};
+
+export default function AdultVerificationPage() {
+  const params = useParams<{ token: string }>();
+  const searchParams = useSearchParams();
+  const token = params.token;
+  const result = searchParams.get("result");
+  const [status, setStatus] = useState<VerificationStatus>("loading");
+
+  useEffect(() => {
+    if (result) return;
+    fetch(`/api/adult-verification/requests/${encodeURIComponent(token)}`, { cache: "no-store" })
+      .then(async (response) => {
+        const data = (await response.json()) as { status?: VerificationStatus };
+        setStatus(data.status ?? "error");
+      })
+      .catch(() => setStatus("error"));
+  }, [result, token]);
+
+  const key = result
+    ? result
+    : status === "completed"
+      ? "success"
+      : status === "cancelled"
+        ? "invalid"
+        : status;
+  const message = key !== "pending" && key !== "loading" ? messages[key] ?? messages.error : null;
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-10">
+      <section className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 text-center shadow-sm sm:p-8">
+        <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-600 text-2xl font-bold text-white">B</div>
+        {status === "loading" && !result ? (
+          <><h1 className="text-xl font-semibold text-gray-900">인증 링크 확인 중</h1><p className="mt-2 text-sm text-gray-600">잠시만 기다려 주세요.</p></>
+        ) : message ? (
+          <><h1 className="text-xl font-semibold text-gray-900">{message.title}</h1><p className="mt-3 text-sm leading-6 text-gray-600">{message.description}</p></>
+        ) : (
+          <>
+            <h1 className="text-xl font-semibold text-gray-900">성인 인증</h1>
+            <p className="mt-3 text-sm leading-6 text-gray-600">비바톤에서 성인 여부만 확인합니다. 인증 결과 외 이름, 생년월일, 전화번호는 이 서비스에 저장하지 않습니다.</p>
+            <a href={`/api/adult-verification/bbaton/start?token=${encodeURIComponent(token)}`} className="mt-6 inline-flex w-full cursor-pointer items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2">비바톤으로 성인 인증</a>
+            <p className="mt-4 text-xs text-gray-500">이 링크는 한 번만 사용할 수 있습니다.</p>
+          </>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/_domains/_adultVerification/server.ts
+++ b/src/app/_domains/_adultVerification/server.ts
@@ -1,0 +1,47 @@
+import { createHash, randomBytes } from "crypto";
+import { createClient } from "@supabase/supabase-js";
+import { createSupabaseAdmin } from "@/libs/supabaseAdmin";
+
+export const hashVerificationToken = (token: string) =>
+  createHash("sha256").update(token).digest("hex");
+
+export const createVerificationToken = () => randomBytes(32).toString("base64url");
+
+export const getAuthenticatedStaff = async (authorization: string | null) => {
+  const accessToken = authorization?.replace(/^Bearer\s+/i, "").trim();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_KEY;
+  if (!accessToken || !url || !anonKey) return null;
+
+  const authClient = createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const { data, error } = await authClient.auth.getUser(accessToken);
+  if (error || !data.user) return null;
+
+  const admin = createSupabaseAdmin();
+  const { data: staff } = await admin
+    .from("users")
+    .select("id, name, oss_role")
+    .eq("id", data.user.id)
+    .in("oss_role", ["staff", "admin"])
+    .maybeSingle();
+
+  return staff ?? null;
+};
+
+export const getRequestByToken = async (token: string) => {
+  const admin = createSupabaseAdmin();
+  const tokenHash = hashVerificationToken(token);
+  const { data, error } = await admin
+    .from("adult_verification_requests")
+    .select("id, customer_id, status, expires_at, completed_at")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  if (error) throw error;
+  return { request: data, tokenHash, admin };
+};
+
+export const isRequestExpired = (expiresAt: string) =>
+  new Date(expiresAt).getTime() <= Date.now();

--- a/src/app/_domains/_customer/_services/customerService.ts
+++ b/src/app/_domains/_customer/_services/customerService.ts
@@ -308,3 +308,48 @@ export const deleteCustomer = async (id: string) => {
 
   if (error) throw error;
 };
+
+export const updateCustomerAdultVerification = async (
+  id: string,
+  verified: boolean,
+  method: "physical_id" | "manual" = "physical_id",
+) => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) throw new Error("AUTH_REQUIRED");
+
+  const previous = await getCustomerById(id);
+  const verifiedAt = verified ? new Date().toISOString() : null;
+  const { data, error } = await supabase
+    .from("customers")
+    .update({
+      adult_verified: verified,
+      adult_verified_at: verifiedAt,
+      adult_verification_method: verified ? method : null,
+      adult_verified_by: verified ? session.user.id : null,
+    })
+    .eq("id", id)
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) throw new Error("NOT_FOUND_CUSTOMER");
+
+  await createLog(
+    LogCategoryEnum.CUSTOMER.value,
+    id,
+    verified ? "adult-verification-manual-complete" : "adult-verification-revoked",
+    verified ? "성인 인증을 수동으로 완료했습니다." : "성인 인증을 해제했습니다.",
+    {
+      adultVerification: {
+        before: previous.adult_verified ?? false,
+        after: verified,
+        method: verified ? method : null,
+        verifiedAt,
+      },
+    },
+  );
+
+  return data;
+};

--- a/src/app/_domains/_customer/_types/customer.types.ts
+++ b/src/app/_domains/_customer/_types/customer.types.ts
@@ -8,6 +8,10 @@ export type CustomerType = {
   is_stamp_eligible?: boolean;
   address?: string | null;
   note?: string | null;
+  adult_verified?: boolean;
+  adult_verified_at?: string | null;
+  adult_verification_method?: "bbaton" | "physical_id" | "manual" | null;
+  adult_verified_by?: string | null;
   created_at: string;
   updated_at: string;
   stamps: { count: number }[];

--- a/src/app/api/adult-verification/bbaton/callback/route.ts
+++ b/src/app/api/adult-verification/bbaton/callback/route.ts
@@ -1,0 +1,103 @@
+import { createHash } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getRequestByToken,
+  isRequestExpired,
+} from "@/app/_domains/_adultVerification/server";
+
+type BBatonTokenResponse = {
+  access_token?: string;
+  token_type?: string;
+};
+
+type BBatonUserResponse = {
+  user_id?: string;
+  adult_flag?: "Y" | "N";
+};
+
+const resultUrl = (request: NextRequest, state: string, result: string) =>
+  new URL(`/adult-verify/${encodeURIComponent(state)}?result=${result}`, request.url);
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("code") ?? "";
+  const state = request.nextUrl.searchParams.get("state") ?? "";
+
+  try {
+    if (!code || !state) return NextResponse.redirect(resultUrl(request, state || "error", "invalid"));
+
+    const { request: verificationRequest, admin } = await getRequestByToken(state);
+    if (!verificationRequest || verificationRequest.status !== "pending") {
+      return NextResponse.redirect(resultUrl(request, state, "invalid"));
+    }
+    if (isRequestExpired(verificationRequest.expires_at)) {
+      await admin
+        .from("adult_verification_requests")
+        .update({ status: "expired", updated_at: new Date().toISOString() })
+        .eq("id", verificationRequest.id);
+      return NextResponse.redirect(resultUrl(request, state, "expired"));
+    }
+
+    const clientId = process.env.BBATON_CLIENT_ID;
+    const clientSecret = process.env.BBATON_CLIENT_SECRET;
+    const redirectUri = process.env.BBATON_REDIRECT_URI;
+    if (!clientId || !clientSecret || !redirectUri) {
+      return NextResponse.redirect(resultUrl(request, state, "unavailable"));
+    }
+
+    const tokenResponse = await fetch("https://bauth.bbaton.com/oauth/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+      }),
+      cache: "no-store",
+    });
+    if (!tokenResponse.ok) throw new Error(`BBaton token error: ${tokenResponse.status}`);
+    const tokenData = (await tokenResponse.json()) as BBatonTokenResponse;
+    if (!tokenData.access_token) throw new Error("BBaton access token missing");
+
+    const profileResponse = await fetch("https://bapi.bbaton.com/v2/user/me", {
+      headers: {
+        Authorization: `${tokenData.token_type || "Bearer"} ${tokenData.access_token}`,
+      },
+      cache: "no-store",
+    });
+    if (!profileResponse.ok) throw new Error(`BBaton profile error: ${profileResponse.status}`);
+    const profile = (await profileResponse.json()) as BBatonUserResponse;
+
+    if (profile.adult_flag !== "Y") {
+      await admin
+        .from("adult_verification_requests")
+        .update({ status: "rejected", updated_at: new Date().toISOString() })
+        .eq("id", verificationRequest.id)
+        .eq("status", "pending");
+      return NextResponse.redirect(resultUrl(request, state, "rejected"));
+    }
+
+    const now = new Date().toISOString();
+    const providerUserHash = profile.user_id
+      ? createHash("sha256").update(profile.user_id).digest("hex")
+      : null;
+    const { data: completed, error: completionError } = await admin.rpc(
+      "complete_adult_verification_request",
+      {
+        p_request_id: verificationRequest.id,
+        p_provider_user_hash: providerUserHash,
+        p_completed_at: now,
+      },
+    );
+    if (completionError || completed !== true) {
+      throw completionError ?? new Error("Request already used or expired");
+    }
+
+    return NextResponse.redirect(resultUrl(request, state, "success"));
+  } catch (error) {
+    console.error("Failed to complete BBaton verification", error);
+    return NextResponse.redirect(resultUrl(request, state || "error", "error"));
+  }
+}

--- a/src/app/api/adult-verification/bbaton/start/route.ts
+++ b/src/app/api/adult-verification/bbaton/start/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getRequestByToken,
+  isRequestExpired,
+} from "@/app/_domains/_adultVerification/server";
+
+export async function GET(request: NextRequest) {
+  try {
+    const token = request.nextUrl.searchParams.get("token") ?? "";
+    const clientId = process.env.BBATON_CLIENT_ID;
+    const redirectUri = process.env.BBATON_REDIRECT_URI;
+    if (!clientId || !redirectUri) {
+      return NextResponse.redirect(new URL(`/adult-verify/${token}?result=unavailable`, request.url));
+    }
+
+    const { request: verificationRequest, admin } = await getRequestByToken(token);
+    if (!verificationRequest || verificationRequest.status !== "pending") {
+      return NextResponse.redirect(new URL(`/adult-verify/${token}?result=invalid`, request.url));
+    }
+    if (isRequestExpired(verificationRequest.expires_at)) {
+      await admin
+        .from("adult_verification_requests")
+        .update({ status: "expired", updated_at: new Date().toISOString() })
+        .eq("id", verificationRequest.id);
+      return NextResponse.redirect(new URL(`/adult-verify/${token}?result=expired`, request.url));
+    }
+
+    const authorizeUrl = new URL("https://bauth.bbaton.com/oauth/authorize");
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("scope", "read_profile");
+    authorizeUrl.searchParams.set("state", token);
+    return NextResponse.redirect(authorizeUrl);
+  } catch (error) {
+    console.error("Failed to start BBaton verification", error);
+    return NextResponse.redirect(new URL("/adult-verify/error?result=error", request.url));
+  }
+}

--- a/src/app/api/adult-verification/requests/[token]/route.ts
+++ b/src/app/api/adult-verification/requests/[token]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getRequestByToken,
+  isRequestExpired,
+} from "@/app/_domains/_adultVerification/server";
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await context.params;
+    const { request, admin } = await getRequestByToken(token);
+    if (!request) {
+      return NextResponse.json({ status: "invalid" }, { status: 404 });
+    }
+
+    if (request.status === "pending" && isRequestExpired(request.expires_at)) {
+      await admin
+        .from("adult_verification_requests")
+        .update({ status: "expired", updated_at: new Date().toISOString() })
+        .eq("id", request.id);
+      return NextResponse.json({ status: "expired" });
+    }
+
+    return NextResponse.json({
+      status: request.status,
+      expiresAt: request.expires_at,
+      completedAt: request.completed_at,
+    });
+  } catch (error) {
+    console.error("Failed to read adult verification request", error);
+    return NextResponse.json({ status: "error" }, { status: 500 });
+  }
+}

--- a/src/app/api/adult-verification/requests/route.ts
+++ b/src/app/api/adult-verification/requests/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createVerificationToken,
+  getAuthenticatedStaff,
+  hashVerificationToken,
+} from "@/app/_domains/_adultVerification/server";
+import { createSupabaseAdmin } from "@/libs/supabaseAdmin";
+
+export async function GET(request: NextRequest) {
+  try {
+    const staff = await getAuthenticatedStaff(request.headers.get("authorization"));
+    if (!staff) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    const admin = createSupabaseAdmin();
+    const { data, error } = await admin
+      .from("adult_verification_requests")
+      .select("id, request_label, status, expires_at, completed_at, created_at, customer_id")
+      .order("created_at", { ascending: false })
+      .limit(100);
+    if (error) throw error;
+
+    const now = Date.now();
+    return NextResponse.json({
+      items: (data ?? []).map((item) => ({
+        ...item,
+        status:
+          item.status === "pending" && new Date(item.expires_at).getTime() <= now
+            ? "expired"
+            : item.status,
+      })),
+    });
+  } catch (error) {
+    console.error("Failed to list adult verification requests", error);
+    return NextResponse.json({ message: "인증 요청을 불러오지 못했습니다." }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const staff = await getAuthenticatedStaff(request.headers.get("authorization"));
+    if (!staff) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    const body = (await request.json()) as { label?: string; customerId?: string };
+    const label = body.label?.trim();
+    if (!label || label.length > 100) {
+      return NextResponse.json({ message: "구분용 이름이나 메모를 100자 이내로 입력해 주세요." }, { status: 400 });
+    }
+
+    const admin = createSupabaseAdmin();
+    let customerId: string | null = null;
+    if (body.customerId && /^\d+$/.test(body.customerId)) {
+      const { data: customer } = await admin
+        .from("customers")
+        .select("id")
+        .eq("id", body.customerId)
+        .maybeSingle();
+      if (!customer) {
+        return NextResponse.json({ message: "고객을 찾을 수 없습니다." }, { status: 404 });
+      }
+      customerId = body.customerId;
+    }
+
+    const token = createVerificationToken();
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const { error } = await admin.from("adult_verification_requests").insert({
+      customer_id: customerId,
+      request_label: label,
+      token_hash: hashVerificationToken(token),
+      status: "pending",
+      expires_at: expiresAt,
+      created_by: staff.id,
+    });
+    if (error) throw error;
+
+    const origin = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || request.nextUrl.origin;
+    return NextResponse.json({
+      url: `${origin}/adult-verify/${token}`,
+      expiresAt,
+    });
+  } catch (error) {
+    console.error("Failed to create adult verification request", error);
+    return NextResponse.json(
+      { message: "인증 링크를 만들지 못했습니다. 서버 설정을 확인해 주세요." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/libs/supabaseAdmin.ts
+++ b/src/libs/supabaseAdmin.ts
@@ -1,0 +1,14 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const createSupabaseAdmin = () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error("Missing Supabase server environment variables");
+  }
+
+  return createClient(url, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+};

--- a/supabase/migrations/20260810000000_adult_verification.sql
+++ b/supabase/migrations/20260810000000_adult_verification.sql
@@ -1,0 +1,101 @@
+alter table public.customers
+  add column if not exists adult_verified boolean not null default false,
+  add column if not exists adult_verified_at timestamptz,
+  add column if not exists adult_verification_method text,
+  add column if not exists adult_verified_by uuid references public.users(id) on delete set null;
+
+alter table public.customers
+  drop constraint if exists customers_adult_verification_method_check;
+
+alter table public.customers
+  add constraint customers_adult_verification_method_check
+  check (
+    adult_verification_method is null
+    or adult_verification_method in ('bbaton', 'physical_id', 'manual')
+  );
+
+create table if not exists public.adult_verification_requests (
+  id uuid primary key default gen_random_uuid(),
+  customer_id bigint references public.customers(id) on delete set null,
+  request_label text not null,
+  token_hash text not null unique,
+  status text not null default 'pending'
+    check (status in ('pending', 'completed', 'expired', 'cancelled', 'rejected')),
+  expires_at timestamptz not null,
+  completed_at timestamptz,
+  provider_user_hash text,
+  created_by uuid not null references public.users(id) on delete restrict,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists adult_verification_requests_customer_id_idx
+  on public.adult_verification_requests(customer_id, created_at desc);
+
+alter table public.adult_verification_requests enable row level security;
+
+drop policy if exists "staff can read adult verification requests"
+on public.adult_verification_requests;
+
+create policy "staff can read adult verification requests"
+on public.adult_verification_requests
+for select
+to authenticated
+using (
+  exists (
+    select 1 from public.users
+    where users.id = auth.uid()
+      and users.oss_role in ('staff', 'admin')
+  )
+);
+
+comment on table public.adult_verification_requests is
+  '고객별 일회성 성인 인증 링크 상태. 원본 토큰은 저장하지 않고 SHA-256 해시만 저장한다.';
+
+create or replace function public.complete_adult_verification_request(
+  p_request_id uuid,
+  p_provider_user_hash text,
+  p_completed_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_customer_id bigint;
+  v_updated_count integer;
+begin
+  update public.adult_verification_requests
+  set status = 'completed',
+      completed_at = p_completed_at,
+      updated_at = p_completed_at,
+      provider_user_hash = p_provider_user_hash
+  where id = p_request_id
+    and status = 'pending'
+    and expires_at > p_completed_at
+  returning customer_id into v_customer_id;
+
+  get diagnostics v_updated_count = row_count;
+  if v_updated_count = 0 then
+    return false;
+  end if;
+
+  if v_customer_id is not null then
+    update public.customers
+    set adult_verified = true,
+        adult_verified_at = p_completed_at,
+        adult_verification_method = 'bbaton',
+        adult_verified_by = null
+    where id = v_customer_id;
+  end if;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.complete_adult_verification_request(uuid, text, timestamptz)
+from public, anon, authenticated;
+
+grant execute on function public.complete_adult_verification_request(uuid, text, timestamptz)
+to service_role;


### PR DESCRIPTION
## 작업 내용

- 고객 생성 전에도 사용할 수 있는 성인인증 관리 화면 추가
- 고객을 구분할 이름 또는 메모로 일회성 인증 링크 생성
- 인증 링크 24시간 만료 및 1회 사용 처리
- 비바톤 OAuth 2.0 성인인증 연동
- 인증 요청 상태 표시
  - 인증 대기
  - 인증 완료
  - 만료
  - 취소
  - 성인 아님
- 비바톤 인증 완료 시 결과 자동 반영
- 개인정보 및 비바톤 액세스 토큰 미저장
- 성인인증 관련 Supabase 마이그레이션 추가

## 확인 경로

고객 목록 → `성인 인증 관리`

또는:

`/adult-verifications`

## 환경변수

Vercel에 다음 환경변수 등록이 필요합니다.

- `BBATON_CLIENT_ID`
- `BBATON_CLIENT_SECRET`
- `BBATON_REDIRECT_URI`
- `SUPABASE_SERVICE_ROLE_KEY`
- `NEXT_PUBLIC_APP_URL`

## DB 적용

성인인증 SQL 마이그레이션 실행 완료

`supabase/migrations/20260810000000_adult_verification.sql`

## 테스트

- ESLint 통과
- TypeScript 타입 검사 통과
- Next.js 프로덕션 빌드 통과
- 로컬 성인인증 관리 페이지 응답 확인